### PR TITLE
Add two missing variables in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ and similarly using PyLops commands:
 ```python
 from pylops import FirstDerivative
 
+nx = 7
+x = range(-(nx // 2), nx // 2 + (1 if nx % 2 else 0))
+
 Dlop = FirstDerivative(nx, dtype='float64')
 
 # y = Dx


### PR DESCRIPTION
The first PyLops example in the README is not self-contained, which it probably should be.  Trying to run it results in a `NameError`.

I chose to use a `range` instead of `np.arange`, but I can change that if that would be better.
