### PR TITLE
Fix broken initialization in CG

### DIFF
--- a/pylops/optimization/solver.py
+++ b/pylops/optimization/solver.py
@@ -61,8 +61,7 @@ def cg(Op, y, x0, niter=10, damp=0., tol=1e-4, show=False, callback=None):
 
     if x0 is None:
         x = ncp.zeros(Op.shape[1], dtype=y.dtype)
-        s = y.copy()
-        r = Op.rmatvec(s)
+        r = y.copy()
     else:
         x = x0.copy()
         r = y - Op.matvec(x)


### PR DESCRIPTION
If `x0=None` is supplied as an argument to `pylops.optimization.solver.cg` (which seems to be intended) `x` is initialized as the zero vector. In this case the residual vector `r` should be `r = y - Op * x = y` and not `r = Op.T * y` (where * is matrix multiplication and .T is transposition).