### PR TITLE
Adds R-linear operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,4 @@ A list of video tutorials to learn more about PyLops:
 * Tyler Hughes, twhughes
 * Lyubov Skopintseva, lskopintseva
 * Francesco Picetti, fpicetti
+* Alan Richardson, ar4

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -57,6 +57,9 @@ Basic operators
     Block
     BlockDiag
     Kronecker
+    Real
+    Imag
+    Conj
 
 Smoothing and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -12,3 +12,4 @@ Contributors
 *  `Tyler Hughes <https://github.com/twhughes>`_, twhughes
 *  `Lyubov Skopintseva <https://github.com/lskopintseva>`_, lskopintseva
 *  `Francesco Picetti <https://github.com/fpicetti>`_, fpicetti
+*  `Alan Richardson <https://github.com/ar4>`_, ar4

--- a/examples/plot_conj.py
+++ b/examples/plot_conj.py
@@ -1,0 +1,41 @@
+"""
+Conj
+====
+
+This example shows how to use the :py:class:`pylops.basicoperators.Conj`
+operator.
+This operator returns the complex conjugate in both forward and adjoint
+modes (it is self adjoint).
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as pltgs
+
+import pylops
+
+plt.close('all')
+
+###############################################################################
+# Let's define a Conj operator to get the complex conjugate
+# of the input.
+
+M = 5
+x = np.arange(M) + 1j * np.arange(M)[::-1]
+Rop = pylops.basicoperators.Conj(M, dtype='complex128')
+
+y = Rop*x
+xadj = Rop.H*y
+
+_, axs = plt.subplots(1, 3, figsize=(10, 4))
+axs[0].plot(np.real(x), lw=2, label='Real')
+axs[0].plot(np.imag(x), lw=2, label='Imag')
+axs[0].legend()
+axs[0].set_title('Input')
+axs[1].plot(np.real(y), lw=2, label='Real')
+axs[1].plot(np.imag(y), lw=2, label='Imag')
+axs[1].legend()
+axs[1].set_title('Forward of Input')
+axs[2].plot(np.real(xadj), lw=2, label='Real')
+axs[2].plot(np.imag(xadj), lw=2, label='Imag')
+axs[2].legend()
+axs[2].set_title('Adjoint of Forward')

--- a/examples/plot_imag.py
+++ b/examples/plot_imag.py
@@ -1,0 +1,42 @@
+"""
+Imag
+====
+
+This example shows how to use the :py:class:`pylops.basicoperators.Imag`
+operator.
+This operator returns the imaginary part of the data as a real value in
+forward mode, and the real part of the model as an imaginary value in
+adjoint mode (with zero real part).
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as pltgs
+
+import pylops
+
+plt.close('all')
+
+###############################################################################
+# Let's define a Imag operator :math:`\mathbf{\Im}` to extract the imaginary
+# component of the input.
+
+M = 5
+x = np.arange(M) + 1j * np.arange(M)[::-1]
+Rop = pylops.basicoperators.Imag(M, dtype='complex128')
+
+y = Rop*x
+xadj = Rop.H*y
+
+_, axs = plt.subplots(1, 3, figsize=(10, 4))
+axs[0].plot(np.real(x), lw=2, label='Real')
+axs[0].plot(np.imag(x), lw=2, label='Imag')
+axs[0].legend()
+axs[0].set_title('Input')
+axs[1].plot(np.real(y), lw=2, label='Real')
+axs[1].plot(np.imag(y), lw=2, label='Imag')
+axs[1].legend()
+axs[1].set_title('Forward of Input')
+axs[2].plot(np.real(xadj), lw=2, label='Real')
+axs[2].plot(np.imag(xadj), lw=2, label='Imag')
+axs[2].legend()
+axs[2].set_title('Adjoint of Forward')

--- a/examples/plot_real.py
+++ b/examples/plot_real.py
@@ -1,0 +1,42 @@
+"""
+Real
+====
+
+This example shows how to use the :py:class:`pylops.basicoperators.Real`
+operator.
+This operator returns the real part of the data in forward and adjoint mode,
+but the forward output will be a real number, while the adjoint output will
+be a complex number with a zero-valued imaginary part.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as pltgs
+
+import pylops
+
+plt.close('all')
+
+###############################################################################
+# Let's define a Real operator :math:`\mathbf{\Re}` to extract the real
+# component of the input.
+
+M = 5
+x = np.arange(M) + 1j * np.arange(M)[::-1]
+Rop = pylops.basicoperators.Real(M, dtype='complex128')
+
+y = Rop*x
+xadj = Rop.H*y
+
+_, axs = plt.subplots(1, 3, figsize=(10, 4))
+axs[0].plot(np.real(x), lw=2, label='Real')
+axs[0].plot(np.imag(x), lw=2, label='Imag')
+axs[0].legend()
+axs[0].set_title('Input')
+axs[1].plot(np.real(y), lw=2, label='Real')
+axs[1].plot(np.imag(y), lw=2, label='Imag')
+axs[1].legend()
+axs[1].set_title('Forward of Input')
+axs[2].plot(np.real(xadj), lw=2, label='Real')
+axs[2].plot(np.imag(xadj), lw=2, label='Imag')
+axs[2].legend()
+axs[2].set_title('Adjoint of Forward')

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -775,12 +775,16 @@ class _ColumnLinearOperator(LinearOperator):
 
 
 class _RealImagLinearOperator(LinearOperator):
-    """Real-Imag linear operator
+    """Real-Imag extraction
 
     Computes forward and adjoint passes of an operator Op and returns only
     its real (or imaginary) component. Note that for the adjoint step the
     output must be complex conjugated (i.e. opposite of the imaginary part is
-    returned)
+    returned). In general this is neither a C-linear nor R-linear operator as
+    the operations are not swapped in the adjoint step. It should be used only
+    when we want to transform a complex system of equations with real-valued
+    model in a system of two sets of equations, one for the real component and
+    one for the imaginary component (see associated Tutorial).
     """
     def __init__(self, Op, forw=True, adj=True, real=True):
         if not isinstance(Op, spLinearOperator):

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -20,6 +20,9 @@ from .basicoperators import HStack
 from .basicoperators import Block
 from .basicoperators import BlockDiag
 from .basicoperators import Kronecker
+from .basicoperators import Real
+from .basicoperators import Imag
+from .basicoperators import Conj
 
 from .basicoperators import CausalIntegration
 from .basicoperators import FirstDerivative

--- a/pylops/basicoperators/BlockDiag.py
+++ b/pylops/basicoperators/BlockDiag.py
@@ -111,6 +111,8 @@ class BlockDiag(LinearOperator):
         else:
             self.dtype = np.dtype(dtype)
         self.explicit = False
+        self.clinear = all([getattr(oper, 'clinear', True)
+                            for oper in self.ops])
 
     @property
     def nproc(self):

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -29,13 +29,13 @@ class Conj(LinearOperator):
 
     .. math::
 
-        y_{i} = \Re{x_{i}} - i\Im{x_{i}} \quad \forall i=0,...,N
+        y_{i} = \Re\{x_{i}\} - i\Im\{x_{i}\} \quad \forall i=0,...,N
 
     In adjoint mode:
 
     .. math::
 
-        x_{i} = \Re{y_{i}} - i\Im{y_{i}} \quad \forall i=0,...,N
+        x_{i} = \Re\{y_{i}\} - i\Im\{y_{i}\} \quad \forall i=0,...,N
 
     """
     def __init__(self, dims, dtype='complex128'):

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -1,0 +1,54 @@
+import numpy as np
+from pylops import LinearOperator
+from pylops.utils.backend import get_array_module
+
+
+class Conj(LinearOperator):
+    r"""Complex conjugate operator.
+
+    Return the complex conjugate of the input. It is self-adjoint.
+
+    Parameters
+    ----------
+    dims : :obj:`int` or :obj:`tuple`
+        Number of samples for each dimension
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
+
+    Attributes
+    ----------
+    shape : :obj:`tuple`
+        Operator shape
+    explicit : :obj:`bool`
+        Operator contains a matrix that can be solved explicitly (``True``) or
+        not (``False``)
+
+    Notes
+    -----
+    In forward mode:
+
+    .. math::
+
+        y_{i} = \Re{x_{i}} - i\Im{x_{i}} \quad \forall i=0,...,N
+
+    In adjoint mode:
+
+    .. math::
+
+        x_{i} = \Re{y_{i}} - i\Im{y_{i}} \quad \forall i=0,...,N
+
+    """
+    def __init__(self, dims, dtype='complex128'):
+        self.shape = (np.prod(np.array(dims)),
+                      np.prod(np.array(dims)))
+        self.dtype = np.dtype(dtype)
+        self.explicit = False
+        self.clinear = False
+
+    def _matvec(self, x):
+        ncp = get_array_module(x)
+        return ncp.conj(x)
+
+    def _rmatvec(self, x):
+        ncp = get_array_module(x)
+        return ncp.conj(x)

--- a/pylops/basicoperators/HStack.py
+++ b/pylops/basicoperators/HStack.py
@@ -110,6 +110,8 @@ class HStack(LinearOperator):
         else:
             self.dtype = np.dtype(dtype)
         self.explicit = False
+        self.clinear = all([getattr(oper, 'clinear', True)
+                            for oper in self.ops])
 
     @property
     def nproc(self):

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -1,0 +1,56 @@
+import numpy as np
+from pylops import LinearOperator
+from pylops.utils.backend import get_array_module
+
+
+class Imag(LinearOperator):
+    r"""Imag operator.
+
+    Return the imaginary component of the input as a real value.
+    The adjoint returns a complex number with zero real component and
+    the imaginary component set to the real component of the input.
+
+    Parameters
+    ----------
+    dims : :obj:`int` or :obj:`tuple`
+        Number of samples for each dimension
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
+
+    Attributes
+    ----------
+    shape : :obj:`tuple`
+        Operator shape
+    explicit : :obj:`bool`
+        Operator contains a matrix that can be solved explicitly (``True``) or
+        not (``False``)
+
+    Notes
+    -----
+    In forward mode:
+
+    .. math::
+
+        y_{i} = \Imag{x_{i}} \quad \forall i=0,...,N
+
+    In adjoint mode:
+
+    .. math::
+
+        x_{i} = 0 + i\Re{y_{i}} \quad \forall i=0,...,N
+
+    """
+    def __init__(self, dims, dtype='complex128'):
+        self.shape = (np.prod(np.array(dims)),
+                      np.prod(np.array(dims)))
+        self.dtype = np.dtype(dtype)
+        self.explicit = False
+        self.clinear = False
+
+    def _matvec(self, x):
+        ncp = get_array_module(x)
+        return ncp.imag(x).astype(self.dtype)
+
+    def _rmatvec(self, x):
+        ncp = get_array_module(x)
+        return (0 + 1j*ncp.real(x)).astype(self.dtype)

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -31,25 +31,26 @@ class Imag(LinearOperator):
 
     .. math::
 
-        y_{i} = \Imag{x_{i}} \quad \forall i=0,...,N
+        y_{i} = \Imag\{x_{i}\} \quad \forall i=0,...,N
 
     In adjoint mode:
 
     .. math::
 
-        x_{i} = 0 + i\Re{y_{i}} \quad \forall i=0,...,N
+        x_{i} = 0 + i\Re\{y_{i}\} \quad \forall i=0,...,N
 
     """
     def __init__(self, dims, dtype='complex128'):
         self.shape = (np.prod(np.array(dims)),
                       np.prod(np.array(dims)))
         self.dtype = np.dtype(dtype)
+        self.rdtype = np.real(np.ones(1, self.dtype)).dtype
         self.explicit = False
         self.clinear = False
 
     def _matvec(self, x):
         ncp = get_array_module(x)
-        return ncp.imag(x).astype(self.dtype)
+        return ncp.imag(x).astype(self.rdtype)
 
     def _rmatvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -31,25 +31,26 @@ class Real(LinearOperator):
 
     .. math::
 
-        y_{i} = \Re{x_{i}} \quad \forall i=0,...,N
+        y_{i} = \Re\{x_{i}\} \quad \forall i=0,...,N
 
     In adjoint mode:
 
     .. math::
 
-        x_{i} = \Re{y_{i}} + 0i \quad \forall i=0,...,N
+        x_{i} = \Re\{y_{i}\} + 0i \quad \forall i=0,...,N
 
     """
     def __init__(self, dims, dtype='complex128'):
         self.shape = (np.prod(np.array(dims)),
                       np.prod(np.array(dims)))
         self.dtype = np.dtype(dtype)
+        self.rdtype = np.real(np.ones(1, self.dtype)).dtype
         self.explicit = False
         self.clinear = False
 
     def _matvec(self, x):
         ncp = get_array_module(x)
-        return ncp.real(x).astype(self.dtype)
+        return ncp.real(x).astype(self.rdtype)
 
     def _rmatvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -1,0 +1,56 @@
+import numpy as np
+from pylops import LinearOperator
+from pylops.utils.backend import get_array_module
+
+
+class Real(LinearOperator):
+    r"""Real operator.
+
+    Return the real component of the input. The adjoint returns a complex
+    number with the same real component as the input and zero imaginary
+    component.
+
+    Parameters
+    ----------
+    dims : :obj:`int` or :obj:`tuple`
+        Number of samples for each dimension
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
+
+    Attributes
+    ----------
+    shape : :obj:`tuple`
+        Operator shape
+    explicit : :obj:`bool`
+        Operator contains a matrix that can be solved explicitly (``True``) or
+        not (``False``)
+
+    Notes
+    -----
+    In forward mode:
+
+    .. math::
+
+        y_{i} = \Re{x_{i}} \quad \forall i=0,...,N
+
+    In adjoint mode:
+
+    .. math::
+
+        x_{i} = \Re{y_{i}} + 0i \quad \forall i=0,...,N
+
+    """
+    def __init__(self, dims, dtype='complex128'):
+        self.shape = (np.prod(np.array(dims)),
+                      np.prod(np.array(dims)))
+        self.dtype = np.dtype(dtype)
+        self.explicit = False
+        self.clinear = False
+
+    def _matvec(self, x):
+        ncp = get_array_module(x)
+        return ncp.real(x).astype(self.dtype)
+
+    def _rmatvec(self, x):
+        ncp = get_array_module(x)
+        return (ncp.real(x) + 0j).astype(self.dtype)

--- a/pylops/basicoperators/VStack.py
+++ b/pylops/basicoperators/VStack.py
@@ -110,6 +110,8 @@ class VStack(LinearOperator):
         else:
             self.dtype = np.dtype(dtype)
         self.explicit = False
+        self.clinear = all([getattr(oper, 'clinear', True)
+                            for oper in self.ops])
 
     @property
     def nproc(self):

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -14,6 +14,9 @@ from .Transpose import Transpose
 from .Roll import Roll
 from .Pad import Pad
 from .Sum import Sum
+from .Real import Real
+from .Imag import Imag
+from .Conj import Conj
 
 from .VStack import VStack
 from .HStack import HStack

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -73,10 +73,15 @@ def dottest(Op, nr=None, nc=None, tol=1e-6, complexflag=0, raiseerror=True, verb
     y = Op.matvec(u)   # Op * u
     x = Op.rmatvec(v)  # Op'* v
 
-    yy = ncp.vdot(y, v) # (Op  * u)' * v
-    xx = ncp.vdot(u, x) # u' * (Op' * v)
+    if getattr(Op, 'clinear', True):
+      yy = ncp.vdot(y, v) # (Op  * u)' * v
+      xx = ncp.vdot(u, x) # u' * (Op' * v)
+    else:
+      # Op is only R-linear, so treat complex numbers as elements of R^2
+      yy = ncp.dot(y.real, v.real) + ncp.dot(y.imag, v.imag)
+      xx = ncp.dot(u.real, x.real) + ncp.dot(u.imag, x.imag)
 
-    # convert back to numpy (in case cupy arrays where used), make into a numpy
+    # convert back to numpy (in case cupy arrays were used), make into a numpy
     # array and extract the first element. This is ugly but allows to handle
     # complex numbers in subsequent prints also when using cupy arrays.
     xx, yy = np.array([to_numpy(xx)])[0], np.array([to_numpy(yy)])[0]

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -179,7 +179,7 @@ def test_apply_columns_explicit(par):
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_realimag(par):
-    """Real/imag operator
+    """Real/imag extraction
     """
     M = np.random.normal(0, 1, (par['ny'], par['nx'])) + \
         1j * np.random.normal(0, 1, (par['ny'], par['nx']))
@@ -205,7 +205,6 @@ def test_realimag(par):
 
     assert_array_equal(np.real(x), xr)
     assert_array_equal(np.imag(x), -xi)
-
 
 
 @pytest.mark.parametrize("par", [(par1), (par1j)])


### PR DESCRIPTION
Many useful linear operators are only linear over real numbers, and
complex numbers when they are treated as being elements of R^2
(e.g., (a+ib) -> (a, b)). These are known as R-linear operators, to
distinguish them from operators that are also linear over complex
numbers (C-linear operators). Examples include operators that
extract the real or imaginary components of the input, and
complex conjugation.

This commit introduces R-linear operators to PyLops. An operator
is specified to be only R-linear (and thus not C-linear) by
setting the new `clinear` attribute on the LinearOperator class
to be False.

When operators are combined, such as by composition or stacking,
the combined operator will be R-linear if any of the component
operators are. This commit implements this in the `dot` method
of the `LinearOperator` class, and also in the `VStack`, `HStack`,
and `BlockDiag` operators.

As complex values are considered to be elements of R^2 when
using R-linear operators, the dot product test for these operators
uses the R^2 inner product rather than the complex inner product.