### PR TITLE
Modified dottest to create u and v with same dtype as operator

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -249,7 +249,7 @@ class LinearOperator(spLinearOperator):
         elif np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
+            if x.ndim == 1:# or x.ndim == 2 and x.shape[1] == 1:
                 return self.matvec(x)
             elif x.ndim == 2:
                 return self.matmat(x)

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -60,26 +60,32 @@ def dottest(Op, nr=None, nc=None, tol=1e-6, complexflag=0, raiseerror=True, verb
 
     assert (nr, nc) == Op.shape, 'Provided nr and nc do not match operator shape'
 
+    # make u and v vectors
+    if complexflag != 0:
+        rdtype = np.real(np.ones(1, Op.dtype)).dtype
+
     if complexflag in (0, 2):
-        u = ncp.random.randn(nc)
+        u = ncp.random.randn(nc).astype(Op.dtype)
     else:
-        u = ncp.random.randn(nc) + 1j*ncp.random.randn(nc)
+        u = ncp.random.randn(nc).astype(rdtype) + \
+            1j * ncp.random.randn( nc).astype(rdtype)
 
     if complexflag in (0, 1):
-        v = ncp.random.randn(nr)
+        v = ncp.random.randn(nr).astype(Op.dtype)
     else:
-        v = ncp.random.randn(nr) + 1j*ncp.random.randn(nr)
+        v = ncp.random.randn(nr).astype(rdtype) + \
+            1j * ncp.random.randn(nr).astype(rdtype)
 
     y = Op.matvec(u)   # Op * u
     x = Op.rmatvec(v)  # Op'* v
 
     if getattr(Op, 'clinear', True):
-      yy = ncp.vdot(y, v) # (Op  * u)' * v
-      xx = ncp.vdot(u, x) # u' * (Op' * v)
+        yy = ncp.vdot(y, v) # (Op  * u)' * v
+        xx = ncp.vdot(u, x) # u' * (Op' * v)
     else:
-      # Op is only R-linear, so treat complex numbers as elements of R^2
-      yy = ncp.dot(y.real, v.real) + ncp.dot(y.imag, v.imag)
-      xx = ncp.dot(u.real, x.real) + ncp.dot(u.imag, x.imag)
+        # Op is only R-linear, so treat complex numbers as elements of R^2
+        yy = ncp.dot(y.real, v.real) + ncp.dot(y.imag, v.imag)
+        xx = ncp.dot(u.real, x.real) + ncp.dot(u.imag, x.imag)
 
     # convert back to numpy (in case cupy arrays were used), make into a numpy
     # array and extract the first element. This is ugly but allows to handle

--- a/pytests/test_causalintegration.py
+++ b/pytests/test_causalintegration.py
@@ -10,22 +10,21 @@ from pylops.optimization.leastsquares import \
     RegularizedInversion, PreconditionedInversion
 
 par1 = {'nt': 20, 'nx': 101, 'dt': 1., 'imag': 0,
-        'dtype':'float32'}  # even samples, real, unitary step
+        'dtype':'float64'}  # even samples, real, unitary step
 par2 = {'nt': 21, 'nx': 101, 'dt': 1., 'imag': 0,
-        'dtype': 'float32'}  # odd samples, real, unitary step
+        'dtype': 'float64'}  # odd samples, real, unitary step
 par3 = {'nt': 20, 'nx': 101, 'dt': .3, 'imag': 0,
-        'dtype': 'float32'}  # even samples, real, non-unitary step
+        'dtype': 'float64'}  # even samples, real, non-unitary step
 par4 = {'nt': 21, 'nx': 101, 'dt': .3,
         'imag': 0, 'dtype': 'float32'}  # odd samples, real, non-unitary step
 par1j = {'nt': 20, 'nx': 101, 'dt': 1., 'imag': 1j,
-         'dtype': 'complex64'}  # even samples, complex, unitary step
+         'dtype': 'complex128'}  # even samples, complex, unitary step
 par2j = {'nt': 21, 'nx': 101, 'dt': 1., 'imag': 1j,
-         'dtype': 'complex64'}  # odd samples, complex, unitary step
+         'dtype': 'complex128'}  # odd samples, complex, unitary step
 par3j = {'nt': 20, 'nx': 101, 'dt': .3, 'imag': 1j,
-         'dtype': 'complex64'}  # even samples, complex, non-unitary step
+         'dtype': 'complex128'}  # even samples, complex, non-unitary step
 par4j = {'nt': 21, 'nx': 101, 'dt': .3,
-        'imag': 1j,
-         'dtype': 'complex64'}  # odd samples, complex, non-unitary step
+        'imag': 1j, 'dtype': 'complex128'}  # odd samples, complex, non-unitary step
 
 
 @pytest.mark.parametrize("par", [(par1), (par2),

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -10,13 +10,13 @@ from pylops.basicoperators import MatrixMult, VStack, \
     HStack, Block, BlockDiag, Real
 
 par1 = {'ny': 101, 'nx': 101,
-        'imag': 0, 'dtype':'float32'}  # square real
+        'imag': 0, 'dtype':'float64'}  # square real
 par2 = {'ny': 301, 'nx': 101,
-        'imag': 0, 'dtype':'float32'}  # overdetermined real
+        'imag': 0, 'dtype':'float64'}  # overdetermined real
 par1j = {'ny': 101, 'nx': 101,
-         'imag': 1j, 'dtype':'complex64'} # square imag
+         'imag': 1j, 'dtype':'complex128'} # square imag
 par2j = {'ny': 301, 'nx': 101,
-         'imag': 1j, 'dtype':'complex64'} # overdetermined imag
+         'imag': 1j, 'dtype':'complex128'} # overdetermined imag
 
 
 @pytest.mark.parametrize("par", [(par1)])
@@ -240,7 +240,6 @@ def test_Block_multiproc(par):
     G = np.random.normal(0, 10, (par['ny'], par['nx'])).astype(par['dtype'])
     Gvert = [MatrixMult(G, dtype=par['dtype'])] * 2
     Ghor = [Gvert] * 4
-    print(Ghor)
     x = np.ones(2*par['nx']) + par['imag']*np.ones(2*par['nx'])
     y = np.ones(4*par['ny']) + par['imag']*np.ones(4*par['ny'])
 

--- a/pytests/test_convolve.py
+++ b/pytests/test_convolve.py
@@ -66,7 +66,7 @@ def test_Convolve1D(par):
     # 1D
     if par['dir'] == 0:
         Cop = Convolve1D(par['nx'], h=h1, offset=par['offset'],
-                         dtype='float32')
+                         dtype='float64')
         assert dottest(Cop, par['nx'], par['nx'])
 
         x = np.zeros((par['nx']))
@@ -78,7 +78,7 @@ def test_Convolve1D(par):
     if par['dir'] < 2:
         Cop = Convolve1D(par['ny'] * par['nx'], h=h1, offset=par['offset'],
                         dims=(par['ny'], par['nx']), dir=par['dir'],
-                        dtype='float32')
+                        dtype='float64')
         assert dottest(Cop, par['ny'] * par['nx'], par['ny'] * par['nx'])
 
         x = np.zeros((par['ny'], par['nx']))
@@ -92,7 +92,7 @@ def test_Convolve1D(par):
     Cop = Convolve1D(par['nz'] * par['ny'] * par['nx'], h=h1,
                      offset=par['offset'],
                      dims=(par['nz'], par['ny'], par['nx']), dir=par['dir'],
-                     dtype='float32')
+                     dtype='float64')
     assert dottest(Cop, par['nz'] * par['ny'] * par['nx'],
                    par['nz'] * par['ny'] * par['nx'])
 
@@ -113,7 +113,7 @@ def test_Convolve2D(par):
     # 2D on 2D
     if par['dir'] == 2:
         Cop = Convolve2D(par['ny'] * par['nx'], h=h2, offset=par['offset'],
-                         dims=(par['ny'], par['nx']), dtype='float32')
+                         dims=(par['ny'], par['nx']), dtype='float64')
         assert dottest(Cop, par['ny'] * par['nx'], par['ny'] * par['nx'])
 
         x = np.zeros((par['ny'], par['nx']))
@@ -127,7 +127,7 @@ def test_Convolve2D(par):
     Cop = Convolve2D(par['nz'] * par['ny'] * par['nx'], h=h2,
                      offset=par['offset'],
                      dims=[par['nz'], par['ny'], par['nx']],
-                     nodir=par['dir'], dtype='float32')
+                     nodir=par['dir'], dtype='float64')
     assert dottest(Cop, par['nz'] * par['ny'] * par['nx'],
                    par['nz'] * par['ny'] * par['nx'])
 
@@ -149,7 +149,7 @@ def test_Convolve3D(par):
     Cop = ConvolveND(par['nz'] * par['ny'] * par['nx'], h=h3,
                      offset=par['offset'],
                      dims=[par['nz'], par['ny'], par['nx']],
-                     dtype='float32')
+                     dtype='float64')
     assert dottest(Cop, par['nz'] * par['ny'] * par['nx'],
                    par['nz'] * par['ny'] * par['nx'])
 
@@ -168,6 +168,6 @@ def test_Convolve3D(par):
                      offset=par['offset'],
                      dims=[par['nz'], par['ny'], par['nx'], par['nt']],
                      dirs=[0, 1, 2],
-                     dtype='float32')
+                     dtype='float64')
     assert dottest(Cop, par['nz'] * par['ny'] * par['nx'] * par['nt'],
                    par['nz'] * par['ny'] * par['nx'] * par['nt'])

--- a/pytests/test_functionoperator.py
+++ b/pytests/test_functionoperator.py
@@ -25,13 +25,15 @@ for nr, nc, dtype in itertools.product(*PARS_LISTS):
     PARS += [{'nr': nr,
               'nc': nc,
               'imag': 0 if dtype.startswith('float') else 1j,
-              'dtype': dtype}]
+              'dtype': dtype,
+              'tol':1e-3 if dtype in ['float32', 'complex64'] else 1e-6}]
 
 
 @pytest.mark.parametrize("par", PARS)
 def test_FunctionOperator(par):
     """Dot-test and inversion for FunctionOperator operator.
     """
+    print(par)
     np.random.seed(10)
     G = (np.random.normal(0, 1, (par['nr'], par['nc'])) +
          np.random.normal(0, 1, (par['nr'], par['nc'])) *
@@ -50,7 +52,8 @@ def test_FunctionOperator(par):
                                dtype=par['dtype'])
 
     assert dottest(Fop, par['nr'], par['nc'],
-                   complexflag=0 if par['imag'] == 0 else 3)
+                   complexflag=0 if par['imag'] == 0 else 3,
+                   tol=par['tol'])
 
     x = (np.ones(par['nc']) +
          np.ones(par['nc'])*par['imag']).astype(par['dtype'])

--- a/pytests/test_kronecker.py
+++ b/pytests/test_kronecker.py
@@ -9,13 +9,13 @@ from pylops.basicoperators import MatrixMult, Identity, \
     Kronecker, FirstDerivative
 
 par1 = {'ny': 11, 'nx': 11,
-        'imag': 0, 'dtype':'float32'}  # square real
+        'imag': 0, 'dtype':'float64'}  # square real
 par2 = {'ny': 21, 'nx': 11,
-        'imag': 0, 'dtype':'float32'}  # overdetermined real
+        'imag': 0, 'dtype':'float64'}  # overdetermined real
 par1j = {'ny': 11, 'nx': 11,
-         'imag': 1j, 'dtype':'complex64'} # square imag
+         'imag': 1j, 'dtype':'complex128'} # square imag
 par2j = {'ny': 21, 'nx': 11,
-         'imag': 1j, 'dtype':'complex64'} # overdetermined imag
+         'imag': 1j, 'dtype':'complex128'} # overdetermined imag
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])

--- a/pytests/test_pad.py
+++ b/pytests/test_pad.py
@@ -7,9 +7,9 @@ from pylops.utils import dottest
 from pylops.basicoperators import Pad
 
 par1 = {'ny': 11, 'nx': 11, 'pad':((0, 2), (4, 5)),
-        'dtype':'float32'}  # square
+        'dtype':'float64'}  # square
 par2 = {'ny': 21, 'nx': 11, 'pad':((3, 1), (0, 3)),
-        'dtype':'float32'}  # rectangular
+        'dtype':'float64'}  # rectangular
 
 np.random.seed(10)
 

--- a/pytests/test_restriction.py
+++ b/pytests/test_restriction.py
@@ -7,13 +7,13 @@ from pylops.utils import dottest
 from pylops.basicoperators import Restriction
 
 par1 = {'ny': 21, 'nx': 11, 'nt':20, 'imag': 0,
-        'dtype':'float32', 'inplace':'True'}  # real, inplace
+        'dtype':'float64', 'inplace':'True'}  # real, inplace
 par2 = {'ny': 21, 'nx': 11, 'nt':20, 'imag': 1j,
-        'dtype':'complex64', 'inplace':'True'} # complex, inplace
+        'dtype':'complex128', 'inplace':'True'} # complex, inplace
 par3 = {'ny': 21, 'nx': 11, 'nt':20, 'imag': 0,
-        'dtype':'float32', 'inplace':'False'}  # real, out of place
+        'dtype':'float64', 'inplace':'False'}  # real, out of place
 par4 = {'ny': 21, 'nx': 11, 'nt':20, 'imag': 1j,
-        'dtype':'complex64', 'inplace':'False'} # complex, out of place
+        'dtype':'complex128', 'inplace':'False'} # complex, out of place
 
 # subsampling factor
 perc_subsampling = 0.4

--- a/pytests/test_smoothing.py
+++ b/pytests/test_smoothing.py
@@ -42,7 +42,7 @@ def test_Smoothing1D(par):
     D1op = Smoothing1D(nsmooth=5, dims=(par['nz'], par['ny'], par['nx']),
                        dir=par['dir'], dtype='float32')
     assert dottest(D1op, par['nz'] * par['ny'] * par['nx'],
-                   par['nz'] * par['ny'] * par['nx'])
+                   par['nz'] * par['ny'] * par['nx'], tol=1e-3)
 
     x = np.random.normal(0, 1, (par['nz'], par['ny'], par['nx'])).flatten()
     y = D1op*x
@@ -59,7 +59,7 @@ def test_Smoothing2D(par):
     if par['dir'] < 2:
         D2op = Smoothing2D(nsmooth=(5, 5), dims=(par['ny'], par['nx']),
                            dtype='float32')
-        assert dottest(D2op, par['ny']*par['nx'], par['ny']*par['nx'])
+        assert dottest(D2op, par['ny']*par['nx'], par['ny']*par['nx'], tol=1e-3)
 
         # forward
         x = np.zeros((par['ny'], par['nx']))


### PR DESCRIPTION
The dottest is now really using the dytpe of the operator to make u and v. Previously it was mistakenly always using float64 and complex128 so we were most of the time checking the dottest for these types even if the operator was of type single (float32 or complex64). For this reason we also had to modify the tolerance in some of the tests that use single precision.