### PR TITLE
Make all FFTs with real dot-test compliant

### DIFF
--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -62,21 +62,25 @@ class _FFT_numpy(LinearOperator):
             if self.fftshift:
                 x = np.fft.ifftshift(x)
             if self.real:
-                y = np.sqrt(1./self.nfft)*np.fft.rfft(np.real(x),
-                                                      n=self.nfft, axis=-1)
+                y = np.fft.rfft(np.real(x), n=self.nfft, axis=-1, norm='ortho')
+                # Apply scaling to obtain a correct adjoint for this operator
+                y[..., 1:1 + (self.nfft - 1) // 2] *= np.sqrt(2)
             else:
-                y = np.sqrt(1./self.nfft)*np.fft.fft(x, n=self.nfft, axis=-1)
+                y = np.fft.fft(x, n=self.nfft, axis=-1, norm='ortho')
         else:
             x = np.reshape(x, self.dims)
             if self.fftshift:
                 x = np.fft.ifftshift(x, axes=self.dir)
             if self.real:
-                y = np.sqrt(1. / self.nfft) * np.fft.rfft(np.real(x),
-                                                          n=self.nfft,
-                                                          axis=self.dir)
+                y = np.fft.rfft(np.real(x), n=self.nfft,
+                                axis=self.dir, norm='ortho')
+                # Apply scaling to obtain a correct adjoint for this operator
+                y = np.swapaxes(y, -1, self.dir)
+                y[..., 1:1 + (self.nfft - 1) // 2] *= np.sqrt(2)
+                y = np.swapaxes(y, self.dir, -1)
             else:
-                y = np.sqrt(1. / self.nfft) * np.fft.fft(x, n=self.nfft,
-                                                         axis=self.dir)
+                y = np.fft.fft(x, n=self.nfft,
+                               axis=self.dir, norm='ortho')
             y = y.flatten()
         y = y.astype(self.cdtype)
         return y
@@ -85,10 +89,12 @@ class _FFT_numpy(LinearOperator):
         if not self.reshape:
             x = x.ravel()
             if self.real:
-                y = np.sqrt(self.nfft)*np.fft.irfft(x, n=self.nfft, axis=-1)
-                y = np.real(y)
+                # Apply scaling to obtain a correct adjoint for this operator
+                x = x.copy()
+                x[..., 1:1 + (self.nfft - 1) // 2] /= np.sqrt(2)
+                y = np.fft.irfft(x, n=self.nfft, axis=-1, norm='ortho')
             else:
-                y = np.sqrt(self.nfft)*np.fft.ifft(x, n=self.nfft, axis=-1)
+                y = np.fft.ifft(x, n=self.nfft, axis=-1, norm='ortho')
             if self.nfft != self.dims[self.dir]:
                 y = y[:self.dims[self.dir]]
             if self.fftshift:
@@ -96,12 +102,14 @@ class _FFT_numpy(LinearOperator):
         else:
             x = np.reshape(x, self.dims_fft)
             if self.real:
-                y = np.sqrt(self.nfft) * np.fft.irfft(x, n=self.nfft,
-                                                      axis=self.dir)
-                y = np.real(y)
+                # Apply scaling to obtain a correct adjoint for this operator
+                x = x.copy()
+                x = np.swapaxes(x, -1, self.dir)
+                x[..., 1:1 + (self.nfft - 1) // 2] /= np.sqrt(2)
+                x = np.swapaxes(x, self.dir, -1)
+                y = np.fft.irfft(x, n=self.nfft, axis=self.dir, norm='ortho')
             else:
-                y = np.sqrt(self.nfft) * np.fft.ifft(x, n=self.nfft,
-                                                     axis=self.dir)
+                y = np.fft.ifft(x, n=self.nfft, axis=self.dir, norm='ortho')
             if self.nfft != self.dims[self.dir]:
                 y = np.take(y, np.arange(0, self.dims[self.dir]),
                             axis=self.dir)
@@ -193,8 +201,9 @@ class _FFT_fftw(LinearOperator):
                 x = np.fft.ifftshift(x)
             if self.dopad:
                 x = np.pad(x, self.pad, 'constant', constant_values=0)
-
-            y = np.sqrt(1./self.nfft)*self.fftplan(x)
+            y = np.sqrt(1. / self.nfft) * self.fftplan(x)
+            if self.real:
+                y[..., 1:1 + (self.nfft - 1) // 2] *= np.sqrt(2)
         else:
             x = np.reshape(x, self.dims)
             if self.fftshift:
@@ -202,12 +211,20 @@ class _FFT_fftw(LinearOperator):
             if self.dopad:
                 x = np.pad(x, self.pad, 'constant', constant_values=0)
             y = np.sqrt(1. / self.nfft) * self.fftplan(x)
-            y = np.ndarray.flatten(y)
-        return y
+            if self.real:
+                # Apply scaling to obtain a correct adjoint for this operator
+                y = np.swapaxes(y, -1, self.dir)
+                y[..., 1:1 + (self.nfft - 1) // 2] *= np.sqrt(2)
+                y = np.swapaxes(y, self.dir, -1)
+        return y.ravel()
 
     def _rmatvec(self, x):
         if not self.reshape:
             x = x.ravel()
+            if self.real:
+                # Apply scaling to obtain a correct adjoint for this operator
+                x = x.copy()
+                x[..., 1:1 + (self.nfft - 1) // 2] /= np.sqrt(2)
             y = np.sqrt(self.nfft) * self.ifftplan(x)
             if self.nfft != self.dims[self.dir]:
                 y = y[:self.dims[self.dir]]
@@ -215,16 +232,21 @@ class _FFT_fftw(LinearOperator):
                 y = np.fft.fftshift(y)
         else:
             x = np.reshape(x, self.dims_fft)
+            if self.real:
+                # Apply scaling to obtain a correct adjoint for this operator
+                x = x.copy()
+                x = np.swapaxes(x, -1, self.dir)
+                x[..., 1:1 + (self.nfft - 1) // 2] /= np.sqrt(2)
+                x = np.swapaxes(x, self.dir, -1)
             y = np.sqrt(self.nfft) * self.ifftplan(x)
             if self.nfft != self.dims[self.dir]:
                 y = np.take(y, np.arange(0, self.dims[self.dir]),
                             axis=self.dir)
             if self.fftshift:
                 y = np.fft.fftshift(y, axes=self.dir)
-            y = np.ndarray.flatten(y)
         if self.real:
             y = np.real(y)
-        return y
+        return y.ravel()
 
 
 def FFT(dims, dir=0, nfft=None, sampling=1., real=False,
@@ -242,18 +264,10 @@ def FFT(dims, dir=0, nfft=None, sampling=1., real=False,
     when ``engine='fftw'`` is chosen.
 
     In both cases, scaling is properly taken into account to guarantee
-    that the operator is passing the dot-test.
-
-    .. note:: For a real valued input signal, it is possible to store the
-      values of the Fourier transform at positive frequencies only as values
-      at negative frequencies are simply their complex conjugates.
-      However as the operation of removing the negative part of the frequency
-      axis in forward mode and adding the complex conjugates in adjoint mode
-      is nonlinear, the Linear Operator FTT with ``real=True`` is not expected
-      to pass the dot-test. It is thus *only* advised to use this flag when a
-      forward and adjoint FFT is used in the same chained operator
-      (e.g., ``FFT.H*Op*FFT``) such as in
-      :py:func:`pylops.waveeqprocessing.mdd.MDC`.
+    that the operator is passing the dot-test. Moreover, for a real valued
+    input signal, it is advised to use the flag `real=True` as it stores
+    the values of the Fourier transform at positive frequencies only as
+    values at negative frequencies are simply their complex conjugates.
 
     Parameters
     ----------
@@ -304,14 +318,15 @@ def FFT(dims, dir=0, nfft=None, sampling=1., real=False,
     :math:`d(t)` in forward mode:
 
     .. math::
-        D(f) = \mathscr{F} (d) = \int d(t) e^{-j2\pi ft} dt
+        D(f) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}} \int d(t) e^{-j2\pi ft} dt
 
     Similarly, the inverse Fourier transform is applied to the Fourier spectrum
     :math:`D(f)` in adjoint mode:
 
     .. math::
-        d(t) = \mathscr{F}^{-1} (D) = \int D(f) e^{j2\pi ft} df
+        d(t) = \mathscr{F}^{-1} (D) = \sqrt{N_F} \int D(f) e^{j2\pi ft} df
 
+    where :math:`N_F` is the number of samples in the Fourier domain `nfft`.
     Both operators are effectively discretized and solved by a fast iterative
     algorithm known as Fast Fourier Transform.
 

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -105,7 +105,7 @@ def dottest(Op, nr=None, nc=None, tol=1e-6, complexflag=0, raiseerror=True, verb
             if verb: print('Dot test failed, v^T(Opu)=%f - u^T(Op^Tv)=%f'
                            % (yy, xx))
             return False
-    elif complexflag == 3:
+    else:
         # Check both real and imag parts
         checkreal = np.abs((np.real(yy) - np.real(xx)) /
                            ((np.real(yy) + np.real(xx)+1e-15) / 2)) < tol
@@ -124,22 +124,4 @@ def dottest(Op, nr=None, nc=None, tol=1e-6, complexflag=0, raiseerror=True, verb
             if verb:
                 print('Dot test failed, v^H(Opu)=%f%+fi - u^H(Op^Hv)=%f%+fi'
                       % (yy.real, yy.imag, xx.real, xx.imag))
-            return False
-    else:
-        # Check only real part (as either model or data are purely real)
-        checkreal = np.abs((np.real(yy) - np.real(xx)) /
-                           ((np.real(yy) + np.real(xx) + 1e-15) / 2)) < tol
-        if checkreal:
-            if verb:
-                print('Dot test passed, v^T(Opu)=%f - u^T(Op^Tv)=%f'
-                      % (yy.real, xx.real))
-            return True
-        else:
-            if raiseerror:
-                raise ValueError('Dot test failed, v^H(Opu)=%f '
-                                 '- u^H(Op^Hv)=%f'
-                                 % (yy.real, xx.real))
-            if verb:
-                print('Dot test failed, v^H(Opu)=%f - u^H(Op^Hv)=%f'
-                      % (yy.real, xx.real))
             return False

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -105,7 +105,8 @@ def dottest(Op, nr=None, nc=None, tol=1e-6, complexflag=0, raiseerror=True, verb
             if verb: print('Dot test failed, v^T(Opu)=%f - u^T(Op^Tv)=%f'
                            % (yy, xx))
             return False
-    else:
+    elif complexflag == 3:
+        # Check both real and imag parts
         checkreal = np.abs((np.real(yy) - np.real(xx)) /
                            ((np.real(yy) + np.real(xx)+1e-15) / 2)) < tol
         checkimag = np.abs((np.imag(yy) - np.imag(xx)) /
@@ -123,4 +124,22 @@ def dottest(Op, nr=None, nc=None, tol=1e-6, complexflag=0, raiseerror=True, verb
             if verb:
                 print('Dot test failed, v^H(Opu)=%f%+fi - u^H(Op^Hv)=%f%+fi'
                       % (yy.real, yy.imag, xx.real, xx.imag))
+            return False
+    else:
+        # Check only real part (as either model or data are purely real)
+        checkreal = np.abs((np.real(yy) - np.real(xx)) /
+                           ((np.real(yy) + np.real(xx) + 1e-15) / 2)) < tol
+        if checkreal:
+            if verb:
+                print('Dot test passed, v^T(Opu)=%f - u^T(Op^Tv)=%f'
+                      % (yy.real, xx.real))
+            return True
+        else:
+            if raiseerror:
+                raise ValueError('Dot test failed, v^H(Opu)=%f '
+                                 '- u^H(Op^Hv)=%f'
+                                 % (yy.real, xx.real))
+            if verb:
+                print('Dot test failed, v^H(Opu)=%f - u^H(Op^Hv)=%f'
+                      % (yy.real, xx.real))
             return False

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -64,12 +64,9 @@ def test_FFT_1dsignal(par):
     FFTop = FFT(dims=[par['nt']], nfft=nfft, sampling=dt,
                 real=par['real'], engine=par['engine'], dtype=par['dtype'])
 
-    # FFT with real=True cannot pass dot-test neither be inverted correctly,
-    # see FFT documentation for a detailed explanation. We thus test FFT.H*FFT
     if par['real']:
-        FFTop = FFTop.H * FFTop
-        assert dottest(FFTop, par['nt'], par['nt'],
-                       complexflag=0, tol=10**(-decimal), verb=True)
+        assert dottest(FFTop, nfft // 2 + 1, par['nt'], complexflag=2,
+                       tol=10**(-decimal), verb=True)
     else:
         assert dottest(FFTop, nfft, par['nt'],
                        complexflag=2, tol=10**(-decimal), verb=True)
@@ -104,12 +101,9 @@ def test_FFT_2dsignal(par):
     FFTop = FFT(dims=(nt, nx), dir=0, nfft=nfft, sampling=dt,
                 real=par['real'], engine=par['engine'], dtype=par['dtype'])
 
-    # FFT with real=True cannot pass dot-test neither be inverted correctly,
-    # see FFT documentation for a detailed explanation. We thus test FFT.H*FFT
     if par['real']:
-        FFTop = FFTop.H * FFTop
-        assert dottest(FFTop, nt * nx, nt * nx,
-                       complexflag=0, tol=10**(-decimal))
+        assert dottest(FFTop, (nfft // 2 + 1) * nx, nt * nx,
+                       complexflag=2, tol=10**(-decimal))
     else:
         assert dottest(FFTop, nfft * nx, nt * nx,
                        complexflag=2, tol=10**(-decimal))
@@ -117,7 +111,7 @@ def test_FFT_2dsignal(par):
                        complexflag=3, tol=10**(-decimal))
 
     D = FFTop * d.flatten()
-    dadj = FFTop.H*D # adjoint is same as inverse for fft
+    dadj = FFTop.H * D # adjoint is same as inverse for fft
     dinv = lsqr(FFTop, D, damp=1e-10, iter_lim=10, show=0)[0]
 
     dadj = np.real(dadj.reshape(nt, nx))
@@ -131,12 +125,9 @@ def test_FFT_2dsignal(par):
     FFTop = FFT(dims=(nt, nx), dir=1, nfft=nfft, sampling=dt,
                 real=par['real'], engine=par['engine'], dtype=par['dtype'])
 
-    # FFT with real=True cannot pass dot-test neither be inverted correctly,
-    # see FFT documentation for a detailed explanation. We thus test FFT.H*FFT
     if par['real']:
-        FFTop = FFTop.H * FFTop
-        assert dottest(FFTop, nt * nx, nt * nx,
-                       complexflag=0, tol=10**(-decimal))
+        assert dottest(FFTop, nt * (nfft // 2 + 1), nt * nx,
+                       complexflag=2, tol=10**(-decimal))
     else:
         assert dottest(FFTop, nt * nfft, nt * nx,
                        complexflag=2, tol=10**(-decimal))
@@ -175,12 +166,9 @@ def test_FFT_3dsignal(par):
     FFTop = FFT(dims=(nt, nx, ny), dir=0, nfft=nfft, sampling=dt,
                 real=par['real'], engine=par['engine'], dtype=par['dtype'])
 
-    # FFT with real=True cannot pass dot-test neither be inverted correctly,
-    # see FFT documentation for a detailed explanation. We thus test FFT.H*FFT
     if par['real']:
-        FFTop = FFTop.H * FFTop
-        assert dottest(FFTop, nt * nx * ny, nt * nx * ny,
-                       complexflag=0, tol=10**(-decimal))
+        assert dottest(FFTop, (nfft//2 + 1) * nx * ny, nt * nx * ny,
+                       complexflag=2, tol=10**(-decimal))
     else:
         assert dottest(FFTop, nfft * nx * ny, nt * nx * ny,
                        complexflag=2, tol=10**(-decimal))
@@ -202,12 +190,9 @@ def test_FFT_3dsignal(par):
     FFTop = FFT(dims=(nt, nx, ny), dir=1, nfft=nfft, sampling=dt,
                 real=par['real'], engine=par['engine'], dtype=par['dtype'])
 
-    # FFT with real=True cannot pass dot-test neither be inverted correctly,
-    # see FFT documentation for a detailed explanation. We thus test FFT.H*FFT
     if par['real']:
-        FFTop = FFTop.H * FFTop
-        assert dottest(FFTop, nt * nx * ny, nt * nx * ny,
-                       complexflag=0, tol=10**(-decimal))
+        assert dottest(FFTop, nt * (nfft//2 + 1) * ny, nt * nx * ny,
+                       complexflag=2, tol=10**(-decimal))
     else:
         assert dottest(FFTop, nt * nfft * ny, nt * nx * ny,
                        complexflag=2, tol=10**(-decimal))
@@ -229,12 +214,9 @@ def test_FFT_3dsignal(par):
     FFTop = FFT(dims=(nt, nx, ny), dir=2, nfft=nfft, sampling=dt,
                 real=par['real'], engine=par['engine'], dtype=par['dtype'])
 
-    # FFT with real=True cannot pass dot-test neither be inverted correctly,
-    # see FFT documentation for a detailed explanation. We thus test FFT.H*FFT
     if par['real']:
-        FFTop = FFTop.H * FFTop
-        assert dottest(FFTop, nt * nx * ny, nt * nx * ny,
-                       complexflag=0, tol=10**(-decimal))
+        assert dottest(FFTop, nt * nx * (nfft//2 + 1) , nt * nx * ny,
+                       complexflag=2, tol=10**(-decimal))
     else:
         assert dottest(FFTop, nt * nx * nfft, nt * nx * ny,
                        complexflag=2, tol=10**(-decimal))
@@ -252,7 +234,7 @@ def test_FFT_3dsignal(par):
     assert_array_almost_equal(d, dinv, decimal=decimal)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_FFT2D(par):
     """Dot-test and inversion for FFT2D operator for 2d signal
     """
@@ -267,12 +249,19 @@ def test_FFT2D(par):
     d = d.astype(par['dtype'])
 
     FFTop = FFT2D(dims=(par['nt'], par['nx']), nffts=(nfft1, nfft2),
-                  sampling=(dt, dx))
-    assert dottest(FFTop, nfft1*nfft2, par['nt']*par['nx'],
-                   complexflag=2, tol=10**(-decimal))
+                  sampling=(dt, dx), real=par['real'])
+
+    if par['real']:
+        assert dottest(FFTop, nfft1*(nfft2 //2 + 1), par['nt']*par['nx'],
+                       complexflag=2, tol=10**(-decimal))
+    else:
+        assert dottest(FFTop, nfft1*nfft2, par['nt']*par['nx'],
+                       complexflag=2, tol=10**(-decimal))
+        assert dottest(FFTop, nfft1 * nfft2, par['nt'] * par['nx'],
+                       complexflag=3, tol=10 ** (-decimal))
 
     D = FFTop * d.flatten()
-    dadj = FFTop.H*D # adjoint is inverse for fft
+    dadj = FFTop.H * D # adjoint is inverse for fft
     dinv = lsqr(FFTop, D, damp=1e-10, iter_lim=100, show=0)[0]
 
     dadj = np.real(dadj).reshape(par['nt'], par['nx'])
@@ -282,7 +271,7 @@ def test_FFT2D(par):
     assert_array_almost_equal(d, dinv, decimal=decimal)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_FFT3D(par):
     """Dot-test and inversion for FFTND operator for 3d signal
     """
@@ -300,13 +289,22 @@ def test_FFT3D(par):
 
     FFTop = FFTND(dims=(par['nt'], par['nx'], par['ny']),
                   nffts=(nfft1, nfft2, nfft3),
-                  sampling=(dt, dx, dy))
-    assert dottest(FFTop, nfft1*nfft2*nfft3,
-                   par['nt']*par['nx']*par['ny'],
-                   complexflag=2, tol=10**(-decimal))
+                  sampling=(dt, dx, dy), real=par['real'])
+
+    if par['real']:
+        assert dottest(FFTop, nfft1*nfft2*(nfft3//2 + 1),
+                       par['nt'] * par['nx'] * par['ny'],
+                       complexflag=2, tol=10**(-decimal))
+    else:
+        assert dottest(FFTop, nfft1 * nfft2 * nfft3,
+                       par['nt'] * par['nx'] * par['ny'],
+                       complexflag=2, tol=10 ** (-decimal))
+        assert dottest(FFTop, nfft1 * nfft2 * nfft3,
+                       par['nt'] * par['nx'] * par['ny'],
+                       complexflag=3, tol=10 ** (-decimal))
 
     D = FFTop * d.flatten()
-    dadj = FFTop.H*D # adjoint is inverse for fft
+    dadj = FFTop.H * D # adjoint is inverse for fft
     dinv = lsqr(FFTop, D, damp=1e-10, iter_lim=100, show=0)[0]
 
     dadj = np.real(dadj).reshape(par['nt'], par['nx'], par['ny'])
@@ -314,4 +312,3 @@ def test_FFT3D(par):
 
     assert_array_almost_equal(d, dadj, decimal=decimal)
     assert_array_almost_equal(d, dinv, decimal=decimal)
-


### PR DESCRIPTION
Add scaling to FFTs when using real Fourier transforms
to make them dot-test compliant as proposed in
https://github.com/PyLops/pylops/issues/268.