### PR TITLE
Automatic casting of dtype in MatrixMult

### DIFF
--- a/pylops/basicoperators/MatrixMult.py
+++ b/pylops/basicoperators/MatrixMult.py
@@ -1,8 +1,11 @@
+import logging
 import numpy as np
 import scipy as sp
 from scipy.sparse.linalg import inv
 from pylops import LinearOperator
 from pylops.utils.backend import get_array_module
+
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.WARNING)
 
 
 class MatrixMult(LinearOperator):
@@ -56,6 +59,11 @@ class MatrixMult(LinearOperator):
                           A.shape[1]*np.prod(self.dims))
             self.explicit = False
         self.dtype = np.dtype(dtype)
+        # Check dtype for correctness (upcast to complex when A is complex)
+        if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=self.dtype)):
+            self.dtype = A.dtype
+            logging.warning('Matrix A is a complex object, dtype '
+                            'casted to %s' % self.dtype)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -79,12 +79,13 @@ def test_MatrixMult(par):
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_MatrixMult_sparse(par):
-    """Dot-test and inversion for test_MatrixMult operator using sparse
+    """Dot-test and inversion for MatrixMult operator using sparse
     matrix
     """
     np.random.seed(10)
     G = rand(par['ny'], par['nx'], density=0.75).astype('float32') + \
-        par['imag'] * rand(par['ny'], par['nx'], density=0.75).astype('float32')
+        par['imag'] * rand(par['ny'], par['nx'], density=0.75).astype(
+        'float32')
 
     Gop = MatrixMult(G, dtype=par['dtype'])
     assert dottest(Gop, par['ny'], par['nx'],
@@ -93,6 +94,20 @@ def test_MatrixMult_sparse(par):
     x = np.ones(par['nx']) + par['imag'] * np.ones(par['nx'])
     xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, show=0)[0]
     assert_array_almost_equal(x, xlsqr, decimal=4)
+
+
+@pytest.mark.parametrize("par", [(par1j), (par2j)])
+def test_MatrixMult_complexcast(par):
+    """Automatic upcasting of MatrixMult operator dtype based on complex
+    matrix
+    """
+    np.random.seed(10)
+    G = rand(par['ny'], par['nx'], density=0.75).astype('float32') + \
+        par['imag'] * rand(par['ny'], par['nx'], density=0.75).astype(
+        'float32')
+
+    Gop = MatrixMult(G, dtype='float32')
+    assert Gop.dtype == 'complex64'
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])


### PR DESCRIPTION
The dtype of MatrixMult is checked against that
of the matrix A and upcasted to complex is the
matrix is complex-valued. See https://github.com/PyLops/pylops/issues/257.