### PR TITLE
Add .eggs/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ db.sqlite3
 build
 dist
 pylops.egg-info/
+.eggs/
 
 # setuptools_scm generated  #
 pylops/version.py


### PR DESCRIPTION
Excludes local build files in `.eggs/` which are generated when installing with `pip install -e`.