### PR TITLE
Implement FFTs using SciPy as backend

### DIFF
--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -280,19 +280,27 @@ def FFT(
     Apply Fast-Fourier Transform (FFT) along a specific direction ``dir`` of a
     multi-dimensional array of size ``dim``.
 
-    Note that the FFT operator is an overload to either the numpy
+    Using the default NumPy engine, the FFT operator is an overload to either the NumPy
     :py:func:`numpy.fft.fft` (or :py:func:`numpy.fft.rfft` for real models) in
-    forward mode and to the numpy :py:func:`numpy.fft.ifft` (or
-    :py:func:`numpy.fft.irfft` for real models) in adjoint mode, or their cupy
-    equivalents. Alternatively, the :py:class:`pyfftw.FFTW` class is used
-    when ``engine='fftw'`` is chosen.
+    forward mode, and to :py:func:`numpy.fft.ifft` (or :py:func:`numpy.fft.irfft`
+    for real models) in adjoint mode, or their CuPy equivalents.
+    When ``engine='fftw'`` is chosen, the :py:class:`pyfftw.FFTW` class is used
+    instead.
+    Alternatively, when the SciPy engine is chosen, the overloads are of
+    :py:func:`scipy.fft.fft` (or :py:func:`scipy.fft.rfft` for real models) in
+    forward mode, and to :py:func:`scipy.fft.ifft` (or :py:func:`scipy.fft.irfft`
+    for real models) in adjoint mode.
 
-    In both cases, scaling is properly taken into account to guarantee
-    that the operator is passing the dot-test. If a user is interested to use
-    the unscaled forward FFT, it must pre-multiply the operator by an
-    appropriate correction factor. Moreover, for a real valued
-    input signal, it is advised to use the flag `real=True` as it stores
-    the values of the Fourier transform at positive frequencies only as
+    In all cases, the "ortho" scaling (see :py:func:`numpy.fft.fft`) is used to
+    to guarantee that the operator passes the dot-test. When using `real=True`, the
+    result of the forward is also multiplied by sqrt(2) for all frequency bins
+    except zero and Nyquist, and the input of the adjoint is divided by
+    sqrt(2) for the same frequencies.
+    If a user is interested in using the unscaled forward FFT, they must pre-multiply
+    the operator by an appropriate correction factor.
+
+    For a real valued input signal, it is advised to use the flag `real=True`
+    as it stores the values of the Fourier transform at positive frequencies only as
     values at negative frequencies are simply their complex conjugates.
 
     Parameters
@@ -343,6 +351,17 @@ def FFT(
 
     Attributes
     ----------
+    dims_fft : :obj:`tuple`
+        Shape of the array after the forward, but before linearization. E.g.
+        ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+    f : :obj:`numpy.ndarray`
+        Discrete Fourier Transform sample frequencies
+    real : :obj:`bool`
+        When True, uses ``rfft``/``irfft``
+    rdtype : :obj:`bool`
+        Expected input type to the forward
+    cdtype : :obj:`bool`
+        Output type of the forward. Complex equivalent to ``rdtype``.
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -119,10 +119,6 @@ class _FFT_scipy(_BaseFFT):
             fftshift_after=fftshift_after,
             dtype=dtype,
         )
-        if self.cdtype != np.complex128:
-            warnings.warn(
-                f"numpy backend always returns complex128 dtype. To respect the passed dtype, data will be casted to {self.cdtype}."
-            )
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)
@@ -141,7 +137,6 @@ class _FFT_scipy(_BaseFFT):
         if self.fftshift_after:
             y = scipy.fft.fftshift(y, axes=self.dir)
         y = y.ravel()
-        y = y.astype(self.cdtype)
         return y
 
     def _rmatvec(self, x):
@@ -164,7 +159,6 @@ class _FFT_scipy(_BaseFFT):
         if self.ifftshift_before:
             y = scipy.fft.fftshift(y, axes=self.dir)
         y = y.ravel()
-        y = y.astype(self.rdtype)
         return y
 
 

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -310,7 +310,7 @@ def FFT(
         (``False``). Used to enforce that the output of adjoint of a real
         model is real.
     fftshift : :obj:`bool`, optional
-        Note: `fftshift` is deprecated, use `ifftshift_before`.
+        Note: ``fftshift`` is deprecated, use ``ifftshift_before``.
     ifftshift_before : :obj:`bool`, optional
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
@@ -325,15 +325,18 @@ def FFT(
         naturally, from negative to positive. When not applying fftshift after FFT,
         frequencies are arranged from zero to largest positive, and then from negative
         Nyquist to the frequency bin before zero.
-        Defaults to not applying fftshift.
     engine : :obj:`str`, optional
         Engine used for fft computation (``numpy``, ``fftw``, or ``scipy``). Choose
         ``numpy`` when working with cupy arrays.
     dtype : :obj:`str`, optional
-        Type of elements in input array. Note that the `dtype` of the operator
+        Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
-        Nevertheless, the provided dtype will be enforced on the vector
-        returned by the `rmatvec` method.
+        In addition, note that neither the NumPy nor the FFTW backends supports
+        returning ``dtype``s different than ``complex128``. As such, when using either
+        backend, arrays will be force-casted to types corresponding to the supplied ``dtype``.
+        The SciPy backend supports all precisions natively.
+        Under all backends, when a real ``dtype`` is supplied, a real result will be
+        enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
     **kwargs_fftw
             Arbitrary keyword arguments
             for :py:class:`pyfftw.FTTW`
@@ -343,8 +346,8 @@ def FFT(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
-        Operator is complex-linear. Is false when either real=True or when
-        dtype is not a complex type.
+        Operator is complex-linear. Is false when either ``real=True`` or when
+        ``dtype`` is not a complex type.
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
         (True) or not (False)
@@ -354,7 +357,7 @@ def FFT(
     ValueError
         If ``dims`` is provided and ``dir`` is bigger than ``len(dims)``
     NotImplementedError
-        If ``engine`` is neither ``numpy`` nor ``fftw``
+        If ``engine`` is neither ``numpy``, ``fftw``, nor ``scipy``.
 
     Notes
     -----
@@ -433,5 +436,5 @@ def FFT(
             dtype=dtype,
         )
     else:
-        raise NotImplementedError("engine must be numpy or fftw")
+        raise NotImplementedError("engine must be numpy, fftw or scipy")
     return f

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -191,46 +191,59 @@ def FFT2D(
         Number of samples for each dimension
     dirs : :obj:`tuple`, optional
         Pair of directions along which FFT2D is applied
-    nffts : :obj:`tuple`, optional
-        Number of samples in Fourier Transform for each direction (same as
-        input if ``nffts=(None, None)``). Note that the order must agree with
-        ``dirs``.
-    sampling : :obj:`tuple`, optional
-        Sampling steps ``dy`` and ``dx``
+    nffts : :obj:`tuple` or :obj:`int`, optional
+        Number of samples in Fourier Transform for each direction. In case only one
+        dimension needs to be specified, use ``None`` for the other dimension in the
+        tuple. The direction with None will use ``dims[dir]`` as ``nfft``. When supplying a
+        tuple, the order must agree with that of ``dirs``. When a single value is
+        passed, it will be used for both directions. As such the default is
+        equivalent to ``nffts=(None, None)``.
+    sampling : :obj:`tuple` or :obj:`float`, optional
+        Sampling steps for each direction. When supplied a single value, it is used
+        for both directions. Unlike ``nffts``, ``None``s will not be converted to the
+        default value.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
         model is real. Note that the real FFT is applied only to the first
         dimension to which the FFT2D operator is applied (last element of
-        `dirs`)
-    ifftshift_before : :obj:`bool`, optional
+        ``dirs``)
+    ifftshift_before : :obj:`tuple` or :obj:`bool`, optional
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
         with respect to the zero value sample. This will shift the zero value sample to
         coincide with the zero index sample. With such an arrangement, FFT will not
         introduce a sample-dependent phase-shift when compared to the continuous Fourier
         Transform.
-        Defaults to not applying ifftshift.
-    fftshift_after : :obj:`bool`, optional
+        When passing a single value, the shift will the same for every direction. Pass
+        a tuple to specify which dimensions are shifted.
+    fftshift_after : :obj:`tuple` or :obj:`bool`, optional
         Apply fftshift (``True``) or not (``False``) to data vector (after FFT).
         Consider using this option when you require frequencies to be arranged
         naturally, from negative to positive. When not applying fftshift after FFT,
         frequencies are arranged from zero to largest positive, and then from negative
         Nyquist to the frequency bin before zero.
-        Defaults to not applying fftshift.
+        When passing a single value, the shift will the same for every direction. Pass
+        a tuple to specify which dimensions are shifted.
+    engine : :obj:`str`, optional
+        Engine used for fft computation (``numpy`` or ``scipy``).
     dtype : :obj:`str`, optional
-        Type of elements in input array. Note that the `dtype` of the operator
+        Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
-        Nevertheless, the provided dtype will be enforced on the vector
-        returned by the `rmatvec` method.
+        In addition, note that the NumPy backend does not support returning ``dtype``s
+        different than ``complex128``. As such, when using the NumPy backend, arrays will
+        be force-casted to types corresponding to the supplied ``dtype``.
+        The SciPy backend supports all precisions natively.
+        Under both backends, when a real ``dtype`` is supplied, a real result will be
+        enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
 
     Attributes
     ----------
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
-        Operator is complex-linear. Is false when either real=True or when
-        dtype is not a complex type.
+        Operator is complex-linear. Is false when either ``real=True`` or when
+        ``dtype`` is not a complex type.
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
         (True) or not (False)
@@ -238,8 +251,12 @@ def FFT2D(
     Raises
     ------
     ValueError
-        If ``dims`` has less than two elements, and if ``dirs``, ``nffts``,
-        or ``sampling`` has more or less than two elements.
+        If ``dims`` has less than two elements.
+        If ``dirs`` does not have exactly two elements.
+        If ``nffts`` or ``sampling`` are not either a single value or a tuple with
+        two elements.
+    NotImplementedError
+        If ``engine`` is neither ``numpy``, nor ``scipy``.
 
     Notes
     -----

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -179,11 +179,27 @@ def FFT2D(
     Apply two dimensional Fast-Fourier Transform (FFT) to any pair of axes of a
     multi-dimensional array depending on the choice of ``dirs``.
 
-    Note that the FFT2D operator is a simple overload to the numpy
-    :py:func:`numpy.fft.fft2` in forward mode and to the numpy
-    :py:func:`numpy.fft.ifft2` in adjoint mode (or their cupy equivalents),
-    however scaling is taken into account differently to guarantee that the
-    operator is passing the dot-test.
+    Using the default NumPy engine, the FFT operator is an overload to either the NumPy
+    :py:func:`numpy.fft.fft2` (or :py:func:`numpy.fft.rfft2` for real models) in
+    forward mode, and to :py:func:`numpy.fft.ifft2` (or :py:func:`numpy.fft.irfft2`
+    for real models) in adjoint mode, or their CuPy equivalents.
+    Alternatively, when the SciPy engine is chosen, the overloads are of
+    :py:func:`scipy.fft.fft2` (or :py:func:`scipy.fft.rfft2` for real models) in
+    forward mode, and to :py:func:`scipy.fft.ifft2` (or :py:func:`scipy.fft.irfft2`
+    for real models) in adjoint mode.
+
+    In all cases, the "ortho" scaling (see :py:func:`numpy.fft.fft2`) is used to
+    to guarantee that the operator passes the dot-test. When using `real=True`, the
+    result of the forward is also multiplied by sqrt(2) for all frequency bins
+    except zero and Nyquist along the second direction of ``dirs``, and the input of
+    the adjoint is divided by sqrt(2) for the same frequencies.
+    If a user is interested in using the unscaled forward FFT, they must pre-multiply
+    the operator by an appropriate correction factor.
+
+    For a real valued input signal, it is advised to use the flag ``real=True``
+    as it stores the values of the Fourier transform of the last direction at positive
+    frequencies only as values at negative frequencies are simply their complex conjugates.
+
 
     Parameters
     ----------
@@ -239,6 +255,19 @@ def FFT2D(
 
     Attributes
     ----------
+    dims_fft : :obj:`tuple`
+        Shape of the array after the forward, but before linearization. E.g.
+        ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+    f1 : :obj:`numpy.ndarray`
+        Discrete Fourier Transform sample frequencies along ``dir[0]``
+    f2 : :obj:`numpy.ndarray`
+        Discrete Fourier Transform sample frequencies along ``dir[1]``
+    real : :obj:`bool`
+        When True, uses ``rfft2``/``irfft2``
+    rdtype : :obj:`bool`
+        Expected input type to the forward
+    cdtype : :obj:`bool`
+        Output type of the forward. Complex equivalent to ``rdtype``.
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -171,47 +171,61 @@ def FFTND(
     ----------
     dims : :obj:`tuple`
         Number of samples for each dimension
-    dirs : :obj:`tuple`, optional
-        Directions along which FFTND is applied
-    nffts : :obj:`tuple`, optional
-        Number of samples in Fourier Transform for each direction (same as
-        input if ``nffts=(None, None, None, ..., None)``)
-    sampling : :obj:`tuple`, optional
-        Sampling steps in each direction
+    dirs : :obj:`tuple` or :obj:`int`, optional
+        Direction(s) along which FFTND is applied
+    nffts : :obj:`tuple` or :obj:`int`, optional
+        Number of samples in Fourier Transform for each direction. In case only one
+        dimension needs to be specified, use ``None`` for the other dimension in the
+        tuple. The direction with None will use ``dims[dir]`` as ``nfft``. When supplying a
+        tuple, the order must agree with that of ``dirs``. When a single value is
+        passed, it will be used for both directions. As such the default is
+        equivalent to ``nffts=(None,..., None)``.
+    sampling : :obj:`tuple` or :obj:`float`, optional
+        Sampling steps for each direction. When supplied a single value, it is used
+        for all directions. Unlike ``nffts``, ``None``s will not be converted to the
+        default value.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
         model is real. Note that the real FFT is applied only to the first
         dimension to which the FFTND operator is applied (last element of
-        `dirs`)
-    ifftshift_before : :obj:`bool`, optional
+        ``dirs``)
+    ifftshift_before : :obj:`tuple` or :obj:`bool`, optional
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
         with respect to the zero value sample. This will shift the zero value sample to
         coincide with the zero index sample. With such an arrangement, FFT will not
         introduce a sample-dependent phase-shift when compared to the continuous Fourier
         Transform.
-        Defaults to not applying ifftshift.
-    fftshift_after : :obj:`bool`, optional
+        When passing a single value, the shift will the same for every direction. Pass
+        a tuple to specify which dimensions are shifted.
+    fftshift_after : :obj:`tuple` or :obj:`bool`, optional
         Apply fftshift (``True``) or not (``False``) to data vector (after FFT).
         Consider using this option when you require frequencies to be arranged
         naturally, from negative to positive. When not applying fftshift after FFT,
         frequencies are arranged from zero to largest positive, and then from negative
         Nyquist to the frequency bin before zero.
-        Defaults to not applying fftshift.
+        When passing a single value, the shift will the same for every direction. Pass
+        a tuple to specify which dimensions are shifted.
+    engine : :obj:`str`, optional
+        Engine used for fft computation (``numpy`` or ``scipy``).
     dtype : :obj:`str`, optional
-        Type of elements in input array. Note that the `dtype` of the operator
+        Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
-        Nevertheless, the provided dtype will be enforced on the vector
-        returned by the `rmatvec` method.
+        In addition, note that the NumPy backend does not support returning ``dtype``s
+        different than ``complex128``. As such, when using the NumPy backend, arrays will
+        be force-casted to types corresponding to the supplied ``dtype``.
+        The SciPy backend supports all precisions natively.
+        Under both backends, when a real ``dtype`` is supplied, a real result will be
+        enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
 
     Attributes
     ----------
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
-        Operator is complex-linear. Is false when either real=True or when
-        dtype is not a complex type.
+        Operator is complex-linear. Is false when either ``real=True`` or when
+        ``dtype`` is not a complex type.
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
         (True) or not (False)
@@ -219,9 +233,10 @@ def FFTND(
     Raises
     ------
     ValueError
-        If ``dims``, ``dirs``, ``nffts``, or ``sampling`` have less than \
-        three elements and if the dimension of ``dirs``, ``nffts``, and
-        ``sampling`` is not the same
+        If ``nffts`` or ``sampling`` are not either a single value or tuple with
+        the same dimension ``dirs``.
+    NotImplementedError
+        If ``engine`` is neither ``numpy``, nor ``scipy``.
 
     Notes
     -----

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -198,9 +198,9 @@ def test_FFT_small_real(par):
 
 par_lists_fft_random_real = dict(
     shape=[
-        np.random.randint(1, 50, size=(1,)),
-        np.random.randint(1, 50, size=(2,)),
-        np.random.randint(1, 50, size=(3,)),
+        np.random.randint(1, 20, size=(1,)),
+        np.random.randint(1, 20, size=(2,)),
+        np.random.randint(1, 20, size=(3,)),
     ],
     dtype_precision=[
         (np.float16, 1),
@@ -297,9 +297,9 @@ def test_FFT_small_complex(par):
 
 par_lists_fft_random_cpx = dict(
     shape=[
-        np.random.randint(1, 50, size=(1,)),
-        np.random.randint(1, 50, size=(2,)),
-        np.random.randint(1, 50, size=(3,)),
+        np.random.randint(1, 20, size=(1,)),
+        np.random.randint(1, 20, size=(2,)),
+        np.random.randint(1, 20, size=(3,)),
     ],
     dtype_precision=[
         (np.float16, 1),
@@ -385,11 +385,12 @@ par_lists_fft2d_random_real = dict(
     ],
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 5),
-        (np.float64, 13),
-        (np.float128, 13),
+        (np.float32, 3),
+        (np.float64, 11),
+        (np.float128, 11),
     ],
     ifftshift_before=[False, True],
+    engine=["numpy", "scipy"],
 )
 pars_fft2d_random_real = [
     dict(zip(par_lists_fft2d_random_real.keys(), value))
@@ -402,6 +403,7 @@ def test_FFT2D_random_real(par):
     shape = par["shape"]
     dtype, decimal = par["dtype_precision"]
     ifftshift_before = par["ifftshift_before"]
+    engine = par["engine"]
 
     x = np.random.randn(*shape).astype(dtype)
 
@@ -416,6 +418,7 @@ def test_FFT2D_random_real(par):
         ifftshift_before=ifftshift_before,
         real=True,
         dtype=dtype,
+        engine=engine,
     )
     x = x.ravel()
     y = FFTop * x
@@ -440,7 +443,7 @@ par_lists_fft2d_random_cpx = dict(
     ],
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 4),
+        (np.float32, 3),
         (np.float64, 11),
         (np.float128, 11),
         (np.complex64, 3),
@@ -449,6 +452,7 @@ par_lists_fft2d_random_cpx = dict(
     ],
     ifftshift_before=itertools.product([False, True], [False, True]),
     fftshift_after=itertools.product([False, True], [False, True]),
+    engine=["numpy", "scipy"],
 )
 # Generate all combinations of the above parameters
 pars_fft2d_random_cpx = [
@@ -463,6 +467,7 @@ def test_FFT2D_random_complex(par):
     dtype, decimal = par["dtype_precision"]
     ifftshift_before = par["ifftshift_before"]
     fftshift_after = par["fftshift_after"]
+    engine = par["engine"]
 
     x = np.random.randn(*shape).astype(dtype)
     if np.issubdtype(dtype, np.complexfloating):
@@ -479,6 +484,7 @@ def test_FFT2D_random_complex(par):
         ifftshift_before=ifftshift_before,
         fftshift_after=fftshift_after,
         dtype=dtype,
+        engine=engine,
     )
 
     # Compute FFT of x independently
@@ -519,10 +525,11 @@ par_lists_fftnd_random_real = dict(
     ],
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 5),
-        (np.float64, 13),
-        (np.float128, 13),
+        (np.float32, 3),
+        (np.float64, 11),
+        (np.float128, 11),
     ],
+    engine=["numpy", "scipy"],
 )
 pars_fftnd_random_real = [
     dict(zip(par_lists_fftnd_random_real.keys(), value))
@@ -534,6 +541,7 @@ pars_fftnd_random_real = [
 def test_FFTND_random_real(par):
     shape = par["shape"]
     dtype, decimal = par["dtype_precision"]
+    engine = par["engine"]
 
     x = np.random.randn(*shape).astype(dtype)
 
@@ -552,6 +560,7 @@ def test_FFTND_random_real(par):
         ifftshift_before=ifftshift_before,
         real=True,
         dtype=dtype,
+        engine=engine,
     )
     x = x.ravel()
     y = FFTop * x
@@ -575,13 +584,14 @@ par_lists_fftnd_random_cpx = dict(
     ],
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 4),
+        (np.float32, 3),
         (np.float64, 11),
         (np.float128, 11),
         (np.complex64, 3),
         (np.complex128, 11),
         (np.complex256, 11),
     ],
+    engine=["numpy", "scipy"],
 )
 # Generate all combinations of the above parameters
 pars_fftnd_random_cpx = [
@@ -594,6 +604,7 @@ pars_fftnd_random_cpx = [
 def test_FFTND_random_complex(par):
     shape = par["shape"]
     dtype, decimal = par["dtype_precision"]
+    engine = par["engine"]
 
     x = np.random.randn(*shape).astype(dtype)
     if np.issubdtype(dtype, np.complexfloating):
@@ -615,6 +626,7 @@ def test_FFTND_random_complex(par):
         ifftshift_before=ifftshift_before,
         fftshift_after=fftshift_after,
         dtype=dtype,
+        engine=engine,
     )
 
     # Compute FFT of x independently

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -145,7 +145,7 @@ par_lists_fft_small_real = dict(
         (np.float128, 13),
     ],
     ifftshift_before=[False, True],
-    engine=["numpy", "fftw"],
+    engine=["numpy", "fftw", "scipy"],
 )
 # Generate all combinations of the above parameters
 pars_fft_small_real = [
@@ -209,7 +209,7 @@ par_lists_fft_random_real = dict(
         (np.float128, 11),
     ],
     ifftshift_before=[False, True],
-    engine=["numpy", "fftw"],
+    engine=["numpy", "fftw", "scipy"],
 )
 pars_fft_random_real = [
     dict(zip(par_lists_fft_random_real.keys(), value))
@@ -255,7 +255,7 @@ par_lists_fft_small_cpx = dict(
     dtype_precision=[(np.complex64, 5), (np.complex128, 13), (np.complex256, 13)],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
-    engine=["numpy", "fftw"],
+    engine=["numpy", "fftw", "scipy"],
 )
 pars_fft_small_cpx = [
     dict(zip(par_lists_fft_small_cpx.keys(), value))
@@ -303,7 +303,7 @@ par_lists_fft_random_cpx = dict(
     ],
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 4),
+        (np.float32, 3),
         (np.float64, 11),
         (np.float128, 11),
         (np.complex64, 3),
@@ -312,7 +312,7 @@ par_lists_fft_random_cpx = dict(
     ],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
-    engine=["numpy", "fftw"],
+    engine=["numpy", "fftw", "scipy"],
 )
 pars_fft_random_cpx = [
     dict(zip(par_lists_fft_random_cpx.keys(), value))


### PR DESCRIPTION
New features:
* FFT, FFT2D and FFTND now support the SciPy backend. As noted in #286, the SciPy backend respects the precision of the input arrays.

Nitty gritty:
* FFT2D and FFTND now correspond to functions instead of classes, in the same manner as FFT is already implemented. As such, concrete implementations are now relegated to _FFT2D_numpy, _FFT2D_scipy, _FFTND_numpy, _FFTND_scipy
* FFTs for all backends still use the NumPy `fftfreq` and `rfftfreq`. This is OK on the SciPy backend because [SciPy actually uses the NumPy versions under the hood](https://github.com/scipy/scipy/blob/master/scipy/fft/__init__.py#L94).

Test suite:
* Added engine="scipy" to the majority of tests. In addition, setting the scipy backend as the default and then running the entire test suite works without problems. Note that in this patch, the numpy backend remains the default.

_Note that this pull request should be applied on top of #288_