### PR TITLE
Added fftengine to Marchenko

### DIFF
--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -138,6 +138,8 @@ class Marchenko:
         :class:`pylops.waveeqprocessing.MDC` operator. In case
         ``prescaled=True``, the ``R`` is assumed to have been pre-scaled by
         the user.
+    fftengine : :obj:`str`, optional
+        Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
 
     Attributes
     ----------
@@ -231,6 +233,7 @@ class Marchenko:
         dtype="float64",
         saveRt=True,
         prescaled=False,
+        fftengine="numpy",
     ):
         warnings.warn(
             "A new implementation of Marchenko is provided in v1.5.0. "
@@ -251,6 +254,7 @@ class Marchenko:
         self.nsmooth = nsmooth
         self.saveRt = saveRt
         self.prescaled = prescaled
+        self.fftengine = fftengine
         self.dtype = dtype
         self.explicit = False
         self.ncp = get_array_module(R)
@@ -372,6 +376,7 @@ class Marchenko:
             dr=self.dr,
             twosided=True,
             conj=False,
+            fftengine=self.fftengine,
             transpose=False,
             saveGt=self.saveRt,
             prescaled=self.prescaled,
@@ -386,6 +391,7 @@ class Marchenko:
             dr=self.dr,
             twosided=True,
             conj=True,
+            fftengine=self.fftengine,
             transpose=False,
             saveGt=self.saveRt,
             prescaled=self.prescaled,
@@ -582,6 +588,7 @@ class Marchenko:
             dr=self.dr,
             twosided=True,
             conj=False,
+            fftengine=self.fftengine,
             transpose=False,
             prescaled=self.prescaled,
             usematmul=usematmul,
@@ -595,6 +602,7 @@ class Marchenko:
             dr=self.dr,
             twosided=True,
             conj=True,
+            fftengine=self.fftengine,
             transpose=False,
             prescaled=self.prescaled,
             usematmul=usematmul,

--- a/pylops/waveeqprocessing/mdd.py
+++ b/pylops/waveeqprocessing/mdd.py
@@ -198,7 +198,7 @@ def MDC(
     dtype : :obj:`str`, optional
         *Deprecated*, will be removed in v2.0.0
     fftengine : :obj:`str`, optional
-        Engine used for fft computation (``numpy`` or ``fftw``)
+        Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
     transpose : :obj:`bool`, optional
         Transpose ``G`` and inputs such that time/frequency is placed in first
         dimension. This allows back-compatibility with v1.4.0 and older but
@@ -299,6 +299,7 @@ def MDD(
     saveGt=True,
     add_negative=True,
     smooth_precond=0,
+    fftengine="numpy",
     **kwargs_solver
 ):
     r"""Multi-dimensional deconvolution.
@@ -355,6 +356,8 @@ def MDD(
         :class:`pylops.signalprocessing.Fredholm1` (``True``) or create
         ``G^H`` on-the-fly (``False``) Note that ``saveGt=True`` will be
         faster but double the amount of required memory
+    fftengine : :obj:`str`, optional
+        Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
     **kwargs_solver
         Arbitrary keyword arguments for chosen solver
         (:py:func:`scipy.sparse.linalg.cg` and
@@ -457,6 +460,7 @@ def MDD(
         twosided=twosided,
         transpose=False,
         saveGt=saveGt,
+        fftengine=fftengine,
     )
     if psf:
         PSFop = MDC(
@@ -468,6 +472,7 @@ def MDD(
             twosided=twosided,
             transpose=False,
             saveGt=saveGt,
+            fftengine=fftengine,
         )
     if dottest:
         Dottest(

--- a/pytests/test_marchenko.py
+++ b/pytests/test_marchenko.py
@@ -72,11 +72,13 @@ Rtwosided_fft = Rtwosided_fft[..., :nfmax]
 R1twosided_fft = np.fft.rfft(R1twosided, 2 * nt - 1, axis=-1) / np.sqrt(2 * nt - 1)
 R1twosided_fft = R1twosided_fft[..., :nfmax]
 
-par1 = {"niter": 10, "prescaled": False}
-par2 = {"niter": 10, "prescaled": True}
+par1 = {"niter": 10, "prescaled": False, "fftengine": "numpy"}
+par2 = {"niter": 10, "prescaled": True, "fftengine": "numpy"}
+par3 = {"niter": 10, "prescaled": False, "fftengine": "scipy"}
+par4 = {"niter": 10, "prescaled": False, "fftengine": "fftw"}
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_Marchenko_freq(par):
     """Solve marchenko equations using input Rs in frequency domain"""
     if par["prescaled"]:
@@ -96,6 +98,7 @@ def test_Marchenko_freq(par):
         toff=toff,
         nsmooth=nsmooth,
         prescaled=par["prescaled"],
+        fftengine=par["fftengine"],
     )
 
     _, _, _, g_inv_minus, g_inv_plus = MarchenkoWM.apply_onepoint(

--- a/pytests/test_oneway.py
+++ b/pytests/test_oneway.py
@@ -23,7 +23,7 @@ parmod = {
 }
 
 par1 = {"ny": 8, "nx": 10, "nt": 20, "dtype": "float32"}  # even
-par2 = {"ny": 9, "nx": 11, "nt": 21, "dtype": "complex64"}  # odd
+par2 = {"ny": 9, "nx": 11, "nt": 21, "dtype": "float32"}  # odd
 
 # deghosting params
 vel_sep = 1000.0  # velocity at separation level


### PR DESCRIPTION
A new optional paramter is added to the Marchenko module
to allow selecting the engine used to perform FFT operations.