### PR TITLE
FFTW important bugfix and minor feature

### DIFF
--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -223,8 +223,6 @@ class _FFT_fftw(_BaseFFT):
         )
 
     def _matvec(self, x):
-        if self.real:
-            x = np.real(x)
         x = np.reshape(x, self.dims)
         if self.ifftshift_before:
             x = np.fft.ifftshift(x, axes=self.dir)

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -177,6 +177,11 @@ class _FFT_fftw(_BaseFFT):
         dtype="complex128",
         **kwargs_fftw,
     ):
+        if np.dtype(dtype) == np.float16:
+            warnings.warn(
+                "fftw backend is unavailable with float16 dtype. Will use float32."
+            )
+            dtype = np.float32
         super().__init__(
             dims=dims,
             dir=dir,

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -160,10 +160,6 @@ def test_FFT_small_real(par):
     ifftshift_before = par["ifftshift_before"]
     engine = par["engine"]
 
-    if engine == "fftw" and dtype == np.float16:
-        # fftw does not support float16 for real
-        return
-
     x = np.array([1, 0, -1, 1], dtype=dtype)
 
     FFTop = FFT(

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -191,9 +191,14 @@ def test_FFT_small_real(par):
         # https://www.iap.uni-jena.de/iapmedia/de/Lecture/Computational+Photonics/CoPho19_supp_FFT_primer.pdf
         x0 = -np.ceil(len(x) / 2)
         y_true *= np.exp(2 * np.pi * 1j * FFTop.f * x0)
+
     assert_array_almost_equal(y, y_true, decimal=decimal)
     assert dottest(FFTop, len(y), len(x), complexflag=0, tol=10 ** (-decimal))
     assert dottest(FFTop, len(y), len(x), complexflag=2, tol=10 ** (-decimal))
+
+    x_inv = FFTop / y
+    x_inv = x_inv.reshape(x.shape)
+    assert_array_almost_equal(x_inv, x, decimal=decimal)
 
 
 par_lists_fft_random_real = dict(
@@ -293,6 +298,10 @@ def test_FFT_small_complex(par):
     y = FFTop * x.ravel()
     assert_array_almost_equal(y, y_true, decimal=decimal)
     assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+
+    x_inv = FFTop / y
+    x_inv = x_inv.reshape(x.shape)
+    assert_array_almost_equal(x_inv, x, decimal=decimal)
 
 
 par_lists_fft_random_cpx = dict(

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -140,9 +140,9 @@ def test_unknown_engine(par):
 par_lists_fft_small_real = dict(
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 5),
-        (np.float64, 13),
-        (np.float128, 13),
+        (np.float32, 4),
+        (np.float64, 11),
+        (np.float128, 11),
     ],
     ifftshift_before=[False, True],
     engine=["numpy", "fftw", "scipy"],
@@ -253,7 +253,7 @@ def test_FFT_random_real(par):
 
 
 par_lists_fft_small_cpx = dict(
-    dtype_precision=[(np.complex64, 5), (np.complex128, 13), (np.complex256, 13)],
+    dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.complex256, 11)],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
     engine=["numpy", "fftw", "scipy"],


### PR DESCRIPTION
## Bug: prevent FFTW from overwriting arrays
I noticed a serious bug in the implementation of FFTW. A wrapper class called as such: [`myfftw = pyfftw.FFTW(self.x, self.y, ...)` **always** returns `self.y` on a call](https://github.com/pyFFTW/pyFFTW/blob/master/pyfftw/pyfftw.pyx#L1760-L1762). As such, when using the output of `myfftw()`, we should always be copying this array onto a new one. Not doing this risks overwriting arrays when multiplying by `FFT(engine="fftw")` several times; the same `LinearOperator` is will always write to `self.y`. Note that using some options may force a copy (e.g. `fftshift_after=True`) but this is not guaranteed.

In addition, when calling `myfftw(x)` on an array `x`, [it *may* create a copy of `x`](https://github.com/pyFFTW/pyFFTW/blob/master/pyfftw/pyfftw.pyx#L1751-L1752), which means that multiplying by an `FFT(engine="fftw")` may also alter the input array.

It is possible to reproduce this bug with the following code:
```python
import numpy as np
from numpy.testing import assert_array_almost_equal
from pylops.signalprocessing import FFT
from pylops.utils import dottest

x = np.array([1, 0, -1, 1], dtype=np.float64)

FFTop = FFT(dims=x.shape, dir=0, real=True, engine="fftw")
print("Input", x)
y = FFTop * x.ravel()
print("After FFT", x)

y_true = np.array([0.5, 1 + 0.5j, -0.5])
y_true[1:-1] *= np.sqrt(2)  # Zero and Nyquist

assert_array_almost_equal(y, y_true)
print("Before dottest", x)
assert dottest(FFTop, len(y), len(x), complexflag=0)
print("After dottest", x)
```
Running this without the patch should output:
```
Input [ 1.  0. -1.  1.]
After FFT [ 1.  0. -1.  1.]
Before dottest [ 1.  0. -1.  1.]
After dottest [-0.24220454  0.77404217 -1.57652909 -1.01908738] # Oops!
```

The fix is straight forward:
* Always copy `x` onto `self.x` when calling `self.fftplan()` in the `_matvec` of `FFT(engine="fftw")`.
* Always copy `x` onto `self.y` when calling `self.ifftplan()` in the `_rmatvec` of `FFT(engine="fftw")`.
* Always copy the outputs of `self.fftplan()` and `self.ifftplan()`.

This patch introduces these changes, in addition to some tests which prevent this issue from happening again. Moreover, I identified a useless call to `np.real` that has been removed. In my local version, all tests pass, even if fftw is used as the default engine. This gives me confidence that the implementation is very consistent with the other backends.

## Feature: promoting to `np.float32` when using FFTW with `np.float16`
The pyFFTW library does not export FFTW plans for float16s, which previously errored with a mysterious message. This patch introduces a promotion to `np.float32` when the user supplies `dtype=np.float16`, and warns the user of this promotion.
