### PR TITLE
Feature: Norm option for FFT operator

### DIFF
--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -110,6 +110,11 @@ class _FFT_numpy(_BaseFFT):
         y = y.astype(self.rdtype)
         return y
 
+    def __truediv__(self, y):
+        if self.norm != "ortho":
+            return self._rmatvec(y) / self._scale / self._scale
+        return self._rmatvec(y)
+
 
 class _FFT_scipy(_BaseFFT):
     """One dimensional Fast-Fourier Transform using numpy"""
@@ -192,6 +197,11 @@ class _FFT_scipy(_BaseFFT):
             y = scipy.fft.fftshift(y, axes=self.dir)
         y = y.ravel()
         return y
+
+    def __truediv__(self, y):
+        if self.norm != "ortho":
+            return self._rmatvec(y) / self._scale / self._scale
+        return self._rmatvec(y)
 
 
 class _FFT_fftw(_BaseFFT):
@@ -339,6 +349,11 @@ class _FFT_fftw(_BaseFFT):
         if not self.clinear:
             y = np.real(y)
         return y.ravel()
+
+    def __truediv__(self, y):
+        if self.norm == "ortho":
+            return self._rmatvec(y)
+        return self._rmatvec(y) / self._scale
 
 
 def FFT(

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -52,6 +52,10 @@ class _FFT_numpy(_BaseFFT):
             warnings.warn(
                 f"numpy backend always returns complex128 dtype. To respect the passed dtype, data will be casted to {self.cdtype}."
             )
+        if self.norm not in ["ortho", "backward", "forward"]:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
         # FFTs are called with "ortho" for backwards compatibility
         # The factors below are conversions factors ortho->norm
         if self.norm == "backward":
@@ -133,6 +137,10 @@ class _FFT_scipy(_BaseFFT):
             fftshift_after=fftshift_after,
             dtype=dtype,
         )
+        if self.norm not in ["ortho", "backward", "forward"]:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
         # FFTs are called with "ortho" for backwards compatibility
         # The factors below are conversions factors ortho->norm
         if self.norm == "backward":

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -390,9 +390,9 @@ def FFT(
     forward mode, and to :py:func:`scipy.fft.ifft` (or :py:func:`scipy.fft.irfft`
     for real models) in adjoint mode.
 
-    When using `real=True`, the result of the forward is also multiplied by sqrt(2)
-    for all frequency bins except zero and Nyquist, and the input of the adjoint is
-    divided by sqrt(2) for the same frequencies.
+    When using `real=True`, the result of the forward is also multiplied by
+    :math:`\sqrt{2}` for all frequency bins except zero and Nyquist, and the input of
+    the adjoint is multiplied by :math:`1 / \sqrt{2}` for the same frequencies.
 
     For a real valued input signal, it is advised to use the flag `real=True`
     as it stores the values of the Fourier transform at positive frequencies only as
@@ -409,14 +409,17 @@ def FFT(
     sampling : :obj:`float`, optional
         Sampling step ``dt``.
     norm : `{"ortho", "backward", "forward"}`, optional
-        Normalization mode (see :py:func:`numpy.fft.fft`). Note that for "backward"
-        and "forward", the scaling placed on the forward is the same as that placed
-        on the adjoint, so as to respect adjoitness. This is different from standard
-        NumPy/SciPy behavior which scales ``fft`` and ``ifft`` differently when using
-        the same ``norm``. As a result, a forward and adjoint pass with the "backward"
-        norm will introduce a factor of :math:`nfft`; a forward and adjoint pass with
-        "forward" will introduce a factor of :math:`nfft^{-1}`. Only "ortho" will
-        recover the original signal.
+        * "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
+        where :math:`N_F` is the number of samples in the Fourier domain given by ``nfft``.
+        * "backward": Does not scale the forward or the adjoint FFT transforms. Note
+        that the adjoint behaviour of this option differs from :py:func:`ifft`
+        implementations in NumPy and SciPy.
+        * "forward": Scales both the forward and adjoint FFT transforms by
+        :math:`1/N_F`. Note the forward behaviour of this option differs from
+        :py:func:`fft` implementations in NumPy and SciPy.
+        Also note that for "forward" and "backward", the operator is not unitary,
+        that is, the adjoint is not the inverse. To invert the operator, simply use
+        `Op \ y`.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -484,7 +487,8 @@ def FFT(
 
     Notes
     -----
-    The FFT operator applies the forward Fourier transform to a signal
+    The FFT operator (using `norm="ortho"`) applies the forward Fourier transform to
+    a signal
     :math:`d(t)` in forward mode:
 
     .. math::
@@ -496,12 +500,13 @@ def FFT(
     .. math::
         d(t) = \mathscr{F}^{-1} (D) = \sqrt{N_F} \int D(f) e^{j2\pi ft} df
 
-    where :math:`N_F` is the number of samples in the Fourier domain `nfft`.
+    where :math:`N_F` is the number of samples in the Fourier domain ``nfft``.
     Both operators are effectively discretized and solved by a fast iterative
-    algorithm known as Fast Fourier Transform. Note that the FFT operator is a
-    special operator in that the adjoint is also the inverse of the forward mode.
-    Moreover, in case of real signal in time domain, the Fourier transform in
-    Hermitian.
+    algorithm known as Fast Fourier Transform. Note that the FFT operator
+    (using `norm="ortho"`) is a special operator in that the adjoint is also
+    the inverse of the forward mode. For other norms, this does not hold (see ``norm``
+    help). However, for any norm, the Fourier transform is Hermitian for real input
+    signals.
 
     """
     # Use fftshift if supplied, otherwise use ifftshift_before

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -352,7 +352,10 @@ def FFT(
         and "forward", the scaling placed on the forward is the same as that placed
         on the adjoint, so as to respect adjoitness. This is different from standard
         NumPy/SciPy behavior which scales ``fft`` and ``ifft`` differently when using
-        the same ``norm``.
+        the same ``norm``. As a result, a forward and adjoint pass with the "backward"
+        norm will introduce a factor of :math:`nfft`; a forward and adjoint pass with
+        "forward" will introduce a factor of :math:`nfft^{-1}`. Only "ortho" will
+        recover the original signal.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -49,6 +49,10 @@ class _FFT2D_numpy(_BaseFFTND):
         self.f1, self.f2 = self.fs
         del self.fs
 
+        if self.norm not in ["ortho", "backward", "forward"]:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
         # FFTs are called with "ortho" for backwards compatibility
         # The factors below are conversions factors ortho->norm
         if self.norm == "backward":
@@ -138,6 +142,10 @@ class _FFT2D_scipy(_BaseFFTND):
         self.f1, self.f2 = self.fs
         del self.fs
 
+        if self.norm not in ["ortho", "backward", "forward"]:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
         # FFTs are called with "ortho" for backwards compatibility
         # The factors below are conversions factors ortho->norm
         if self.norm == "backward":

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -105,6 +105,11 @@ class _FFT2D_numpy(_BaseFFTND):
             y = np.fft.fftshift(y, axes=self.dirs[self.ifftshift_before])
         return y.ravel()
 
+    def __truediv__(self, y):
+        if self.norm != "ortho":
+            return self._rmatvec(y) / self._scale / self._scale
+        return self._rmatvec(y)
+
 
 class _FFT2D_scipy(_BaseFFTND):
     """Two dimensional Fast-Fourier Transform using scipy"""
@@ -195,6 +200,11 @@ class _FFT2D_scipy(_BaseFFTND):
         if self.ifftshift_before.any():
             y = scipy.fft.fftshift(y, axes=self.dirs[self.ifftshift_before])
         return y.ravel()
+
+    def __truediv__(self, y):
+        if self.norm != "ortho":
+            return self._rmatvec(y) / self._scale / self._scale
+        return self._rmatvec(y)
 
 
 def FFT2D(

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -49,16 +49,17 @@ class _FFT2D_numpy(_BaseFFTND):
         self.f1, self.f2 = self.fs
         del self.fs
 
-        if self.norm not in ["ortho", "backward", "forward"]:
+        self._norm_kwargs = {"norm": None}  # backward
+        if self.norm == "ortho":
+            self._norm_kwargs["norm"] = "ortho"
+        elif self.norm == "backward":
+            self._scale = np.prod(self.nffts)
+        elif self.norm == "forward":
+            self._scale = 1.0 / np.prod(self.nffts)
+        else:
             raise ValueError(
                 f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
             )
-        # FFTs are called with "ortho" for backwards compatibility
-        # The factors below are conversions factors ortho->norm
-        if self.norm == "backward":
-            self._scale = np.sqrt(np.prod(self.nffts))
-        elif self.norm == "forward":
-            self._scale = np.sqrt(1.0 / np.prod(self.nffts))
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)
@@ -67,14 +68,14 @@ class _FFT2D_numpy(_BaseFFTND):
         if not self.clinear:
             x = np.real(x)
         if self.real:
-            y = np.fft.rfft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
+            y = np.fft.rfft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
             # Apply scaling to obtain a correct adjoint for this operator
             y = np.swapaxes(y, -1, self.dirs[-1])
             y[..., 1 : 1 + (self.nffts[-1] - 1) // 2] *= np.sqrt(2)
             y = np.swapaxes(y, self.dirs[-1], -1)
         else:
-            y = np.fft.fft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
-        if self.norm != "ortho":
+            y = np.fft.fft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
+        if self.norm == "forward":
             y *= self._scale
         y = y.astype(self.cdtype)
         if self.fftshift_after.any():
@@ -91,10 +92,10 @@ class _FFT2D_numpy(_BaseFFTND):
             x = np.swapaxes(x, -1, self.dirs[-1])
             x[..., 1 : 1 + (self.nffts[-1] - 1) // 2] /= np.sqrt(2)
             x = np.swapaxes(x, self.dirs[-1], -1)
-            y = np.fft.irfft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
+            y = np.fft.irfft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         else:
-            y = np.fft.ifft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
-        if self.norm != "ortho":
+            y = np.fft.ifft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
+        if self.norm == "backward":
             y *= self._scale
         y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
         y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])
@@ -107,7 +108,7 @@ class _FFT2D_numpy(_BaseFFTND):
 
     def __truediv__(self, y):
         if self.norm != "ortho":
-            return self._rmatvec(y) / self._scale / self._scale
+            return self._rmatvec(y) / self._scale
         return self._rmatvec(y)
 
 
@@ -147,16 +148,17 @@ class _FFT2D_scipy(_BaseFFTND):
         self.f1, self.f2 = self.fs
         del self.fs
 
-        if self.norm not in ["ortho", "backward", "forward"]:
-            raise ValueError(
-                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
-            )
-        # FFTs are called with "ortho" for backwards compatibility
-        # The factors below are conversions factors ortho->norm
-        if self.norm == "backward":
+        self._norm_kwargs = {"norm": None}  # backward
+        if self.norm == "ortho":
+            self._norm_kwargs["norm"] = "ortho"
+        elif self.norm == "backward":
             self._scale = np.sqrt(np.prod(self.nffts))
         elif self.norm == "forward":
             self._scale = np.sqrt(1.0 / np.prod(self.nffts))
+        else:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)
@@ -165,14 +167,14 @@ class _FFT2D_scipy(_BaseFFTND):
         if not self.clinear:
             x = np.real(x)
         if self.real:
-            y = scipy.fft.rfft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
+            y = scipy.fft.rfft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
             # Apply scaling to obtain a correct adjoint for this operator
             y = np.swapaxes(y, -1, self.dirs[-1])
             y[..., 1 : 1 + (self.nffts[-1] - 1) // 2] *= np.sqrt(2)
             y = np.swapaxes(y, self.dirs[-1], -1)
         else:
-            y = scipy.fft.fft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
-        if self.norm != "ortho":
+            y = scipy.fft.fft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
+        if self.norm == "forward":
             y *= self._scale
         if self.fftshift_after.any():
             y = scipy.fft.fftshift(y, axes=self.dirs[self.fftshift_after])
@@ -188,10 +190,10 @@ class _FFT2D_scipy(_BaseFFTND):
             x = np.swapaxes(x, -1, self.dirs[-1])
             x[..., 1 : 1 + (self.nffts[-1] - 1) // 2] /= np.sqrt(2)
             x = np.swapaxes(x, self.dirs[-1], -1)
-            y = scipy.fft.irfft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
+            y = scipy.fft.irfft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         else:
-            y = scipy.fft.ifft2(x, s=self.nffts, axes=self.dirs, norm="ortho")
-        if self.norm != "ortho":
+            y = scipy.fft.ifft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
+        if self.norm == "backward":
             y *= self._scale
         y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
         y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -4,13 +4,13 @@ import warnings
 import numpy as np
 import scipy.fft
 
-from pylops.signalprocessing._BaseFFTs import _BaseFFTND
+from pylops.signalprocessing._BaseFFTs import _BaseFFTND, _FFTNorms
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class _FFT2D_numpy(_BaseFFTND):
-    """Two dimensional Fast-Fourier Transform using numpy"""
+    """Two dimensional Fast-Fourier Transform using NumPy"""
 
     def __init__(
         self,
@@ -49,17 +49,13 @@ class _FFT2D_numpy(_BaseFFTND):
         self.f1, self.f2 = self.fs
         del self.fs
 
-        self._norm_kwargs = {"norm": None}  # backward
-        if self.norm == "ortho":
+        self._norm_kwargs = {"norm": None}  # equivalent to "backward" in Numpy/Scipy
+        if self.norm is _FFTNorms.ORTHO:
             self._norm_kwargs["norm"] = "ortho"
-        elif self.norm == "backward":
+        elif self.norm is _FFTNorms.NONE:
             self._scale = np.prod(self.nffts)
-        elif self.norm == "forward":
+        elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = 1.0 / np.prod(self.nffts)
-        else:
-            raise ValueError(
-                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
-            )
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)
@@ -75,7 +71,7 @@ class _FFT2D_numpy(_BaseFFTND):
             y = np.swapaxes(y, self.dirs[-1], -1)
         else:
             y = np.fft.fft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
-        if self.norm == "forward":
+        if self.norm is _FFTNorms.ONE_OVER_N:
             y *= self._scale
         y = y.astype(self.cdtype)
         if self.fftshift_after.any():
@@ -95,7 +91,7 @@ class _FFT2D_numpy(_BaseFFTND):
             y = np.fft.irfft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         else:
             y = np.fft.ifft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
-        if self.norm == "backward":
+        if self.norm is _FFTNorms.NONE:
             y *= self._scale
         y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
         y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])
@@ -107,13 +103,13 @@ class _FFT2D_numpy(_BaseFFTND):
         return y.ravel()
 
     def __truediv__(self, y):
-        if self.norm != "ortho":
+        if self.norm is not _FFTNorms.ORTHO:
             return self._rmatvec(y) / self._scale
         return self._rmatvec(y)
 
 
 class _FFT2D_scipy(_BaseFFTND):
-    """Two dimensional Fast-Fourier Transform using scipy"""
+    """Two dimensional Fast-Fourier Transform using SciPy"""
 
     def __init__(
         self,
@@ -148,17 +144,13 @@ class _FFT2D_scipy(_BaseFFTND):
         self.f1, self.f2 = self.fs
         del self.fs
 
-        self._norm_kwargs = {"norm": None}  # backward
-        if self.norm == "ortho":
+        self._norm_kwargs = {"norm": None}  # equivalent to "backward" in Numpy/Scipy
+        if self.norm is _FFTNorms.ORTHO:
             self._norm_kwargs["norm"] = "ortho"
-        elif self.norm == "backward":
+        elif self.norm is _FFTNorms.NONE:
             self._scale = np.sqrt(np.prod(self.nffts))
-        elif self.norm == "forward":
+        elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = np.sqrt(1.0 / np.prod(self.nffts))
-        else:
-            raise ValueError(
-                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
-            )
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)
@@ -174,7 +166,7 @@ class _FFT2D_scipy(_BaseFFTND):
             y = np.swapaxes(y, self.dirs[-1], -1)
         else:
             y = scipy.fft.fft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
-        if self.norm == "forward":
+        if self.norm is _FFTNorms.ONE_OVER_N:
             y *= self._scale
         if self.fftshift_after.any():
             y = scipy.fft.fftshift(y, axes=self.dirs[self.fftshift_after])
@@ -193,7 +185,7 @@ class _FFT2D_scipy(_BaseFFTND):
             y = scipy.fft.irfft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         else:
             y = scipy.fft.ifft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
-        if self.norm == "backward":
+        if self.norm is _FFTNorms.NONE:
             y *= self._scale
         y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
         y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])
@@ -204,7 +196,7 @@ class _FFT2D_scipy(_BaseFFTND):
         return y.ravel()
 
     def __truediv__(self, y):
-        if self.norm != "ortho":
+        if self.norm is not _FFTNorms.ORTHO:
             return self._rmatvec(y) / self._scale / self._scale
         return self._rmatvec(y)
 
@@ -261,19 +253,15 @@ def FFT2D(
         Sampling steps for each direction. When supplied a single value, it is used
         for both directions. Unlike ``nffts``, ``None``s will not be converted to the
         default value.
-    norm : `{"ortho", "backward", "forward"}`, optional
+    norm : `{"ortho", "none", "1/n"}`, optional
         * "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
         where :math:`N_F` is the number of samples in the Fourier domain given by
         product of all elements of ``nffts``.
-        * "backward": Does not scale the forward or the adjoint FFT transforms. Note
-        that the adjoint behaviour of this option differs from :py:func:`ifft2`
-        implementations in NumPy and SciPy.
-        * "forward": Scales both the forward and adjoint FFT transforms by
-        :math:`1/N_F`. Note the forward behaviour of this option differs from
-        :py:func:`fft2` implementations in NumPy and SciPy.
-        Also note that for "forward" and "backward", the operator is not unitary,
-        that is, the adjoint is not the inverse. To invert the operator, simply use
-        `Op \ y`.
+        * "none": Does not scale the forward or the adjoint FFT transforms.
+        * "1/n": Scales both the forward and adjoint FFT transforms by
+        :math:`1/N_F`.
+        Note that for "none" and "1/n", the operator is not unitary, that is,
+        the adjoint is not the inverse. To invert the operator, simply use `Op \ y`.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -340,6 +328,7 @@ def FFT2D(
         If ``dirs`` does not have exactly two elements.
         If ``nffts`` or ``sampling`` are not either a single value or a tuple with
         two elements.
+        If ``norm`` is not one of "ortho", "none", or "1/n".
     NotImplementedError
         If ``engine`` is neither ``numpy``, nor ``scipy``.
 
@@ -356,7 +345,7 @@ def FFT2D(
     the Fourier spectrum :math:`D(k_y, k_x)` in adjoint mode:
 
     .. math::
-        d(y,x) = \mathscr{F}^{-1} (D) = \sqrt{N_F} \int \int D(k_y, k_x) e^{j2\pi k_yy}
+        d(y,x) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}} \int \int D(k_y, k_x) e^{j2\pi k_yy}
         e^{j2\pi k_xx} dk_y  dk_x
 
     where :math:`N_F` is the number of samples in the Fourier domain given by the

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -40,6 +40,10 @@ class _FFTND_numpy(_BaseFFTND):
                 f"numpy backend always returns complex128 dtype. To respect the passed dtype, data will be casted to {self.cdtype}."
             )
 
+        if self.norm not in ["ortho", "backward", "forward"]:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
         # FFTs are called with "ortho" for backwards compatibility
         # The factors below are conversions factors ortho->norm
         if self.norm == "backward":
@@ -120,6 +124,10 @@ class _FFTND_scipy(_BaseFFTND):
             dtype=dtype,
         )
 
+        if self.norm not in ["ortho", "backward", "forward"]:
+            raise ValueError(
+                f"'{self.norm}' is not one of 'ortho', 'backward' or 'forward'"
+            )
         # FFTs are called with "ortho" for backwards compatibility
         # The factors below are conversions factors ortho->norm
         if self.norm == "backward":

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -96,6 +96,11 @@ class _FFTND_numpy(_BaseFFTND):
             y = np.fft.fftshift(y, axes=self.dirs[self.ifftshift_before])
         return y.ravel()
 
+    def __truediv__(self, y):
+        if self.norm != "ortho":
+            return self._rmatvec(y) / self._scale / self._scale
+        return self._rmatvec(y)
+
 
 class _FFTND_scipy(_BaseFFTND):
     """N-dimensional Fast-Fourier Transform using scipy"""
@@ -177,6 +182,11 @@ class _FFTND_scipy(_BaseFFTND):
         if self.ifftshift_before.any():
             y = scipy.fft.fftshift(y, axes=self.dirs[self.ifftshift_before])
         return y.ravel()
+
+    def __truediv__(self, y):
+        if self.norm != "ortho":
+            return self._rmatvec(y) / self._scale / self._scale
+        return self._rmatvec(y)
 
 
 def FFTND(

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -2,12 +2,19 @@ import logging
 import warnings
 
 import numpy as np
+from enum import Enum, auto
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
 from pylops.utils.backend import get_complex_dtype, get_real_dtype
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+
+
+class _FFTNorms(Enum):
+    ORTHO = auto()
+    NONE = auto()
+    ONE_OVER_N = auto()
 
 
 def _value_or_list_like_to_array(value_or_list_like, repeat=1):
@@ -95,7 +102,15 @@ class _BaseFFT(LinearOperator):
             nfft = nffts[0]
         self.nfft = nfft
 
-        self.norm = norm
+        if norm == "ortho":
+            self.norm = _FFTNorms.ORTHO
+        elif norm == "none":
+            self.norm = _FFTNorms.NONE
+        elif norm == "1/n":
+            self.norm = _FFTNorms.ONE_OVER_N
+        else:
+            raise ValueError(f"'{norm}' is not one of 'ortho', 'none' or '1/n'")
+
         self.real = real
         self.ifftshift_before = ifftshift_before
 
@@ -207,7 +222,16 @@ class _BaseFFTND(LinearOperator):
                     "respectively."
                 )
             )
-        self.norm = norm
+
+        if norm == "ortho":
+            self.norm = _FFTNorms.ORTHO
+        elif norm == "none":
+            self.norm = _FFTNorms.NONE
+        elif norm == "1/n":
+            self.norm = _FFTNorms.ONE_OVER_N
+        else:
+            raise ValueError(f"'{norm}' is not one of 'ortho', 'none' or '1/n'")
+
         self.real = real
 
         fs = [

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -1,8 +1,8 @@
 import logging
 import warnings
+from enum import Enum, auto
 
 import numpy as np
-from enum import Enum, auto
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
@@ -106,8 +106,16 @@ class _BaseFFT(LinearOperator):
             self.norm = _FFTNorms.ORTHO
         elif norm == "none":
             self.norm = _FFTNorms.NONE
-        elif norm == "1/n":
+        elif norm.lower() == "1/n":
             self.norm = _FFTNorms.ONE_OVER_N
+        elif norm == "backward":
+            raise ValueError(
+                'To use no scaling on the forward transform, use "none". Note that in this case, the adjoint transform will *not* have a 1/n scaling.'
+            )
+        elif norm == "forward":
+            raise ValueError(
+                'To use 1/n scaling on the forward transform, use "1/n". Note that in this case, the adjoint transform will *also* have a 1/n scaling.'
+            )
         else:
             raise ValueError(f"'{norm}' is not one of 'ortho', 'none' or '1/n'")
 
@@ -227,8 +235,16 @@ class _BaseFFTND(LinearOperator):
             self.norm = _FFTNorms.ORTHO
         elif norm == "none":
             self.norm = _FFTNorms.NONE
-        elif norm == "1/n":
+        elif norm.lower() == "1/n":
             self.norm = _FFTNorms.ONE_OVER_N
+        elif norm == "backward":
+            raise ValueError(
+                'To use no scaling on the forward transform, use "none". Note that in this case, the adjoint transform will *not* have a 1/n scaling.'
+            )
+        elif norm == "forward":
+            raise ValueError(
+                'To use 1/n scaling on the forward transform, use "1/n". Note that in this case, the adjoint transform will *also* have a 1/n scaling.'
+            )
         else:
             raise ValueError(f"'{norm}' is not one of 'ortho', 'none' or '1/n'")
 

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -72,6 +72,7 @@ class _BaseFFT(LinearOperator):
         dir=0,
         nfft=None,
         sampling=1.0,
+        norm="ortho",
         real=False,
         ifftshift_before=False,
         fftshift_after=False,
@@ -94,8 +95,8 @@ class _BaseFFT(LinearOperator):
             nfft = nffts[0]
         self.nfft = nfft
 
+        self.norm = norm
         self.real = real
-
         self.ifftshift_before = ifftshift_before
 
         self.f = (

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -147,6 +147,7 @@ class _BaseFFTND(LinearOperator):
         dirs=None,
         nffts=None,
         sampling=1.0,
+        norm="ortho",
         real=False,
         ifftshift_before=False,
         fftshift_after=False,
@@ -206,6 +207,7 @@ class _BaseFFTND(LinearOperator):
                     "respectively."
                 )
             )
+        self.norm = norm
         self.real = real
 
         fs = [

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -732,6 +732,10 @@ def test_FFT2D_small_complex(par):
     assert_array_almost_equal(y, y_true, decimal=decimal)
     assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
 
+    x_inv = FFTop / y.ravel()
+    x_inv = x_inv.reshape(x.shape)
+    assert_array_almost_equal(x_inv, x, decimal=decimal)
+
 
 @pytest.mark.parametrize("par", pars_fft2dnd_small_cpx)
 def test_FFTND_small_complex(par):
@@ -774,6 +778,10 @@ def test_FFTND_small_complex(par):
     y = y.reshape(FFTop.dims_fft)
     assert_array_almost_equal(y, y_true, decimal=decimal)
     assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+
+    x_inv = FFTop / y.ravel()
+    x_inv = x_inv.reshape(x.shape)
+    assert_array_almost_equal(x_inv, x, decimal=decimal)
 
 
 @pytest.mark.parametrize(

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -140,9 +140,9 @@ def test_unknown_engine(par):
 par_lists_fft_small_real = dict(
     dtype_precision=[
         (np.float16, 1),
-        (np.float32, 5),
-        (np.float64, 13),
-        (np.float128, 13),
+        (np.float32, 4),
+        (np.float64, 11),
+        (np.float128, 11),
     ],
     norm=["ortho", "backward", "forward"],
     ifftshift_before=[False, True],
@@ -260,7 +260,7 @@ def test_FFT_random_real(par):
 
 
 par_lists_fft_small_cpx = dict(
-    dtype_precision=[(np.complex64, 5), (np.complex128, 13), (np.complex256, 13)],
+    dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.complex256, 11)],
     norm=["ortho", "backward", "forward"],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -674,6 +674,103 @@ def test_FFTND_random_complex(par):
         assert dottest(FFTop, nr, nc, complexflag=3, tol=10 ** (-decimal))
 
 
+par_lists_fft2dnd_small_cpx = dict(
+    dtype_precision=[(np.complex64, 5), (np.complex128, 11), (np.complex256, 11)],
+    norm=["ortho", "backward", "forward"],
+    engine=["numpy", "scipy"],
+)
+pars_fft2dnd_small_cpx = [
+    dict(zip(par_lists_fft2dnd_small_cpx.keys(), value))
+    for value in itertools.product(*par_lists_fft2dnd_small_cpx.values())
+]
+
+
+@pytest.mark.parametrize("par", pars_fft2dnd_small_cpx)
+def test_FFT2D_small_complex(par):
+    dtype, decimal = par["dtype_precision"]
+    norm = par["norm"]
+
+    x = np.array(
+        [
+            [1, 2 - 1j, -1j, -1 + 2j],
+            [2 - 1j, -1j, -1 - 2j, 1],
+            [-1j, -1 - 2j, 1, 2 - 1j],
+            [-1 - 2j, 1, 2 - 1j, -1j],
+        ]
+    )
+
+    FFTop = FFT2D(
+        dims=x.shape,
+        dirs=(0, 1),
+        norm=norm,
+        dtype=dtype,
+    )
+
+    # Compute FFT of x independently
+    y_true = np.array(
+        [
+            [8 - 12j, -4, -4j, 4],
+            [4j, 4 - 8j, -4j, 4],
+            [4j, -4, 4j, 4],
+            [4j, -4, -4j, 4 + 16j],
+        ],
+        dtype=FFTop.cdtype,
+    )  # Backward
+    if norm == "ortho":
+        y_true /= 4
+    elif norm == "forward":
+        y_true /= 16
+
+    # Compute FFT with FFTop and compare with y_true
+    y = FFTop * x.ravel()
+    y = y.reshape(FFTop.dims_fft)
+    assert_array_almost_equal(y, y_true, decimal=decimal)
+    assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+
+
+@pytest.mark.parametrize("par", pars_fft2dnd_small_cpx)
+def test_FFTND_small_complex(par):
+    dtype, decimal = par["dtype_precision"]
+    norm = par["norm"]
+
+    x = np.array(
+        [
+            [1, 2 - 1j, -1j, -1 + 2j],
+            [2 - 1j, -1j, -1 - 2j, 1],
+            [-1j, -1 - 2j, 1, 2 - 1j],
+            [-1 - 2j, 1, 2 - 1j, -1j],
+        ]
+    )
+
+    FFTop = FFTND(
+        dims=x.shape,
+        dirs=(0, 1),
+        norm=norm,
+        dtype=dtype,
+    )
+
+    # Compute FFT of x independently
+    y_true = np.array(
+        [
+            [8 - 12j, -4, -4j, 4],
+            [4j, 4 - 8j, -4j, 4],
+            [4j, -4, 4j, 4],
+            [4j, -4, -4j, 4 + 16j],
+        ],
+        dtype=FFTop.cdtype,
+    )  # Backward
+    if norm == "ortho":
+        y_true /= 4
+    elif norm == "forward":
+        y_true /= 16
+
+    # Compute FFT with FFTop and compare with y_true
+    y = FFTop * x.ravel()
+    y = y.reshape(FFTop.dims_fft)
+    assert_array_almost_equal(y, y_true, decimal=decimal)
+    assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+
+
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par5), (par1w), (par2w), (par3w), (par4w)]
 )

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -144,7 +144,7 @@ par_lists_fft_small_real = dict(
         (np.float64, 11),
         (np.float128, 11),
     ],
-    norm=["ortho", "backward", "forward"],
+    norm=["ortho", "none", "1/n"],
     ifftshift_before=[False, True],
     engine=["numpy", "fftw", "scipy"],
 )
@@ -177,9 +177,9 @@ def test_FFT_small_real(par):
 
     if norm == "ortho":
         y_true = np.array([0.5, 1 + 0.5j, -0.5], dtype=FFTop.cdtype)
-    elif norm == "backward":
+    elif norm == "none":
         y_true = np.array([1, 2 + 1j, -1], dtype=FFTop.cdtype)
-    elif norm == "forward":
+    elif norm == "1/n":
         y_true = np.array([0.25, 0.5 + 0.25j, -0.25], dtype=FFTop.cdtype)
 
     y_true[1:-1] *= np.sqrt(2)  # Zero and Nyquist
@@ -261,7 +261,7 @@ def test_FFT_random_real(par):
 
 par_lists_fft_small_cpx = dict(
     dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.complex256, 11)],
-    norm=["ortho", "backward", "forward"],
+    norm=["ortho", "none", "1/n"],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
     engine=["numpy", "fftw", "scipy"],
@@ -293,9 +293,9 @@ def test_FFT_small_complex(par):
     # Compute FFT of x independently
     if norm == "ortho":
         y_true = np.array([1, -1 - 1j, -1j, 2 + 2j], dtype=FFTop.cdtype)
-    elif norm == "backward":
+    elif norm == "none":
         y_true = np.array([2, -2 - 2j, -2j, 4 + 4j], dtype=FFTop.cdtype)
-    elif norm == "forward":
+    elif norm == "1/n":
         y_true = np.array([0.5, -0.5 - 0.5j, -0.5j, 1 + 1j], dtype=FFTop.cdtype)
 
     if fftshift_after:
@@ -681,7 +681,7 @@ def test_FFTND_random_complex(par):
 
 par_lists_fft2dnd_small_cpx = dict(
     dtype_precision=[(np.complex64, 5), (np.complex128, 11), (np.complex256, 11)],
-    norm=["ortho", "backward", "forward"],
+    norm=["ortho", "none", "1/n"],
     engine=["numpy", "scipy"],
 )
 pars_fft2dnd_small_cpx = [
@@ -723,7 +723,7 @@ def test_FFT2D_small_complex(par):
     )  # Backward
     if norm == "ortho":
         y_true /= 4
-    elif norm == "forward":
+    elif norm == "1/n":
         y_true /= 16
 
     # Compute FFT with FFTop and compare with y_true
@@ -770,7 +770,7 @@ def test_FFTND_small_complex(par):
     )  # Backward
     if norm == "ortho":
         y_true /= 4
-    elif norm == "forward":
+    elif norm == "1/n":
         y_true /= 16
 
     # Compute FFT with FFTop and compare with y_true


### PR DESCRIPTION
New features:
* Adds a `norm` parameter to `FFT`, `FFT2D` and `FFTND` (and base respective base classes). Possible values are "ortho" (default), "backward" and "forward" (it might be a good idea to change these names... opinions?).
* Adds `__truediv__` for all FFT operators, obtained by multiplying by the adjoint with the proper scalar
* Improves documentation
* Closes #268 

Implementational details:
* FFTW backend: FFTW supports an equivalent implementation to "ortho" and "backward" through use of keywords. For norm="forward", we just need to scale the forward FFT with 1/N.
* NumPy and SciPy backends: In order to support old versions of these libraries, we only implement "ortho" through the use of the `norm` option in `fft`. "forward" and "backward" are both implemented manually.