### PR TITLE
Patch docs - math edition

### DIFF
--- a/docs/source/api/others.rst
+++ b/docs/source/api/others.rst
@@ -7,11 +7,8 @@ Alongside with its *Linear Operators* and *Solvers*, PyLops contains also a numb
 performing universal tasks that are used by several operators or simply within one or more :ref:`tutorials` for
 the preparation of input data and subsequent visualization of results.
 
-Shared
-------
-
 Dot-test
-~~~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -21,7 +18,7 @@ Dot-test
     dottest
 
 Estimators
-~~~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -33,7 +30,7 @@ Estimators
     trace_nahutchpp
 
 Scalability test
-~~~~~~~~~~~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -42,11 +39,8 @@ Scalability test
 
     scalability_test
 
-Others
-------
-
 Synthetics
-~~~~~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -70,7 +64,7 @@ Synthetics
 
 
 Signal-processing
-~~~~~~~~~~~~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -83,7 +77,7 @@ Signal-processing
 
 
 Tapers
-~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -95,7 +89,7 @@ Tapers
 
 
 Wavelets
-~~~~~~~~
+------
 
 .. currentmodule:: pylops.utils
 
@@ -106,8 +100,8 @@ Wavelets
     wavelets.gaussian
 
 
-Geophysicical Reservoir characterization
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Geophysical Reservoir characterization
+------
 
 .. currentmodule:: pylops.avo
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -129,6 +129,7 @@ PyLops is a `NUMFOCUS <https://numfocus.org/sponsored-projects/affiliated-projec
    gpu.rst
    extensions.rst
    tutorials/index.rst
+   gallery/index.rst
    FAQs <faq.rst>
 
 .. toctree::

--- a/docs/source/papers.rst
+++ b/docs/source/papers.rst
@@ -9,65 +9,65 @@ PyLops framework:
 - Vakalis, S.Chen, D., Yan, M., and Nanzer, J. A.,
   *Image enhancement in active incoherent millimeter-wave imaging*.
   Passive and Active Millimeter-Wave Imaging XXIV 11745
-  `link <https://www.spiedigitallibrary.org/conference-proceedings-of-spie/11745/1174507/Image-enhancement-in-active-incoherent-millimeter-wave-imaging/10.1117/12.2585650.short>`_ (2021).
+  `link <https://www.spiedigitallibrary.org/conference-proceedings-of-spie/11745/1174507/Image-enhancement-in-active-incoherent-millimeter-wave-imaging/10.1117/12.2585650.short>`__ (2021).
 
 - Li, X., Becker, T., Ravasi,  M., Robertsson, J., and van Manen D.J.,
   *Closed-aperture unbounded acoustics experimentation using multidimensional deconvolution*.
   The Journal of the Acoustical Society of America 149 (3), 1813-1828
-  `link <https://asa.scitation.org/doi/abs/10.1121/10.0003706>`_ (2021).
+  `link <https://asa.scitation.org/doi/abs/10.1121/10.0003706>`__ (2021).
 
 - Kuijpers, D., Vasconcelos, I., and Putzky, P., *Reconstructing missing
   seismic data using Deep Learning.* arXiv,
-  `link <https://arxiv.org/abs/2101.09554>`_ (2021).
+  `link <https://arxiv.org/abs/2101.09554>`__ (2021).
 
 - Ravasi, M., and Birnie, C., *A Joint Inversion-Segmentation approach to Assisted Seismic Interpretation.*
   arXiv,
-  `link <https://arxiv.org/abs/2102.03860>`_
-  - `code <https://github.com/DIG-Kaust/HTracker>`_ (2021).
+  `link <https://arxiv.org/abs/2102.03860>`__
+  - `code <https://github.com/DIG-Kaust/HTracker>`__ (2021).
 
 - Haindl, C., Ravasi, M., and Broggini, F., *Handling gaps in acquisition geometries —
   Improving Marchenko-based imaging using sparsity-promoting inversion and joint inversion
   of time-lapse data.* Geophysics, 86 (2), S143-S154
-  `link <https://library.seg.org/doi/abs/10.1190/geo2020-0036.1>`_
-  - `code <https://github.com/chaindl/JointMarchenkoImaging>`_ (2021).
+  `link <https://library.seg.org/doi/abs/10.1190/geo2020-0036.1>`__
+  - `code <https://github.com/chaindl/JointMarchenkoImaging>`__ (2021).
 
 - Ulrich, I. E., Zunino, A., Boehm, C., and Fichtner, A., *Sparsifying regularizations
   for stochastic sample average minimization in ultrasound computed tomography.*
   Medical Imaging 2021: Ultrasonic Imaging and Tomography.
   International Society for Optics and Photonics,
-  `link <https://www.spiedigitallibrary.org/conference-proceedings-of-spie/11602/116020Y/Sparsifying-regularizations-for-stochastic-sample-average-minimization-in-ultrasound-computed/10.1117/12.2580926.full>`_ (2021).
+  `link <https://www.spiedigitallibrary.org/conference-proceedings-of-spie/11602/116020Y/Sparsifying-regularizations-for-stochastic-sample-average-minimization-in-ultrasound-computed/10.1117/12.2580926.full>`__ (2021).
 
 - R Feng, R., Mejer Hansen, T., Grana, D., and Balling, N., *An unsupervised
   deep-learning method for porosity estimation based on poststack seismic data.*
   Geophysics, 85 (6), M97-M105.
-  `link <https://library.seg.org/doi/full/10.1190/geo2020-0121.1>`_ (2020).
+  `link <https://library.seg.org/doi/full/10.1190/geo2020-0121.1>`__ (2020).
 
 - Nightingale J. W., Hayes, R.G, et al.,
   *PyAutoLens: Open-Source Strong Gravitational Lensing*, JOSS,
-  `link <https://joss.theoj.org/papers/d997cd03e4d9a3668bb1c6253381404c>`_
-  - `code <https://github.com/Jammy2211/PyAutoLens>`_ (2020).
+  `link <https://joss.theoj.org/papers/d997cd03e4d9a3668bb1c6253381404c>`__
+  - `code <https://github.com/Jammy2211/PyAutoLens>`__ (2020).
 
 - Zhang, M., *Marchenko Green’s functions from compressive sensing acquisition*
   SEG Technical Program Expanded Abstracts,
-  `link <https://library.seg.org/doi/10.1190/segam2020-3424845.1>`_ (2020).
+  `link <https://library.seg.org/doi/10.1190/segam2020-3424845.1>`__ (2020).
 
 - Vargas, D., and Vasconcelos I., *Rayleigh-Marchenko Redatuming Using
   Scattered Fields in Highly Complex Media*, EAGE Technical Program Expanded
   Abstracts,
-  `link <https://www.earthdoc.org/content/papers/10.3997/2214-4609.202011347>`_
+  `link <https://www.earthdoc.org/content/papers/10.3997/2214-4609.202011347>`__
   (2020).
 
 - Ravasi, M., and Vasconcelos I., *Implementation of Large-Scale Integral
   Operators with Modern HPC Solutions*, EAGE Technical Program Expanded
   Abstracts,
-  `link <https://www.earthdoc.org/content/papers/10.3997/2214-4609.202010529>`_
-  - `code <https://github.com/mrava87/EAGE_MDCHPC_2020>`_ (2020).
+  `link <https://www.earthdoc.org/content/papers/10.3997/2214-4609.202010529>`__
+  - `code <https://github.com/mrava87/EAGE_MDCHPC_2020>`__ (2020).
 
 - Ruan, J., and Vasconcelos I., *Data-and prior-driven sampling and wavefield
   reconstruction for sparse, irregularly-sampled, higher-order gradient data*,
   SEG Technical Program Expanded Abstracts,
-  `link <https://library.seg.org/doi/abs/10.1190/segam2019-3216425.1>`_
-  - `code <https://github.com/JingmingR/Turbulence-wavefield-reconstruction>`_
+  `link <https://library.seg.org/doi/abs/10.1190/segam2019-3216425.1>`__
+  - `code <https://github.com/JingmingR/Turbulence-wavefield-reconstruction>`__
   (2019).
 
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,6 +1,6 @@
 .. _general_examples:
 
-PyLops gallery
---------------
+Gallery
+-------
 
-Below is a gallery of examples
+Below is a gallery of examples which use PyLops operators and utilities.

--- a/examples/plot_cgls.py
+++ b/examples/plot_cgls.py
@@ -7,7 +7,7 @@ and :py:func:`pylops.optimization.leastsquares.lsqr` PyLops solvers
 to minimize the following cost function:
 
 .. math::
-        J = || \mathbf{y} -  \mathbf{Ax} ||_2^2 + \epsilon || \mathbf{x} ||_2^2
+        J = \| \mathbf{y} -  \mathbf{Ax} \|_2^2 + \epsilon \| \mathbf{x} \|_2^2
 
 Note that the LSQR solver behaves in the same way as the scipy's
 :py:func:`scipy.sparse.linalg.lsqr` solver. However, our solver is also able

--- a/examples/plot_ista.py
+++ b/examples/plot_ista.py
@@ -12,14 +12,13 @@ a sparse representation in a certain domain. MP and OMP use a L0 norm and
 mathematically translates to solving the following constrained problem:
 
 .. math::
-    ||\mathbf{x}||_0 \quad  subj. to
-    \quad ||\mathbf{Op}\mathbf{x}-  \mathbf{b}||_2 <= \sigma,
+    \quad \|\mathbf{Op}\mathbf{x}-  \mathbf{b}\|_2 <= \sigma,
 
 while IRLS, ISTA and FISTA solve an uncostrained problem with a L1
 regularization term:
 
 .. math::
-    J = ||\mathbf{d} - \mathbf{Op} \mathbf{x}||_2 + \epsilon ||\mathbf{x}||_1
+    J = \|\mathbf{d} - \mathbf{Op} \mathbf{x}\|_2 + \epsilon \|\mathbf{x}\|_1
 
 """
 

--- a/examples/plot_linearregr.py
+++ b/examples/plot_linearregr.py
@@ -10,7 +10,7 @@ coefficients, namely intercept :math:`\mathbf{x_0}` and gradient
 :math:`\mathbf{x_1}`, for this equation:
 
     .. math::
-        y_i = x_0 + x_1 t_i   \qquad \forall i=1,2,...,N
+        y_i = x_0 + x_1 t_i   \qquad \forall i=1,2,\ldots,N
 
 As we can express this problem in a matrix form:
 

--- a/examples/plot_linearregr.py
+++ b/examples/plot_linearregr.py
@@ -20,7 +20,7 @@ As we can express this problem in a matrix form:
 our solution can be obtained by solving the following optimization problem:
 
     .. math::
-        J= ||\mathbf{y} - \mathbf{A} \mathbf{x}||_2
+        J= \|\mathbf{y} - \mathbf{A} \mathbf{x}\|_2
 
 See documentation of :py:class:`pylops.LinearRegression` for more detailed
 definition of the forward problem.

--- a/examples/plot_regr.py
+++ b/examples/plot_regr.py
@@ -9,7 +9,7 @@ In short, polynomial regression is the problem of finding the best fitting
 coefficients for the following equation:
 
     .. math::
-        y_i = \sum_{n=0}^{order} x_n t_i^n  \qquad \forall i=1,2,...,N
+        y_i = \sum_{n=0}^{order} x_n t_i^n  \qquad \forall i=1,2,\ldots,N
 
 As we can express this problem in a matrix form:
 

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -299,39 +299,44 @@ def akirichards(theta, vsvp, n=1):
     theta : :obj:`np.ndarray`
         Incident angles in degrees
     vsvp : :obj:`np.ndarray` or :obj:`float`
-        VS/VP ratio
+        :math:`V_S/V_P` ratio
     n : :obj:`int`, optional
-        number of samples (if ``vsvp`` is a scalare)
+        number of samples (if ``vsvp`` is a scalar)
 
     Returns
     -------
     G1 : :obj:`np.ndarray`
         first coefficient of three terms Aki-Richards approximation
-        :math:`[n_{theta}  \times  n_{vsvp}]`
+        :math:`[n_\theta  \times  n_\text{vsvp}]`
     G2 : :obj:`np.ndarray`
         second coefficient of three terms Aki-Richards approximation
-        :math:`[n_{theta}  \times  n_{vsvp}]`
+        :math:`[n_\theta  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`
         third coefficient of three terms Aki-Richards approximation
-        :math:`[n_{theta}  \times  n_{vsvp}]`
+        :math:`[n_\theta  \times  n_\text{vsvp}]`
 
     Notes
     -----
     The three terms Aki-Richards approximation [1]_ is used to compute the
     reflection coefficient as linear combination of contrasts in
-    :math:`V_P`, :math:`V_S`, and :math:`\rho`. More specifically:
+    :math:`V_P`, :math:`V_S`, and :math:`\rho.` More specifically:
 
     .. math::
-        R(\theta) = G_1(\theta) \frac{\Delta V_P}{\bar{V_P}} + G_2(\theta)
-        \frac{\Delta V_S}{\bar{V_S}} + G_3(\theta)
-        \frac{\Delta \rho}{\bar{\rho}}
+        R(\theta) = G_1(\theta) \frac{\Delta V_P}{\overline{V}_P} + G_2(\theta)
+        \frac{\Delta V_S}{\overline{V}_S} + G_3(\theta)
+        \frac{\Delta \rho}{\overline{\rho}}
 
-    where :math:`G_1(\theta) = \frac{1}{2 cos^2 \theta}`,
-    :math:`G_2(\theta) = -4 (V_S/V_P)^2 sin^2 \theta`,
-    :math:`G_3(\theta) = 0.5 - 2 (V_S/V_P)^2 sin^2 \theta`,
-    :math:`\frac{\Delta V_P}{\bar{V_P}} = 2 \frac{V_{P,2}-V_{P,1}}{V_{P,2}+V_{P,1}}`,
-    :math:`\frac{\Delta V_S}{\bar{V_S}} = 2 \frac{V_{S,2}-V_{S,1}}{V_{S,2}+V_{S,1}}`, and
-    :math:`\frac{\Delta \rho}{\bar{\rho}} = 2 \frac{\rho_2-\rho_1}{\rho_2+\rho_1}`.
+    where
+
+    .. math::
+        \begin{align}
+        G_1(\theta) &= \frac{1}{2 \cos^2 \theta},\\
+        G_2(\theta) &= -4 (V_S/V_P)^2 \sin^2 \theta,\\
+         G_3(\theta) &= 0.5 - 2 (V_S/V_P)^2 \sin^2 \theta,\\
+         \frac{\Delta V_P}{\overline{V}_P} &= 2 \frac{V_{P,2}-V_{P,1}}{V_{P,2}+V_{P,1}},\\
+         \frac{\Delta V_S}{\overline{V}_S} &= 2 \frac{V_{S,2}-V_{S,1}}{V_{S,2}+V_{S,1}}, \\
+         \frac{\Delta \rho}{\overline{\rho}} &= 2 \frac{\rho_2-\rho_1}{\rho_2+\rho_1}.
+        \end{align}
 
     .. [1] https://wiki.seg.org/wiki/AVO_equations
 
@@ -362,7 +367,7 @@ def fatti(theta, vsvp, n=1):
     theta : :obj:`np.ndarray`
         Incident angles in degrees
     vsvp : :obj:`np.ndarray` or :obj:`float`
-        VS/VP ratio
+        :math:`V_S/V_P` ratio
     n : :obj:`int`, optional
         number of samples (if ``vsvp`` is a scalar)
 
@@ -370,31 +375,36 @@ def fatti(theta, vsvp, n=1):
     -------
     G1 : :obj:`np.ndarray`
         first coefficient of three terms Smith-Gidlow approximation
-        :math:`[n_{theta}  \times  n_{vsvp}]`
+        :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G2 : :obj:`np.ndarray`
         second coefficient of three terms Smith-Gidlow approximation
-        :math:`[n_{theta}  \times  n_{vsvp}]`
+        :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`
         third coefficient of three terms Smith-Gidlow approximation
-        :math:`[n_{theta}  \times  n_{vsvp}]`
+        :math:`[n_{\theta}  \times  n_\text{vsvp}]`
 
     Notes
     -----
     The three terms Fatti approximation [1]_ is used to compute the reflection
-    coefficient as linear combination of contrasts in :math:`AI`,
-    :math:`SI`, and :math:`\rho`. More specifically:
+    coefficient as linear combination of contrasts in :math:`\text{AI},`
+    :math:`SI`, and :math:`\rho.` More specifically:
 
     .. math::
-        R(\theta) = G_1(\theta) \frac{\Delta AI}{\bar{AI}} + G_2(\theta)
-        \frac{\Delta SI}{\bar{SI}} +
-        G_3(\theta) \frac{\Delta \rho}{\bar{\rho}}
+        R(\theta) = G_1(\theta) \frac{\Delta \text{AI}}{\bar{\text{AI}}} + G_2(\theta)
+        \frac{\Delta \text{SI}}{\overline{\text{SI}}} +
+        G_3(\theta) \frac{\Delta \rho}{\overline{\rho}}
 
-    where :math:`G_1(\theta) = 0.5 (1 + tan^2 \theta)`,
-    :math:`G_2(\theta) = -4 (V_S/V_P)^2 sin^2 \theta`,
-    :math:`G_3(\theta) = 0.5 (4 (V_S/V_P)^2 sin^2 \theta - tan^2 \theta)`,
-    :math:`\frac{\Delta AI}{\bar{AI}} = 2 \frac{AI_2-AI_1}{AI_2+AI_1}`.
-    :math:`\frac{\Delta SI}{\bar{SI}} = 2 \frac{SI_2-SI_1}{SI_2+SI_1}`.
-    :math:`\frac{\Delta \rho}{\bar{\rho}} = 2 \frac{\rho_2-\rho_1}{\rho_2+\rho_1}`.
+    where
+
+    .. math::
+        \begin{align}
+        G_1(\theta) &= 0.5 (1 + \tan^2 \theta),\\
+        G_2(\theta) &= -4 (V_S/V_P)^2 \sin^2 \theta,\\
+        G_3(\theta) &= 0.5 \left(4 (V_S/V_P)^2 \sin^2 \theta - \tan^2 \theta\right),\\
+        \frac{\Delta \text{AI}}{\overline{\text{AI}}} &= 2 \frac{\text{AI}_2-\text{AI}_1}{\text{AI}_2+\text{AI}_1},\\
+        \frac{\Delta \text{SI}}{\overline{\text{SI}}} &= 2 \frac{\text{SI}_2-\text{SI}_1}{\text{SI}_2+\text{SI}_1},\\
+        \frac{\Delta \rho}{\overline{\rho}} &= 2 \frac{\rho_2-\rho_1}{\rho_2+\rho_1}.
+        \end{align}
 
     .. [1] https://www.subsurfwiki.org/wiki/Fatti_equation
 
@@ -425,38 +435,44 @@ def ps(theta, vsvp, n=1):
     theta : :obj:`np.ndarray`
         Incident angles in degrees
     vsvp : :obj:`np.ndarray` or :obj:`float`
-        VS/VP ratio
+        :math:`V_S/V_P` ratio
     n : :obj:`int`, optional
         number of samples (if ``vsvp`` is a scalar)
 
     Returns
     -------
     G1 : :obj:`np.ndarray`
-        first coefficient for VP :math:`[n_{theta}  \times  n_{vsvp}]`
+        first coefficient for VP :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G2 : :obj:`np.ndarray`
-        second coefficient for VS :math:`[n_{theta}  \times  n_{vsvp}]`
+        second coefficient for VS :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`
-        third coefficient for density :math:`[n_{theta}  \times  n_{vsvp}]`
+        third coefficient for density :math:`[n_{\theta}  \times  n_\text{vsvp}]`
 
     Notes
     -----
     The approximation in [1]_ is used to compute the PS
     reflection coefficient as linear combination of contrasts in
-    :math:`V_P`, :math:`V_S`, and :math:`\rho`. More specifically:
+    :math:`V_P`, :math:`V_S`, and :math:`\rho.` More specifically:
 
     .. math::
         R(\theta) = G_2(\theta) \frac{\Delta V_S}{\bar{V_S}} + G_3(\theta)
-        \frac{\Delta \rho}{\bar{\rho}}
+        \frac{\Delta \rho}{\overline{\rho}}
 
-    where :math:`G_2(\theta) = tan \theta / 2 [4 (V_S/V_P)^2 sin^2 \theta -
-    4(V_S/V_P) cos \theta cos \phi]`,
-    :math:`G_3(\theta) = -tan \theta / 2 [1 - 2 (V_S/V_P)^2 sin^2 \theta +
-    2(V_S/V_P) cos \theta cos \phi]`,
-    :math:`\frac{\Delta V_S}{\bar{V_S}} = 2 \frac{V_{S,2}-V_{S,1}}{V_{S,2}+V_{S,1}}`, and
-    :math:`\frac{\Delta \rho}{\bar{\rho}} = 2 \frac{\rho_2-\rho_1}{\rho_2+\rho_1}`.
+    where
+
+    .. math::
+        \begin{align}
+        G_2(\theta) &= \tan \frac{\theta}{2} \left\{4 (V_S/V_P)^2 \sin^2 \theta
+            - 4(V_S/V_P) \cos \theta \cos \phi \right\},\\
+        G_3(\theta) &= -\tan \frac{\theta}{2} \left\{1 - 2 (V_S/V_P)^2 \sin^2 \theta +
+        2(V_S/V_P) \cos \theta \cos \phi\right\},\\
+        \frac{\Delta V_S}{\overline{V_S}} &= 2 \frac{V_{S,2}-V_{S,1}}{V_{S,2}+V_{S,1}},\\
+        \frac{\Delta \rho}{\overline{\rho}} &= 2 \frac{\rho_2-\rho_1}{\rho_2+\rho_1}.
+        \end{align}
+
     Note that :math:`\theta` is the P-incidence angle whilst :math:`\phi` is
     the S-reflected angle which is computed using Snell's law and the average
-    :math:`VS/VP` ratio.
+    :math:`V_S/V_P` ratio.
 
     .. [1] Xu, Y., and Bancroft, J.C., "Joint AVO analysis of PP and PS
         seismic data", CREWES Report, vol. 9. 1997.
@@ -499,7 +515,7 @@ class AVOLinearModelling(LinearOperator):
     theta : :obj:`np.ndarray`
         Incident angles in degrees
     vsvp : :obj:`np.ndarray` or :obj:`float`
-        VS/VP ratio
+        :math:`V_S/V_P` ratio
     nt0 : :obj:`int`, optional
         number of samples (if ``vsvp`` is a scalar)
     spatdims : :obj:`int` or :obj:`tuple`, optional
@@ -528,14 +544,14 @@ class AVOLinearModelling(LinearOperator):
     -----
     The AVO linearized operator performs a linear combination of three
     (or two) elastic parameters arranged in input vector :math:`\mathbf{m}`
-    of size :math:`n_{t0} \times N` to create the so-called seismic
+    of size :math:`n_{t_0} \times N` to create the so-called seismic
     reflectivity:
 
     .. math::
         r(t, \theta, x, y) = \sum_{i=1}^N G_i(t, \theta) m_i(t, x, y) \qquad
-        \forall \quad t, \theta
+        \forall \,t,\theta
 
-    where :math:`N=2/3`. Note that the reflectivity can be in 1d, 2d or 3d
+    where :math:`N=2,\, 3`. Note that the reflectivity can be in 1d, 2d or 3d
     and ``spatdims`` contains the dimensions of the spatial axis (or axes)
     :math:`x` and :math:`y`.
 

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -142,7 +142,7 @@ def zoeppritz_element(vp1, vs1, rho1, vp0, vs0, rho0, theta1, element="PdPu"):
     theta1 : :obj:`np.ndarray` or :obj:`float`
         Incident angles in degrees
     element : :obj:`str`, optional
-        specific choice of incident and reflected wave combining
+        Specific choice of incident and reflected wave combining
         any two of the following strings: ``Pd`` P-wave downgoing,
         ``Sd`` S-wave downgoing, ``Pu`` P-wave upgoing,
         ``Su`` S-wave upgoing (e.g., ``PdPu``)
@@ -301,23 +301,23 @@ def akirichards(theta, vsvp, n=1):
     vsvp : :obj:`np.ndarray` or :obj:`float`
         :math:`V_S/V_P` ratio
     n : :obj:`int`, optional
-        number of samples (if ``vsvp`` is a scalar)
+        Number of samples (if ``vsvp`` is a scalar)
 
     Returns
     -------
     G1 : :obj:`np.ndarray`
-        first coefficient of three terms Aki-Richards approximation
+        First coefficient of three terms Aki-Richards approximation
         :math:`[n_\theta  \times  n_\text{vsvp}]`
     G2 : :obj:`np.ndarray`
-        second coefficient of three terms Aki-Richards approximation
+        Second coefficient of three terms Aki-Richards approximation
         :math:`[n_\theta  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`
-        third coefficient of three terms Aki-Richards approximation
+        Third coefficient of three terms Aki-Richards approximation
         :math:`[n_\theta  \times  n_\text{vsvp}]`
 
     Notes
     -----
-    The three terms Aki-Richards approximation [1]_ is used to compute the
+    The three terms Aki-Richards approximation [1]_, [2]_, is used to compute the
     reflection coefficient as linear combination of contrasts in
     :math:`V_P`, :math:`V_S`, and :math:`\rho.` More specifically:
 
@@ -339,6 +339,8 @@ def akirichards(theta, vsvp, n=1):
         \end{align}
 
     .. [1] https://wiki.seg.org/wiki/AVO_equations
+
+    .. [2] Aki, K., and Richards, P. G. (2002). Quantitative Seismology (2nd ed.). University Science Books.
 
     """
     ncp = get_array_module(theta)
@@ -369,25 +371,25 @@ def fatti(theta, vsvp, n=1):
     vsvp : :obj:`np.ndarray` or :obj:`float`
         :math:`V_S/V_P` ratio
     n : :obj:`int`, optional
-        number of samples (if ``vsvp`` is a scalar)
+        Number of samples (if ``vsvp`` is a scalar)
 
     Returns
     -------
     G1 : :obj:`np.ndarray`
-        first coefficient of three terms Smith-Gidlow approximation
+        First coefficient of three terms Smith-Gidlow approximation
         :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G2 : :obj:`np.ndarray`
-        second coefficient of three terms Smith-Gidlow approximation
+        Second coefficient of three terms Smith-Gidlow approximation
         :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`
-        third coefficient of three terms Smith-Gidlow approximation
+        Third coefficient of three terms Smith-Gidlow approximation
         :math:`[n_{\theta}  \times  n_\text{vsvp}]`
 
     Notes
     -----
-    The three terms Fatti approximation [1]_ is used to compute the reflection
+    The three terms Fatti approximation [1]_, [2]_, is used to compute the reflection
     coefficient as linear combination of contrasts in :math:`\text{AI},`
-    :math:`SI`, and :math:`\rho.` More specifically:
+    :math:`\text{SI}`, and :math:`\rho.` More specifically:
 
     .. math::
         R(\theta) = G_1(\theta) \frac{\Delta \text{AI}}{\bar{\text{AI}}} + G_2(\theta)
@@ -407,6 +409,10 @@ def fatti(theta, vsvp, n=1):
         \end{align}
 
     .. [1] https://www.subsurfwiki.org/wiki/Fatti_equation
+
+    .. [2] Jan L. Fatti, George C. Smith, Peter J. Vail, Peter J. Strauss, and Philip R. Levitt, (1994), "Detection of gas in sandstone reservoirs using AVO analysis: A 3-D seismic case history using the Geostack technique," Geophysics 59: 1362-1376.
+
+
 
     """
     ncp = get_array_module(theta)
@@ -437,19 +443,19 @@ def ps(theta, vsvp, n=1):
     vsvp : :obj:`np.ndarray` or :obj:`float`
         :math:`V_S/V_P` ratio
     n : :obj:`int`, optional
-        number of samples (if ``vsvp`` is a scalar)
+        Number of samples (if ``vsvp`` is a scalar)
 
     Returns
     -------
     G1 : :obj:`np.ndarray`
-        first coefficient for VP :math:`[n_{\theta}  \times  n_\text{vsvp}]`.
+        First coefficient for VP :math:`[n_{\theta}  \times  n_\text{vsvp}]`.
         Since the PS reflection at zero angle is zero, this value is not used and is
         only available to ensure function signature compatibility with other
         linearization routines.
     G2 : :obj:`np.ndarray`
-        second coefficient for VS :math:`[n_{\theta}  \times  n_\text{vsvp}]`
+        Second coefficient for VS :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`
-        third coefficient for density :math:`[n_{\theta}  \times  n_\text{vsvp}]`
+        Third coefficient for density :math:`[n_{\theta}  \times  n_\text{vsvp}]`
 
     Notes
     -----
@@ -520,13 +526,17 @@ class AVOLinearModelling(LinearOperator):
     vsvp : :obj:`np.ndarray` or :obj:`float`
         :math:`V_S/V_P` ratio
     nt0 : :obj:`int`, optional
-        number of samples (if ``vsvp`` is a scalar)
+        Number of samples (if ``vsvp`` is a scalar)
     spatdims : :obj:`int` or :obj:`tuple`, optional
         Number of samples along spatial axis (or axes)
         (``None`` if only one dimension is available)
-    linearization : :obj:`str`, optional
-        choice of linearization: ``akirich``: PP Aki-Richards,
-        ``fatti``: PP Fatti, ``ps``: PS reflection,
+    linearization : `{"akirich", "fatti", "PS"}`, optional
+        * "akirich": Aki-Richards. See :py:func:`pylops.avo.avo.akirichards`.
+
+        * "fatti": Fatti. See :py:func:`pylops.avo.avo.fatti`.
+
+        * "PS": PS. See :py:func:`pylops.avo.avo.ps`.
+
     dtype : :obj:`str`, optional
         Type of elements in input array.
 

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -442,7 +442,10 @@ def ps(theta, vsvp, n=1):
     Returns
     -------
     G1 : :obj:`np.ndarray`
-        first coefficient for VP :math:`[n_{\theta}  \times  n_\text{vsvp}]`
+        first coefficient for VP :math:`[n_{\theta}  \times  n_\text{vsvp}]`.
+        Since the PS reflection at zero angle is zero, this value is not used and is
+        only available to ensure function signature compatibility with other
+        linearization routines.
     G2 : :obj:`np.ndarray`
         second coefficient for VS :math:`[n_{\theta}  \times  n_\text{vsvp}]`
     G3 : :obj:`np.ndarray`

--- a/pylops/avo/poststack.py
+++ b/pylops/avo/poststack.py
@@ -128,7 +128,7 @@ def PoststackLinearModelling(
 
     Create operator to be applied to an elastic parameter trace (or stack of
     traces) for generation of band-limited seismic post-stack data. The input
-    model and data have shape :math:`[n_{t0} (\times n_x \times n_y)]`.
+    model and data have shape :math:`[n_{t_0} \,(\times n_x \times n_y)]`.
 
     Parameters
     ----------
@@ -137,7 +137,7 @@ def PoststackLinearModelling(
         and centered to zero). If 1d, assume stationary wavelet for the entire
         time axis. If 2d, use as non-stationary wavelet (user must provide
         one wavelet per time sample in an array of size
-        :math:`[n_{t0} \times n_{wav}]` where :math:`n_{wav}` is the length
+        :math:`[n_{t_0} \times n_\text{wav}]` where :math:`n_\text{wav}` is the length
         of each wavelet). Note that the ``dtype`` of this variable will define
         that of the operator
     nt0 : :obj:`int`
@@ -171,7 +171,7 @@ def PoststackLinearModelling(
     forward model:
 
     .. math::
-        d(t, \theta=0) =  w(t) * \frac{dln(m(t))}{dt}
+        d(t, \theta=0) =  w(t) * \frac{\mathrm{d}\ln m(t)}{\mathrm{d}t}
 
     where :math:`m(t)` is the elastic parameter profile and
     :math:`w(t)` is the time domain seismic wavelet. In compact form:
@@ -183,7 +183,7 @@ def PoststackLinearModelling(
     modelling operator can be used to create zero-offset data:
 
     .. math::
-        d(t, \theta=0) = \frac{1}{2} w(t) * \frac{dln(m(t))}{dt}
+        d(t, \theta=0) = \frac{1}{2} w(t) * \frac{\mathrm{d}\ln m(t)}{\mathrm{d}t}
 
     where the scaling factor :math:`\frac{1}{2}` can be easily included in
     the wavelet.
@@ -218,14 +218,14 @@ def PoststackInversion(
     ----------
     data : :obj:`np.ndarray`
         Band-limited seismic post-stack data of size
-        :math:`[n_{t0} (\times n_x \times n_y)]`
+        :math:`[n_{t_0}\,(\times n_x \times n_y)]`
     wav : :obj:`np.ndarray`
         Wavelet in time domain (must have odd number of elements
         and centered to zero). If 1d, assume stationary wavelet for the entire
-        time axis. If 2d of size :math:`[n_{t0} \times n_h]` use as
+        time axis. If 2d of size :math:`[n_{t_0} \times n_h]` use as
         non-stationary wavelet
     m0 : :obj:`np.ndarray`, optional
-        Background model of size :math:`[n_{t0} (\times n_x \times n_y)]`
+        Background model of size :math:`[n_{t_0}\,(\times n_x \times n_y)]`
     explicit : :obj:`bool`, optional
         Create a chained linear operator (``False``, preferred for large data)
         or a ``MatrixMult`` linear operator with dense matrix
@@ -252,10 +252,10 @@ def PoststackInversion(
     Returns
     -------
     minv : :obj:`np.ndarray`
-        Inverted model of size :math:`[n_{t0} (\times n_x \times n_y)]`
+        Inverted model of size :math:`[n_{t_0}\,(\times n_x \times n_y)]`
     datar : :obj:`np.ndarray`
         Residual data (i.e., data - background data) of
-        size :math:`[n_{t0} (\times n_x \times n_y)]`
+        size :math:`[n_{t_0}\,(\times n_x \times n_y)]`
 
     Notes
     -----
@@ -269,7 +269,7 @@ def PoststackInversion(
       if ``simultaneous=True``)
     * ``explicit=True`` with ``epsI`` and ``epsR=None``: the regularized
       normal equations :math:`\mathbf{W}^T\mathbf{d} = (\mathbf{W}^T
-      \mathbf{W} + \epsilon_I^2 \mathbf{I}) \mathbf{AI}` are instead fed
+      \mathbf{W} + \epsilon_\mathbf{I}^2 \mathbf{I}) \mathbf{AI}` are instead fed
       into the :py:func:`scipy.linalg.lstsq` solver if ``simultaneous=False``
       (or the iterative solver :py:func:`scipy.sparse.linalg.lsqr`
       if ``simultaneous=True``)

--- a/pylops/avo/prestack.py
+++ b/pylops/avo/prestack.py
@@ -69,12 +69,14 @@ def PrestackLinearModelling(
     spatdims : :obj:`int` or :obj:`tuple`, optional
         Number of samples along spatial axis (or axes)
         (``None`` if only one dimension is available)
-    linearization : :obj:`str` or :obj:`func`, optional
-        * "akirich": Aki-Richards
+    linearization : `{"akirich", "fatti", "PS"}` or :obj:`callable`, optional
+        * "akirich": Aki-Richards. See :py:func:`pylops.avo.avo.akirichards`.
 
-        * "fatti": Fatti
+        * "fatti": Fatti. See :py:func:`pylops.avo.avo.fatti`.
 
-        * "PS": PS, or any function on the form of ``pylops.avo.avo.akirichards``
+        * "PS": PS. See :py:func:`pylops.avo.avo.ps`.
+
+        * Function with the same signature as :py:func:`pylops.avo.avo.akirichards`
     explicit : :obj:`bool`, optional
         Create a chained linear operator (``False``, preferred for large data)
         or a ``MatrixMult`` linear operator with dense matrix
@@ -237,12 +239,14 @@ def PrestackWaveletModelling(
         Index of the center of the wavelet
     vsvp : :obj:`np.ndarray` or :obj:`float`, optional
         :math:`V_S/V_P` ratio
-    linearization : :obj:`str`, optional
-        * "akirich": Aki-Richards
+    linearization : `{"akirich", "fatti", "PS"}` or :obj:`callable`, optional
+        * "akirich": Aki-Richards. See :py:func:`pylops.avo.avo.akirichards`.
 
-        * "fatti": Fatti
+        * "fatti": Fatti. See :py:func:`pylops.avo.avo.fatti`.
 
-        * "PS": PS, or any function on the form of ``pylops.avo.avo.akirichards``
+        * "PS": PS. See :py:func:`pylops.avo.avo.ps`.
+
+        * Function with the same signature as :py:func:`pylops.avo.avo.akirichards`
 
     Returns
     -------
@@ -368,12 +372,15 @@ def PrestackInversion(
     m0 : :obj:`np.ndarray`, optional
         Background model of size :math:`[n_{t_0} \times n_{m}
         \,(\times n_x \times n_y)]`
-    linearization : :obj:`str` or :obj:`list`, optional
-        * "akirich": Aki-Richards
+    linearization : `{"akirich", "fatti", "PS"}` or :obj:`list`, optional
+        * "akirich": Aki-Richards. See :py:func:`pylops.avo.avo.akirichards`.
 
-        * "fatti": Fatti
+        * "fatti": Fatti. See :py:func:`pylops.avo.avo.fatti`.
 
-        * "PS": PS or a combination of them (required only when ``m0`` is ``None``).
+        * "PS": PS. See :py:func:`pylops.avo.avo.ps`.
+
+        * List which is a combination of previous options (required only when ``m0 is None``).
+
     explicit : :obj:`bool`, optional
         Create a chained linear operator (``False``, preferred for large data)
         or a ``MatrixMult`` linear operator with dense matrix

--- a/pylops/avo/prestack.py
+++ b/pylops/avo/prestack.py
@@ -46,11 +46,11 @@ def PrestackLinearModelling(
     Create operator to be applied to elastic property profiles
     for generation of band-limited seismic angle gathers from a
     linearized version of the Zoeppritz equation. The input model must
-    be arranged in a vector of size :math:`n_m \times n_{t0} (\times n_x \times n_y)`
-    for ``explicit=True`` and :math:`n_{t0} \times n_m  (\times n_x \times n_y)`
+    be arranged in a vector of size :math:`n_m \times n_{t_0}\,(\times n_x \times n_y)`
+    for ``explicit=True`` and :math:`n_{t_0} \times n_m \,(\times n_x \times n_y)`
     for ``explicit=False``. Similarly the output data is arranged in a
-    vector of size :math:`n_{theta} \times n_{t0}  (\times n_x \times n_y)`
-    for ``explicit=True`` and :math:`n_{t0} \times n_{theta} (\times n_x \times n_y)`
+    vector of size :math:`n_{\theta} \times n_{t_0} \,(\times n_x \times n_y)`
+    for ``explicit=True`` and :math:`n_{t_0} \times n_{\theta} \,(\times n_x \times n_y)`
     for ``explicit=False``.
 
     Parameters
@@ -63,16 +63,18 @@ def PrestackLinearModelling(
         Incident angles in degrees. Must have same ``dtype`` of ``wav`` (or
         it will be automatically casted to it)
     vsvp : :obj:`float` or :obj:`np.ndarray`
-        VS/VP ratio (constant or time/depth variant)
+        :math:`V_S/V_P` ratio (constant or time/depth variant)
     nt0 : :obj:`int`, optional
         number of samples (if ``vsvp`` is a scalar)
     spatdims : :obj:`int` or :obj:`tuple`, optional
         Number of samples along spatial axis (or axes)
         (``None`` if only one dimension is available)
     linearization : :obj:`str` or :obj:`func`, optional
-        choice of linearization, ``akirich``: Aki-Richards, ``fatti``: Fatti,
-        ``ps``: PS or any function on the form of
-        ``pylops.avo.avo.akirichards``
+        * "akirich": Aki-Richards
+
+        * "fatti": Fatti
+
+        * "PS": PS, or any function on the form of ``pylops.avo.avo.akirichards``
     explicit : :obj:`bool`, optional
         Create a chained linear operator (``False``, preferred for large data)
         or a ``MatrixMult`` linear operator with dense matrix
@@ -223,8 +225,8 @@ def PrestackWaveletModelling(
     Parameters
     ----------
     m : :obj:`np.ndarray`
-        elastic parameter profles of size :math:`[n_{t0} \times N]`
-        where :math:`N=3/2`. Note that the ``dtype`` of this
+        elastic parameter profles of size :math:`[n_{t_0} \times N]`
+        where :math:`N=3,\,2`. Note that the ``dtype`` of this
         variable will define that of the operator
     theta : :obj:`int`
         Incident angles in degrees. Must have same ``dtype`` of ``m`` (or
@@ -234,11 +236,13 @@ def PrestackWaveletModelling(
     wavc : :obj:`int`, optional
         Index of the center of the wavelet
     vsvp : :obj:`np.ndarray` or :obj:`float`, optional
-        VS/VP ratio
+        :math:`V_S/V_P` ratio
     linearization : :obj:`str`, optional
-        choice of linearization, ``akirich``: Aki-Richards,
-        ``fatti``: Fatti, ``ps``: PS, or any function on the form of
-        ``pylops.avo.avo.akirichards``
+        * "akirich": Aki-Richards
+
+        * "fatti": Fatti
+
+        * "PS": PS, or any function on the form of ``pylops.avo.avo.akirichards``
 
     Returns
     -------
@@ -256,7 +260,7 @@ def PrestackWaveletModelling(
     of constructing seismic reflectivities using three (or two)
     profiles of elastic parameters in time (or depth)
     domain arranged in an input vector :math:`\mathbf{m}`
-    of size :math:`nt0 \times N`:
+    of size :math:`n_{t_0} \times N`:
 
     .. math::
         d(t, \theta) =  \sum_{i=1}^N G_i(t, \theta) m_i(t) * w(t)
@@ -355,19 +359,21 @@ def PrestackInversion(
     ----------
     data : :obj:`np.ndarray`
         Band-limited seismic post-stack data of size
-        :math:`[(n_{lins} \times) n_{t0} \times n_{\theta} (\times n_x \times n_y)]`
+        :math:`[(n_\text{lins} \times) \, n_{t_0} \times n_{\theta} \, (\times n_x \times n_y)]`
     theta : :obj:`np.ndarray`
         Incident angles in degrees
     wav : :obj:`np.ndarray`
         Wavelet in time domain (must had odd number of elements
         and centered to zero)
     m0 : :obj:`np.ndarray`, optional
-        Background model of size :math:`[n_{t0} \times n_{m}
-        (\times n_x \times n_y)]`
+        Background model of size :math:`[n_{t_0} \times n_{m}
+        \,(\times n_x \times n_y)]`
     linearization : :obj:`str` or :obj:`list`, optional
-        choice of linearization, ``akirich``: Aki-Richards, ``fatti``: Fatti
-        ``PS``: PS or a combination of them (required only when ``m0``
-        is ``None``).
+        * "akirich": Aki-Richards
+
+        * "fatti": Fatti
+
+        * "PS": PS or a combination of them (required only when ``m0`` is ``None``).
     explicit : :obj:`bool`, optional
         Create a chained linear operator (``False``, preferred for large data)
         or a ``MatrixMult`` linear operator with dense matrix
@@ -392,7 +398,7 @@ def PrestackInversion(
     kind : :obj:`str`, optional
         Derivative kind (``forward`` or ``centered``).
     vsvp : :obj:`float` or :obj:`np.ndarray`
-        VS/VP ratio (constant or time/depth variant)
+        :math:`V_S/V_P` ratio (constant or time/depth variant)
     **kwargs_solver
         Arbitrary keyword arguments for :py:func:`scipy.linalg.lstsq`
         solver (if ``explicit=True`` and  ``epsR=None``)
@@ -402,11 +408,11 @@ def PrestackInversion(
     Returns
     -------
     minv : :obj:`np.ndarray`
-        Inverted model of size :math:`[n_{t0} \times n_{m}
-        (\times n_x \times n_y)]`
+        Inverted model of size :math:`[n_{t_0} \times n_{m}
+        \,(\times n_x \times n_y)]`
     datar : :obj:`np.ndarray`
         Residual data (i.e., data - background data) of
-        size :math:`[n_{t0} \times n_{\theta} (\times n_x \times n_y)]`
+        size :math:`[n_{t_0} \times n_{\theta} \,(\times n_x \times n_y)]`
 
     Notes
     -----

--- a/pylops/basicoperators/Block.py
+++ b/pylops/basicoperators/Block.py
@@ -47,15 +47,15 @@ def Block(ops, nproc=1, dtype=None):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_{1,1}}  & \mathbf{L_{1,2}} &  ... & \mathbf{L_{1,M}}  \\
-            \mathbf{L_{2,1}}  & \mathbf{L_{2,2}} &  ... & \mathbf{L_{2,M}}  \\
-            ...               & ...              &  ... & ...               \\
-            \mathbf{L_{N,1}}  & \mathbf{L_{N,2}} &  ... & \mathbf{L_{N,M}}  \\
+            \mathbf{L_{1,1}}  & \mathbf{L_{1,2}} &  \ldots & \mathbf{L_{1,M}}  \\
+            \mathbf{L_{2,1}}  & \mathbf{L_{2,2}} &  \ldots & \mathbf{L_{2,M}}  \\
+            \vdots            & \vdots           &  \ddots & \vdots            \\
+            \mathbf{L_{N,1}}  & \mathbf{L_{N,2}} &  \ldots & \mathbf{L_{N,M}}
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{x}_{1}  \\
             \mathbf{x}_{2}  \\
-            ...     \\
+            \vdots          \\
             \mathbf{x}_{M}
         \end{bmatrix} =
         \begin{bmatrix}
@@ -63,27 +63,27 @@ def Block(ops, nproc=1, dtype=None):
             \mathbf{L_{1,M}} \mathbf{x}_{M} \\
             \mathbf{L_{2,1}} \mathbf{x}_{1} + \mathbf{L_{2,2}} \mathbf{x}_{2} +
             \mathbf{L_{2,M}} \mathbf{x}_{M} \\
-            ...     \\
+            \vdots     \\
             \mathbf{L_{N,1}} \mathbf{x}_{1} + \mathbf{L_{N,2}} \mathbf{x}_{2} +
-            \mathbf{L_{N,M}} \mathbf{x}_{M} \\
+            \mathbf{L_{N,M}} \mathbf{x}_{M}
         \end{bmatrix}
 
     while its application in adjoint mode leads to
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_{1,1}}^H  & \mathbf{L_{2,1}}^H &  ... &
+            \mathbf{L_{1,1}}^H  & \mathbf{L_{2,1}}^H &  \ldots &
             \mathbf{L_{N,1}}^H  \\
-            \mathbf{L_{1,2}}^H  & \mathbf{L_{2,2}}^H &  ... &
+            \mathbf{L_{1,2}}^H  & \mathbf{L_{2,2}}^H &  \ldots &
             \mathbf{L_{N,2}}^H  \\
-            ...                 & ...                &  ... & ... \\
-            \mathbf{L_{1,M}}^H  & \mathbf{L_{2,M}}^H &  ... &
+            \vdots                 & \vdots                &  \ddots & \vdots \\
+            \mathbf{L_{1,M}}^H  & \mathbf{L_{2,M}}^H &  \ldots &
             \mathbf{L_{N,M}}^H  \\
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{y}_{1}  \\
             \mathbf{y}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{y}_{N}
         \end{bmatrix} =
         \begin{bmatrix}
@@ -93,10 +93,10 @@ def Block(ops, nproc=1, dtype=None):
             \mathbf{L_{1,2}}^H \mathbf{y}_{1} +
             \mathbf{L_{2,2}}^H \mathbf{y}_{2} +
             \mathbf{L_{N,2}}^H \mathbf{y}_{N} \\
-            ...     \\
+            \vdots     \\
             \mathbf{L_{1,M}}^H \mathbf{y}_{1} +
             \mathbf{L_{2,M}}^H \mathbf{y}_{2} +
-            \mathbf{L_{N,M}}^H \mathbf{y}_{N} \\
+            \mathbf{L_{N,M}}^H \mathbf{y}_{N}
         \end{bmatrix}
 
     """

--- a/pylops/basicoperators/BlockDiag.py
+++ b/pylops/basicoperators/BlockDiag.py
@@ -46,21 +46,21 @@ class BlockDiag(LinearOperator):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_1}  & \mathbf{0}   &  ... &  \mathbf{0}  \\
-            \mathbf{0}    & \mathbf{L_2} &  ... &  \mathbf{0}  \\
-            ...           & ...          &  ... &  ...         \\
-            \mathbf{0}    & \mathbf{0}   &  ... &  \mathbf{L_N}
+            \mathbf{L_1}  & \mathbf{0}   &  \ldots &  \mathbf{0}  \\
+            \mathbf{0}    & \mathbf{L_2} &  \ldots &  \mathbf{0}  \\
+            \vdots        & \vdots       &  \ddots &  \vdots         \\
+            \mathbf{0}    & \mathbf{0}   &  \ldots &  \mathbf{L_N}
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{x}_{1}  \\
             \mathbf{x}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{x}_{N}
         \end{bmatrix} =
         \begin{bmatrix}
             \mathbf{L_1} \mathbf{x}_{1}  \\
             \mathbf{L_2} \mathbf{x}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{L_N} \mathbf{x}_{N}
         \end{bmatrix}
 
@@ -68,21 +68,21 @@ class BlockDiag(LinearOperator):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_1}^H  \quad \mathbf{0}    \quad ... \quad  \mathbf{0}  \\
-            \mathbf{0}    \quad \mathbf{L_2}^H  \quad ... \quad  \mathbf{0}  \\
-            ...           \quad ...             \quad ... \quad  ...         \\
-            \mathbf{0}    \quad \mathbf{0}      \quad ... \quad  \mathbf{L_N}^H
+            \mathbf{L_1}^H  & \mathbf{0}     & \ldots & \mathbf{0}  \\
+            \mathbf{0}      & \mathbf{L_2}^H & \ldots & \mathbf{0}  \\
+            \vdots          & \vdots         & \ddots & \vdots      \\
+            \mathbf{0}      & \mathbf{0}     & \ldots & \mathbf{L_N}^H
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{y}_{1}  \\
             \mathbf{y}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{y}_{N}
         \end{bmatrix} =
         \begin{bmatrix}
             \mathbf{L_1}^H \mathbf{y}_{1}  \\
             \mathbf{L_2}^H \mathbf{y}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{L_N}^H \mathbf{y}_{N}
         \end{bmatrix}
 

--- a/pylops/basicoperators/CausalIntegration.py
+++ b/pylops/basicoperators/CausalIntegration.py
@@ -46,41 +46,42 @@ class CausalIntegration(LinearOperator):
     For simplicity, given a one dimensional array, the causal integration is:
 
     .. math::
-        y(t) = \int x(t) dt
+        y(t) = \int\limits_{-\infty}^t x(\tau) \,\mathrm{d}\tau
 
     which can be discretised as :
 
     .. math::
-        y[i] = \sum_{j=0}^i x[j] dt
+        y[i] = \sum_{j=0}^i x[j] \,\Delta t
 
     or
 
     .. math::
-        y[i] = (\sum_{j=0}^{i-1} x[j] + 0.5x[i]) dt
+        y[i] = \left(\sum_{j=0}^{i-1} x[j] + 0.5x[i]\right) \,\Delta t
 
     or
 
     .. math::
-        y[i] = (\sum_{j=1}^{i-1} x[j] + 0.5x[0] + 0.5x[i]) dt
+        y[i] = \left(\sum_{j=1}^{i-1} x[j] + 0.5x[0] + 0.5x[i]\right) \,\Delta t
 
-    where :math:`dt` is the ``sampling`` interval. In our implementation, the
+    where :math:`\Delta t` is the ``sampling`` interval, and assuming the signal is zero
+    before sample :math:`j=0`. In our implementation, the
     choice to add :math:`x[i]` or :math:`0.5x[i]` is made by selecting ``kind=full``
     or ``kind=half``, respectively. The choice to add :math:`0.5x[i]` and
     :math:`0.5x[0]` instead of made by selecting the ``kind=trapezoidal``.
 
-    Note that the integral of a signal has no unique solution, as any constant
-    :math:`c` can be added to :math:`y`, for example if :math:`x(t)=t^2` the
-    resulting integration is:
+    Note that the causal integral of a signal will depend, up to a constant,
+    on causal start of the signal. For example if :math:`x(\tau) = t^2` the
+    resulting indefinite integration is:
 
     .. math::
-        y(t) = \int t^2 dt = \frac{t^3}{3} + c
+        y(t) = \int \tau^2 \,\mathrm{d}\tau = \frac{t^3}{3} + C
 
-    If we apply a first derivative to :math:`y` we in fact obtain:
+    However, if we apply a first derivative to :math:`y` always obtain:
 
     .. math::
-        x(t) = \frac{dy}{dt} = t^2
+        x(t) = \frac{\mathrm{d}y}{\mathrm{d}t} = t^2
 
-    no matter the choice of :math:`c`.
+    no matter the choice of :math:`C`.
 
     """
 

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -30,13 +30,13 @@ class Conj(LinearOperator):
 
     .. math::
 
-        y_{i} = \Re\{x_{i}\} - i\Im\{x_{i}\} \quad \forall i=0,...,N
+        y_{i} = \Re\{x_{i}\} - i\Im\{x_{i}\} \quad \forall i=0,\ldots,N-1
 
     In adjoint mode:
 
     .. math::
 
-        x_{i} = \Re\{y_{i}\} - i\Im\{y_{i}\} \quad \forall i=0,...,N
+        x_{i} = \Re\{y_{i}\} - i\Im\{y_{i}\} \quad \forall i=0,\ldots,N-1
 
     """
 

--- a/pylops/basicoperators/Diagonal.py
+++ b/pylops/basicoperators/Diagonal.py
@@ -43,7 +43,7 @@ class Diagonal(LinearOperator):
 
     .. math::
 
-        y_i = d_i x_i  \quad \forall i=1,2,...,N
+        y_i = d_i x_i  \quad \forall i=1,2,\ldots,N
 
     This is equivalent to a matrix-vector multiplication with a matrix
     containing the vector :math:`\mathbf{d}` along its main diagonal.

--- a/pylops/basicoperators/DirectionalDerivative.py
+++ b/pylops/basicoperators/DirectionalDerivative.py
@@ -7,17 +7,21 @@ def FirstDirectionalDerivative(
 ):
     r"""First Directional derivative.
 
-    Apply directional derivative operator to a multi-dimensional
-    array (at least 2 dimensions are required) along either a single common
-    direction or different directions for each point of the array.
+    Apply a directional derivative operator to a multi-dimensional array
+    along either a single common direction or different directions for each
+    point of the array.
+
+    .. note:: At least 2 dimensions are required, consider using
+      :py:func:`pylops.FirstDerivative` for 1d arrays.
+
 
     Parameters
     ----------
     dims : :obj:`tuple`
         Number of samples for each dimension.
     v : :obj:`np.ndarray`, optional
-        Single direction (array of size :math:`n_{dims}`) or group of directions
-        (array of size :math:`[n_{dims} \times n_{d0} \times ... \times n_{d_{n_{dims}}}]`)
+        Single direction (array of size :math:`n_\text{dims}`) or group of directions
+        (array of size :math:`[n_\text{dims} \times n_{d_0} \times ... \times n_{d_{n_\text{dims}}}]`)
     sampling : :obj:`tuple`, optional
         Sampling steps for each direction.
     edge : :obj:`bool`, optional
@@ -70,17 +74,20 @@ def FirstDirectionalDerivative(
 def SecondDirectionalDerivative(dims, v, sampling=1, edge=False, dtype="float64"):
     r"""Second Directional derivative.
 
-    Apply second directional derivative operator to a multi-dimensional
-    array (at least 2 dimensions are required) along either a single common
-    direction or different directions for each point of the array.
+    Apply a second directional derivative operator to a multi-dimensional array
+    along either a single common direction or different directions for each
+    point of the array.
+
+    .. note:: At least 2 dimensions are required, consider using
+      :py:func:`pylops.SecondDerivative` for 1d arrays.
 
     Parameters
     ----------
     dims : :obj:`tuple`
         Number of samples for each dimension.
     v : :obj:`np.ndarray`, optional
-        Single direction (array of size :math:`n_{dims}`) or group of directions
-        (array of size :math:`[n_{dims} \times n_{d0} \times ... \times n_{d_{n_{dims}}}]`)
+        Single direction (array of size :math:`n_\text{dims}`) or group of directions
+        (array of size :math:`[n_\text{dims} \times n_{d_0} \times ... \times n_{d_{n_\text{dims}}}]`)
     sampling : :obj:`tuple`, optional
         Sampling steps for each direction.
     edge : :obj:`bool`, optional

--- a/pylops/basicoperators/FirstDerivative.py
+++ b/pylops/basicoperators/FirstDerivative.py
@@ -7,7 +7,8 @@ from pylops.utils.backend import get_array_module
 class FirstDerivative(LinearOperator):
     r"""First derivative.
 
-    Apply first derivative.
+    Apply a first derivative using a three-point stencil finite-difference
+    approximation.
 
     Parameters
     ----------
@@ -19,7 +20,7 @@ class FirstDerivative(LinearOperator):
     dir : :obj:`int`, optional
         Direction along which the derivative is applied.
     sampling : :obj:`float`, optional
-        Sampling step ``dx``.
+        Sampling step :math:`\Delta x`.
     edge : :obj:`bool`, optional
         Use reduced order derivative at edges (``True``) or
         ignore them (``False``)
@@ -46,17 +47,17 @@ class FirstDerivative(LinearOperator):
     first derivative is:
 
     .. math::
-        y[i] = (0.5x[i+1] - 0.5x[i-1]) / dx
+        y[i] = (0.5x[i+1] - 0.5x[i-1]) / \Delta x
 
     while the first-order forward stencil is:
 
     .. math::
-        y[i] = (x[i+1] - x[i]) / dx
+        y[i] = (x[i+1] - x[i]) / \Delta x
 
     and the first-order backward stencil is:
 
     .. math::
-        y[i] = (x[i] - x[i-1]) / dx
+        y[i] = (x[i] - x[i-1]) / \Delta x
 
     """
 

--- a/pylops/basicoperators/Flip.py
+++ b/pylops/basicoperators/Flip.py
@@ -35,7 +35,7 @@ class Flip(LinearOperator):
     in forward mode this is equivalent to:
 
     .. math::
-        y[i] = x[N-i] \quad \forall i=0,1,2,...,N-1
+        y[i] = x[N-1-i] \quad \forall i=0,1,2,\ldots,N-1
 
     where :math:`N` is the lenght of the input model. As this operator is
     self-adjoint, :math:`x` and :math:`y` in the equation above are simply

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -6,23 +6,23 @@ from pylops import LinearOperator
 class FunctionOperator(LinearOperator):
     r"""Function Operator.
 
-    Simple wrapper to functions for forward `f` and adjoint `fc`
+    Simple wrapper to functions for forward `f` and adjoint `f_c`
     multiplication.
 
-    Functions :math:`f` and :math:`fc` are such that
-    :math:`f:\mathbb{F}^m \to \mathbb{F}^n` and
-    :math:`fc:\mathbb{F}^n \to \mathbb{F}^m` where :math:`\mathbb{F}` is
-    the appropriate underlying type (e.g., :math:`\mathbb{R}` for real or
-    :math:`\mathbb{C}` for complex)
+    Functions :math:`f` and :math:`f_c` are such that
+    :math:`f:\mathbb{F}^m \to \mathbb{F}_c^n` and
+    :math:`f_c:\mathbb{F}_c^n \to \mathbb{F}^m` where :math:`\mathbb{F}` and
+    :math:`\mathbb{F}_c` are the underlying fields (e.g., :math:`\mathbb{R}` for
+    real or :math:`\mathbb{C}` for complex)
 
     FunctionOperator can be called in the following ways:
     ``FunctionOperator(f, n)``, ``FunctionOperator(f, n, m)``,
     ``FunctionOperator(f, fc, n)``, and ``FunctionOperator(f, fc, n, m)``.
 
     The first two methods can only be used for forward modelling and
-    will return `NotImplementedError` if the adjoint is called.
+    will return ``NotImplementedError`` if the adjoint is called.
     The first and third method assume the matrix (or matrices) to be square.
-    All methods can be called with the `dtype` keyword argument.
+    All methods can be called with the ``dtype`` keyword argument.
 
     Parameters
     ----------

--- a/pylops/basicoperators/Gradient.py
+++ b/pylops/basicoperators/Gradient.py
@@ -6,8 +6,10 @@ from pylops.basicoperators import FirstDerivative, VStack
 def Gradient(dims, sampling=1, edge=False, dtype="float64", kind="centered"):
     r"""Gradient.
 
-    Apply gradient operator to a multi-dimensional
-    array (at least 2 dimensions are required).
+    Apply gradient operator to a multi-dimensional array.
+
+    .. note:: At least 2 dimensions are required, use
+      :py:func:`pylops.FirstDerivative` for 1d arrays.
 
     Parameters
     ----------

--- a/pylops/basicoperators/HStack.py
+++ b/pylops/basicoperators/HStack.py
@@ -51,16 +51,16 @@ class HStack(LinearOperator):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L}_{1} & \mathbf{L}_{2} & ... & \mathbf{L}_{N}
+            \mathbf{L}_{1} & \mathbf{L}_{2} & \ldots & \mathbf{L}_{N}
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{x}_{1}  \\
             \mathbf{x}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{x}_{N}
         \end{bmatrix} =
         \mathbf{L}_{1} \mathbf{x}_1 + \mathbf{L}_{2} \mathbf{x}_2 +
-        ... + \mathbf{L}_{N} \mathbf{x}_N
+        \ldots + \mathbf{L}_{N} \mathbf{x}_N
 
     while its application in adjoint mode leads to
 
@@ -68,20 +68,20 @@ class HStack(LinearOperator):
         \begin{bmatrix}
             \mathbf{L}_{1}^H  \\
             \mathbf{L}_{2}^H  \\
-            ...     \\
+            \vdots     \\
             \mathbf{L}_{N}^H
         \end{bmatrix}
         \mathbf{y} =
         \begin{bmatrix}
             \mathbf{L}_{1}^H \mathbf{y}  \\
             \mathbf{L}_{2}^H \mathbf{y}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{L}_{N}^H \mathbf{y}
         \end{bmatrix} =
         \begin{bmatrix}
             \mathbf{x}_{1}  \\
             \mathbf{x}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{x}_{N}
         \end{bmatrix}
 

--- a/pylops/basicoperators/Identity.py
+++ b/pylops/basicoperators/Identity.py
@@ -42,7 +42,7 @@ class Identity(LinearOperator):
 
     .. math::
 
-        y_i = x_i  \quad \forall i=1,2,...,N
+        y_i = x_i  \quad \forall i=1,2,\ldots,N
 
     or in matrix form:
 
@@ -62,16 +62,16 @@ class Identity(LinearOperator):
 
     .. math::
 
-        y_i = x_i  \quad \forall i=1,2,...,N
+        y_i = x_i  \quad \forall i=1,2,\ldots,N
 
     and all the elements of the data :math:`\mathbf{y}` into the first
     :math:`M` elements of model in adjoint mode (other elements are ``O``):
 
     .. math::
 
-        x_i = y_i  \quad \forall i=1,2,...,M
+        x_i = y_i  \quad \forall i=1,2,\ldots,M
 
-        x_i = 0 \quad \forall i=M+1,...,N
+        x_i = 0 \quad \forall i=M+1,\ldots,N
 
     """
 

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -32,13 +32,13 @@ class Imag(LinearOperator):
 
     .. math::
 
-        y_{i} = \Imag\{x_{i}\} \quad \forall i=0,...,N
+        y_{i} = \Im\{x_{i}\} \quad \forall i=0,\ldots,N-1
 
     In adjoint mode:
 
     .. math::
 
-        x_{i} = 0 + i\Re\{y_{i}\} \quad \forall i=0,...,N
+        x_{i} = 0 + i\Re\{y_{i}\} \quad \forall i=0,\ldots,N-1
 
     """
 

--- a/pylops/basicoperators/Kronecker.py
+++ b/pylops/basicoperators/Kronecker.py
@@ -31,22 +31,22 @@ class Kronecker(LinearOperator):
     Notes
     -----
     The Kronecker product (denoted with :math:`\otimes`) is an operation
-    on two operators :math:`\mathbf{Op_1}` and :math:`\mathbf{Op_2}` of
+    on two operators :math:`\mathbf{Op}_1` and :math:`\mathbf{Op}_2` of
     sizes :math:`\lbrack n_1 \times m_1 \rbrack` and
     :math:`\lbrack n_2 \times m_2 \rbrack` respectively, resulting in a
     block matrix of size :math:`\lbrack n_1 n_2 \times m_1 m_2 \rbrack`.
 
     .. math::
 
-        \mathbf{Op_1} \otimes \mathbf{Op_2} = \begin{bmatrix}
-            Op_1^{1,1} \mathbf{Op_2} &  ... & Op_1^{1,m_1} \mathbf{Op_2}   \\
-            ...                     &  ... & ... \\
-            Op_1^{n_1,1} \mathbf{Op_2} &  ... & Op_1^{n_1,m_1} \mathbf{Op_2}
+        \mathbf{Op}_1 \otimes \mathbf{Op}_2 = \begin{bmatrix}
+            \text{Op}_1^{1,1} \mathbf{Op}_2   &  \ldots & \text{Op}_1^{1,m_1} \mathbf{Op}_2   \\
+            \vdots                            &  \ddots & \vdots \\
+            \text{Op}_1^{n_1,1} \mathbf{Op}_2 &  \ldots & \text{Op}_1^{n_1,m_1} \mathbf{Op}_2
         \end{bmatrix}
 
     The application of the resulting matrix to a vector :math:`\mathbf{x}` of
     size :math:`\lbrack m_1 m_2 \times 1 \rbrack` is equivalent to the
-    application of the second operator :math:`\mathbf{Op_2}` to the rows of
+    application of the second operator :math:`\mathbf{Op}_2` to the rows of
     a matrix of size :math:`\lbrack m_2 \times m_1 \rbrack` obtained by
     reshaping the input vector :math:`\mathbf{x}`, followed by the application
     of the first operator to the transposed matrix produced by the first

--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -9,8 +9,10 @@ def Laplacian(
 ):
     r"""Laplacian.
 
-    Apply second-order centered Laplacian operator to a multi-dimensional
-    array (at least 2 dimensions are required)
+    Apply second-order centered Laplacian operator to a multi-dimensional array.
+
+    .. note:: At least 2 dimensions are required, use
+      :py:func:`pylops.SecondDerivative` for 1d arrays.
 
     Parameters
     ----------
@@ -43,7 +45,7 @@ def Laplacian(
 
     .. math::
         y[i, j] = (x[i+1, j] + x[i-1, j] + x[i, j-1] +x[i, j+1] - 4x[i, j])
-                  / (dx*dy)
+                  / (\Delta x \Delta y)
 
     """
     l2op = weights[0] * SecondDerivative(

--- a/pylops/basicoperators/LinearRegression.py
+++ b/pylops/basicoperators/LinearRegression.py
@@ -9,7 +9,7 @@ def LinearRegression(taxis, dtype="float64"):
     r"""Linear regression.
 
     Creates an operator that applies linear regression to a set of points.
-    Values along the t-axis  must be provided while initializing the operator.
+    Values along the :math:`t`-axis  must be provided while initializing the operator.
     Intercept and gradient form the model vector to be provided in forward
     mode, while the values of the regression line curve shall be provided
     in adjoint mode.
@@ -17,7 +17,7 @@ def LinearRegression(taxis, dtype="float64"):
     Parameters
     ----------
     taxis : :obj:`numpy.ndarray`
-        Elements along the t-axis.
+        Elements along the :math:`t`-axis.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -32,7 +32,7 @@ def LinearRegression(taxis, dtype="float64"):
     Raises
     ------
     TypeError
-        If ``t`` is not :obj:`numpy.ndarray`.
+        If ``taxis`` is not :obj:`numpy.ndarray`.
 
     See Also
     --------
@@ -43,7 +43,7 @@ def LinearRegression(taxis, dtype="float64"):
     The LinearRegression operator solves the following problem:
 
     .. math::
-        y_i = x_0 + x_1 t_i  \qquad \forall i=1,2,...,N
+        y_i = x_0 + x_1 t_i  \qquad \forall i=1,2,\ldots,N
 
     We can express this problem in a matrix form
 
@@ -53,7 +53,7 @@ def LinearRegression(taxis, dtype="float64"):
     where
 
     .. math::
-        \mathbf{y}= [y_1, y_2,...,y_N]^T, \qquad \mathbf{x}= [x_0, x_1]^T
+        \mathbf{y}= [y_1, y_2,\ldots,y_N]^T, \qquad \mathbf{x}= [x_0, x_1]^T
 
     and
 
@@ -62,7 +62,7 @@ def LinearRegression(taxis, dtype="float64"):
         = \begin{bmatrix}
             1       & t_{1}  \\
             1       & t_{2}  \\
-            ..      & ..     \\
+            \vdots      & \vdots     \\
             1       & t_{N}
         \end{bmatrix}
 

--- a/pylops/basicoperators/Pad.py
+++ b/pylops/basicoperators/Pad.py
@@ -38,22 +38,22 @@ class Pad(LinearOperator):
     Notes
     -----
     Given an array of size :math:`N`, the *Pad* operator simply adds
-    :math:`pad_{in}` at the start and :math:`pad_{end}` at the end in forward mode:
+    :math:`\text{pad}_\text{in}` at the start and :math:`\text{pad}_\text{end}` at the end in forward mode:
 
     .. math::
 
-        y_{i} = x_{i-pad_{in}}  \quad \forall
-        i=pad_{in},pad_{in}+1,...,pad_{in}+N-1
+        y_{i} = x_{i-\text{pad}_\text{in}}  \quad \forall
+        i=\text{pad}_\text{in},\ldots,\text{pad}_\text{in}+N-1
 
     and :math:`y_i = 0 \quad \forall
-    i=0,...,pad_{in}-1, pad_{in}+N-1,...,N+pad_{in}+pad_{end}`
+    i=0,\ldots,\text{pad}_\text{in}-1, \text{pad}_\text{in}+N-1,\ldots,N+\text{pad}_\text{in}+\text{pad}_\text{end}`
 
-    In adjoint mode, values from :math:`pad_{in}` to :math:`N-pad_{end}` are
+    In adjoint mode, values from :math:`\text{pad}_\text{in}` to :math:`N-\text{pad}_\text{end}` are
     extracted from the data:
 
     .. math::
 
-        x_{i} = y_{pad_{in}+i}  \quad \forall i=0, N-1
+        x_{i} = y_{\text{pad}_\text{in}+i}  \quad \forall i=0, N-1
 
     """
 

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -32,13 +32,13 @@ class Real(LinearOperator):
 
     .. math::
 
-        y_{i} = \Re\{x_{i}\} \quad \forall i=0,...,N
+        y_{i} = \Re\{x_{i}\} \quad \forall i=0,\ldots,N-1
 
     In adjoint mode:
 
     .. math::
 
-        x_{i} = \Re\{y_{i}\} + 0i \quad \forall i=0,...,N
+        x_{i} = \Re\{y_{i}\} + 0i \quad \forall i=0,\ldots,N-1
 
     """
 

--- a/pylops/basicoperators/Regression.py
+++ b/pylops/basicoperators/Regression.py
@@ -12,7 +12,7 @@ class Regression(LinearOperator):
     r"""Polynomial regression.
 
     Creates an operator that applies polynomial regression to a set of points.
-    Values along the t-axis must be provided while initializing the operator.
+    Values along the :math:`t`-axis must be provided while initializing the operator.
     The coefficients of the polynomial regression form the model vector to
     be provided in forward mode, while the values of the regression
     curve shall be provided in adjoint mode.
@@ -20,7 +20,7 @@ class Regression(LinearOperator):
     Parameters
     ----------
     taxis : :obj:`numpy.ndarray`
-        Elements along the t-axis.
+        Elements along the :math:`t`-axis.
     order : :obj:`int`
         Order of the regressed polynomial.
     dtype : :obj:`str`, optional
@@ -37,7 +37,7 @@ class Regression(LinearOperator):
     Raises
     ------
     TypeError
-        If ``t`` is not :obj:`numpy.ndarray`.
+        If ``taxis`` is not :obj:`numpy.ndarray`.
 
     See Also
     --------
@@ -48,7 +48,7 @@ class Regression(LinearOperator):
     The Regression operator solves the following problem:
 
     .. math::
-        y_i = \sum_{n=0}^{order} x_n t_i^n  \qquad \forall i=1,2,...,N
+        y_i = \sum_{n=0}^\text{order} x_n t_i^n  \qquad \forall i=1,2,\ldots,N
 
     where :math:`N` represents the order of the chosen polynomial. We can
     express this problem in a matrix form
@@ -59,18 +59,18 @@ class Regression(LinearOperator):
     where
 
     .. math::
-        \mathbf{y}= [y_1, y_2,...,y_N]^T,
-        \qquad \mathbf{x}= [x_0, x_1,...,x_{order}]^T
+        \mathbf{y}= [y_1, y_2,\ldots,y_N]^T,
+        \qquad \mathbf{x}= [x_0, x_1,\ldots,x_\text{order}]^T
 
     and
 
     .. math::
         \mathbf{A}
         = \begin{bmatrix}
-            1  & t_{1} & t_{1}^2 & .. & t_{1}^{order}  \\
-            1  & t_{2} & t_{2}^2 & .. & t_{1}^{order}  \\
-            .. & ..    & ..      & .. & ..             \\
-            1  & t_{N} & t_{N}^2 & .. & t_{N}^{order}  \\
+            1      & t_{1}  & t_{1}^2 & \ldots & t_{1}^\text{order}  \\
+            1      & t_{2}  & t_{2}^2 & \ldots & t_{1}^\text{order}  \\
+            \vdots & \vdots & \vdots  & \ddots & \vdots             \\
+            1      & t_{N}  & t_{N}^2 & \ldots & t_{N}^\text{order}
         \end{bmatrix}
 
     """

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -63,20 +63,20 @@ class Restriction(LinearOperator):
 
     .. math::
 
-        y_i = x_{l_i}  \quad \forall i=1,2,...,N
+        y_i = x_{l_i}  \quad \forall i=1,2,\ldots,N
 
-    where :math:`\mathbf{l}=[l_1, l_2,..., l_N]` is a vector containing the indeces
+    where :math:`\mathbf{l}=[l_1, l_2,\ldots, l_N]` is a vector containing the indeces
     of the original array at which samples are taken.
 
     Conversely, in adjoint mode the available values in the data vector
     :math:`\mathbf{y}` are placed at locations
-    :math:`\mathbf{l}=[l_1, l_2,..., l_M]` in the model vector:
+    :math:`\mathbf{l}=[l_1, l_2,\ldots, l_M]` in the model vector:
 
     .. math::
 
-        x_{l_i} = y_i  \quad \forall i=1,2,...,N
+        x_{l_i} = y_i  \quad \forall i=1,2,\ldots,N
 
-    and :math:`x_{j}=0 j \neq l_i` (i.e., at all other locations in input
+    and :math:`x_{j}=0` for :math:`j \neq l_i` (i.e., at all other locations in input
     vector).
 
     """

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -7,7 +7,8 @@ from pylops.utils.backend import get_array_module
 class SecondDerivative(LinearOperator):
     r"""Second derivative.
 
-    Apply second-order second derivative.
+    Apply a second derivative using a three-point stencil finite-difference
+    approximation.
 
     Parameters
     ----------
@@ -19,7 +20,7 @@ class SecondDerivative(LinearOperator):
     dir : :obj:`int`, optional
         Direction along which the derivative is applied.
     sampling : :obj:`float`, optional
-        Sampling step ``dx``.
+        Sampling step :math:`\Delta x`.
     edge : :obj:`bool`, optional
         Use reduced order derivative at edges (``True``) or
         ignore them (``False``)
@@ -43,7 +44,7 @@ class SecondDerivative(LinearOperator):
     first derivative is:
 
     .. math::
-        y[i] = (x[i+1] - 2x[i] + x[i-1]) / dx^2
+        y[i] = (x[i+1] - 2x[i] + x[i-1]) / \Delta x^2
 
     """
 

--- a/pylops/basicoperators/Smoothing1D.py
+++ b/pylops/basicoperators/Smoothing1D.py
@@ -32,27 +32,27 @@ def Smoothing1D(nsmooth, dims, dir=0, dtype="float64"):
     -----
     The Smoothing1D operator is a special type of convolutional operator that
     convolves the input model (or data) with a constant filter of size
-    :math:`n_{smooth}`:
+    :math:`n_\text{smooth}`:
 
     .. math::
-        \mathbf{f} = [ 1/n_{smooth}, 1/n_{smooth}, ..., 1/n_{smooth} ]
+        \mathbf{f} = [ 1/n_\text{smooth}, 1/n_\text{smooth}, ..., 1/n_\text{smooth} ]
 
     When applied to the first direction:
 
     .. math::
-        y[i,j,k] = 1/n_{smooth} \sum_{l=-(n_{smooth}-1)/2}^{(n_{smooth}-1)/2}
+        y[i,j,k] = 1/n_\text{smooth} \sum_{l=-(n_\text{smooth}-1)/2}^{(n_\text{smooth}-1)/2}
         x[l,j,k]
 
     Similarly when applied to the second direction:
 
     .. math::
-        y[i,j,k] = 1/n_{smooth} \sum_{l=-(n_{smooth}-1)/2}^{(n_{smooth}-1)/2}
+        y[i,j,k] = 1/n_\text{smooth} \sum_{l=-(n_\text{smooth}-1)/2}^{(n_\text{smooth}-1)/2}
         x[i,l,k]
 
     and the third direction:
 
     .. math::
-        y[i,j,k] = 1/n_{smooth} \sum_{l=-(n_{smooth}-1)/2}^{(n_{smooth}-1)/2}
+        y[i,j,k] = 1/n_\text{smooth} \sum_{l=-(n_\text{smooth}-1)/2}^{(n_\text{smooth}-1)/2}
         x[i,j,l]
 
     Note that since the filter is symmetrical, the *Smoothing1D* operator is

--- a/pylops/basicoperators/Smoothing2D.py
+++ b/pylops/basicoperators/Smoothing2D.py
@@ -16,7 +16,7 @@ def Smoothing2D(nsmooth, dims, nodir=None, dtype="float64"):
     dims : :obj:`tuple`
         Number of samples for each dimension
     nodir : :obj:`int`, optional
-        Direction along which smoothing is NOT applied (set to None for 2d
+        Direction along which smoothing is **not** applied (set to ``None`` for 2d
         arrays)
     dtype : :obj:`str`, optional
         Type of elements in input array.
@@ -37,14 +37,14 @@ def Smoothing2D(nsmooth, dims, nodir=None, dtype="float64"):
     -----
     The 2D Smoothing operator is a special type of convolutional operator that
     convolves the input model (or data) with a constant 2d filter of size
-    :math:`n_{smooth, 1} \quad x \quad n_{smooth, 2}`:
+    :math:`n_{\text{smooth}, 1} \times n_{\text{smooth}, 2}`:
 
     Its application to a two dimensional input signal is:
 
     .. math::
-        y[i,j] = 1/(n_{smooth, 1}*n_{smooth, 2})
-        \sum_{l=-(n_{smooth,1}-1)/2}^{(n_{smooth,1}-1)/2}
-        \sum_{m=-(n_{smooth,2}-1)/2}^{(n_{smooth,2}-1)/2} x[l,m]
+        y[i,j] = 1/(n_{\text{smooth}, 1}\cdot n_{\text{smooth}, 2})
+        \sum_{l=-(n_{\text{smooth},1}-1)/2}^{(n_{\text{smooth},1}-1)/2}
+        \sum_{m=-(n_{\text{smooth},2}-1)/2}^{(n_{\text{smooth},2}-1)/2} x[l,m]
 
     Note that since the filter is symmetrical, the *Smoothing2D* operator is
     self-adjoint.

--- a/pylops/basicoperators/Spread.py
+++ b/pylops/basicoperators/Spread.py
@@ -27,7 +27,7 @@ class Spread(LinearOperator):
     r"""Spread operator.
 
     Spread values from the input model vector arranged as a 2-dimensional
-    array of size :math:`[n_{x0} \times n_{t0}]` into the data vector of size
+    array of size :math:`[n_{x_0} \times n_{t_0}]` into the data vector of size
     :math:`[n_x \times n_t]`. Spreading is performed along parametric curves
     provided as look-up table of pre-computed indices (``table``)
     or computed on-the-fly using a function handle (``fh``).
@@ -39,23 +39,23 @@ class Spread(LinearOperator):
     ----------
     dims : :obj:`tuple`
         Dimensions of model vector (vector will be reshaped internally into
-        a two-dimensional array of size :math:`[n_{x0} \times n_{t0}]`,
+        a two-dimensional array of size :math:`[n_{x_0} \times n_{t_0}]`,
         where the first dimension is the spreading/stacking direction)
     dimsd : :obj:`tuple`
         Dimensions of model vector (vector will be reshaped internal into
         a two-dimensional array of size :math:`[n_x \times n_t]`)
     table : :obj:`np.ndarray`, optional
         Look-up table of indeces of size
-        :math:`[n_{x0} \times n_{t0} \times n_x]` (if ``None`` use function
+        :math:`[n_{x_0} \times n_{t_0} \times n_x]` (if ``None`` use function
         handle ``fh``)
     dtable : :obj:`np.ndarray`, optional
         Look-up table of decimals remainders for linear interpolation of size
-        :math:`[n_{x0} \times n_{t0} \times n_x]` (if ``None`` use function
+        :math:`[n_{x_0} \times n_{t_0} \times n_x]` (if ``None`` use function
         handle ``fh``)
     fh : :obj:`np.ndarray`, optional
         Function handle that returns an index (and a fractional value in case
         of ``interp=True``) to be used for spreading/stacking given indices
-        in :math:`x0` and :math:`t` axes (if ``None`` use look-up table
+        in :math:`x_0` and :math:`t` axes (if ``None`` use look-up table
         ``table``)
     interp : :obj:`bool`, optional
         Apply linear interpolation (``True``) or nearest interpolation
@@ -84,7 +84,7 @@ class Spread(LinearOperator):
         If both ``table`` and ``fh`` are not provided
     ValueError
         If ``table`` has shape different from
-        :math:`[n_{x0} \times n_t0 \times n_x]`
+        :math:`[n_{x_0} \times n_{t_0} \times n_x]`
 
     Notes
     -----
@@ -93,16 +93,16 @@ class Spread(LinearOperator):
     :math:`[n_x \times n_t]`:
 
     .. math::
-        m(x0, t_0) \rightarrow d(x, t=f(x0, x, t_0))
+        m(x_0, t_0) \rightarrow d(x, t=f(x_0, x, t_0))
 
-    where :math:`f(x0, x, t)` is a mapping function that returns a value t
-    given values :math:`x0`, :math:`x`, and  :math:`t_0`.
+    where :math:`f(x_0, x, t)` is a mapping function that returns a value t
+    given values :math:`x_0`, :math:`x`, and  :math:`t_0`.
 
     In adjoint mode, the model is reconstructed by means of the following
     stacking operation:
 
     .. math::
-        m(x0, t_0) = \int{d(x, t=f(x0, x, t_0))} dx
+        m(x_0, t_0) = \int{d(x, t=f(x_0, x, t_0))} \,\mathrm{d}x
 
     Note that ``table`` (or ``fh``)  must return integer numbers
     representing indices in the axis :math:`t`. However it also possible to

--- a/pylops/basicoperators/Symmetrize.py
+++ b/pylops/basicoperators/Symmetrize.py
@@ -39,22 +39,22 @@ class Symmetrize(LinearOperator):
 
     .. math::
         y[i] = \begin{cases}
-        x[i-N],& i\geq N\\
-        x[N-i],& \text{otherwise}
+        x[i-N+1],& i\geq N\\
+        x[N-1-i],& \text{otherwise}
         \end{cases}
 
-    for :math:`i=0,1,2,...,2N-2`, where :math:`N` is the lenght of
+    for :math:`i=0,1,2,\ldots,2N-2`, where :math:`N` is the lenght of
     the input model.
 
     In adjoint mode, the Symmetrize operator assigns the sums of the elements
-    in position :math:`N-i` and :math:`N+i` to position :math:`i` as follows:
+    in position :math:`N-1-i` and :math:`N-1+i` to position :math:`i` as follows:
 
     .. math::
         \begin{multline}
-        x[i] = y[N-i]+y[N+i] \quad \forall i=1,2,...,N-1
+        x[i] = y[N-1-i]+y[N-1+i] \quad \forall i=0,2,\ldots,N-1
         \end{multline}
 
-    apart from the central sample where :math:`x[0] = y[N]`.
+    apart from the central sample where :math:`x[0] = y[N-1]`.
     """
 
     def __init__(self, N, dims=None, dir=0, dtype="float64"):

--- a/pylops/basicoperators/VStack.py
+++ b/pylops/basicoperators/VStack.py
@@ -53,20 +53,20 @@ class VStack(LinearOperator):
         \begin{bmatrix}
             \mathbf{L}_{1}  \\
             \mathbf{L}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{L}_{N}
         \end{bmatrix}
         \mathbf{x} =
         \begin{bmatrix}
             \mathbf{L}_{1} \mathbf{x}  \\
             \mathbf{L}_{2} \mathbf{x}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{L}_{N} \mathbf{x}
         \end{bmatrix} =
         \begin{bmatrix}
             \mathbf{y}_{1}  \\
             \mathbf{y}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{y}_{N}
         \end{bmatrix}
 
@@ -74,16 +74,16 @@ class VStack(LinearOperator):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L}_{1}^H & \mathbf{L}_{2}^H & ... & \mathbf{L}_{N}^H
+            \mathbf{L}_{1}^H & \mathbf{L}_{2}^H & \ldots & \mathbf{L}_{N}^H
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{y}_{1}  \\
             \mathbf{y}_{2}  \\
-            ...     \\
+            \vdots     \\
             \mathbf{y}_{N}
         \end{bmatrix} =
         \mathbf{L}_{1}^H \mathbf{y}_1 + \mathbf{L}_{2}^H \mathbf{y}_2 +
-        ... + \mathbf{L}_{N}^H \mathbf{y}_N
+        \ldots + \mathbf{L}_{N}^H \mathbf{y}_N
 
     """
 

--- a/pylops/optimization/leastsquares.py
+++ b/pylops/optimization/leastsquares.py
@@ -86,20 +86,20 @@ def NormalEquationsInversion(
     -----
     Solve the following normal equations for a system of regularized equations
     given the operator :math:`\mathbf{Op}`, a data weighting operator
-    :math:`\mathbf{W}`, a list of regularization terms (:math:`\mathbf{R_i}`
-    and/or :math:`\mathbf{N_i}`), the data :math:`\mathbf{d}` and
-    regularization data :math:`\mathbf{d}_{R_i}`, and the damping factors
-    :math:`\epsilon_I`, :math:`\epsilon_{{R}_i}` and :math:`\epsilon_{{N}_i}`:
+    :math:`\mathbf{W}`, a list of regularization terms (:math:`\mathbf{R}_i`
+    and/or :math:`\mathbf{N}_i`), the data :math:`\mathbf{d}` and
+    regularization data :math:`\mathbf{d}_{\mathbf{R}_i}`, and the damping factors
+    :math:`\epsilon_I`, :math:`\epsilon_{\mathbf{R}_i}` and :math:`\epsilon_{\mathbf{N}_i}`:
 
     .. math::
         ( \mathbf{Op}^T \mathbf{W} \mathbf{Op} +
-        \sum_i \epsilon_{{R}_i}^2 \mathbf{R}_i^T \mathbf{R}_i +
-        \sum_i \epsilon_{{N}_i}^2 \mathbf{N}_i +
+        \sum_i \epsilon_{\mathbf{R}_i}^2 \mathbf{R}_i^T \mathbf{R}_i +
+        \sum_i \epsilon_{\mathbf{N}_i}^2 \mathbf{N}_i +
         \epsilon_I^2 \mathbf{I} )  \mathbf{x}
-        = \mathbf{Op}^T \mathbf{W} \mathbf{d} +  \sum_i \epsilon_{{R}_i}^2
-        \mathbf{R}_i^T \mathbf{d}_{R_i}
+        = \mathbf{Op}^T \mathbf{W} \mathbf{d} +  \sum_i \epsilon_{\mathbf{R}_i}^2
+        \mathbf{R}_i^T \mathbf{d}_{\mathbf{R}_i}
 
-    Note that the data term of the regularizations :math:`\mathbf{N_i}` is
+    Note that the data term of the regularizations :math:`\mathbf{N}_i` is
     implicitly assumed to be zero.
 
     """
@@ -195,7 +195,7 @@ def RegularizedOperator(Op, Regs, epsRs=(1,)):
     .. math::
         \begin{bmatrix}
             \mathbf{Op}    \\
-            \epsilon_{R_1} \mathbf{R}_1 \\
+            \epsilon_{\mathbf{R}_1} \mathbf{R}_1 \\
             ...   \\
             \epsilon_{R_N} \mathbf{R}_N
         \end{bmatrix}
@@ -257,7 +257,7 @@ def RegularizedInversion(
         Gives the reason for termination
 
         ``1`` means :math:`\mathbf{x}` is an approximate solution to
-        :math:`\mathbf{d} = \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{d} = \mathbf{Op}\,\mathbf{x}`
 
         ``2`` means :math:`\mathbf{x}` approximately solves the least-squares
         problem
@@ -265,7 +265,7 @@ def RegularizedInversion(
         Iteration number upon termination
     r1norm : :obj:`float`
         :math:`||\mathbf{r}||_2^2`, where
-        :math:`\mathbf{r} = \mathbf{d} - \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{r} = \mathbf{d} - \mathbf{Op}\,\mathbf{x}`
     r2norm : :obj:`float`
         :math:`\sqrt{\mathbf{r}^T\mathbf{r}  +
         \epsilon^2 \mathbf{x}^T\mathbf{x}}`.
@@ -281,22 +281,22 @@ def RegularizedInversion(
     -----
     Solve the following system of regularized equations given the operator
     :math:`\mathbf{Op}`, a data weighting operator :math:`\mathbf{W}^{1/2}`,
-    a list of regularization terms :math:`\mathbf{R_i}`,
+    a list of regularization terms :math:`\mathbf{R}_i`,
     the data :math:`\mathbf{d}` and regularization damping factors
-    :math:`\epsilon_I`: and :math:`\epsilon_{{R}_i}`:
+    :math:`\epsilon_\mathbf{I}`: and :math:`\epsilon_{\mathbf{R}_i}`:
 
     .. math::
         \begin{bmatrix}
             \mathbf{W}^{1/2} \mathbf{Op}    \\
-            \epsilon_{R_1} \mathbf{R}_1 \\
-            ...   \\
-            \epsilon_{R_N} \mathbf{R}_N
+            \epsilon_{\mathbf{R}_1} \mathbf{R}_1 \\
+            \vdots   \\
+            \epsilon_{\mathbf{R}_N} \mathbf{R}_N
         \end{bmatrix} \mathbf{x} =
         \begin{bmatrix}
             \mathbf{W}^{1/2} \mathbf{d}    \\
-            \epsilon_{R_1} \mathbf{d}_{R_1} \\
-            ...   \\
-            \epsilon_{R_N} \mathbf{d}_{R_N} \\
+            \epsilon_{\mathbf{R}_1} \mathbf{d}_{\mathbf{R}_1} \\
+            \vdots   \\
+            \epsilon_{\mathbf{R}_N} \mathbf{d}_{\mathbf{R}_N} \\
         \end{bmatrix}
 
     where the ``Weight`` provided here is equivalent to the
@@ -383,6 +383,7 @@ def PreconditionedInversion(Op, P, data, x0=None, returninfo=False, **kwargs_sol
         (:py:func:`scipy.sparse.linalg.lsqr` and
         :py:func:`pylops.optimization.solver.cgls` are used as default for numpy
         and cupy `data`, respectively)
+
     Returns
     -------
     xinv : :obj:`numpy.ndarray`
@@ -391,7 +392,7 @@ def PreconditionedInversion(Op, P, data, x0=None, returninfo=False, **kwargs_sol
         Gives the reason for termination
 
         ``1`` means :math:`\mathbf{x}` is an approximate solution to
-        :math:`\mathbf{d} = \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{d} = \mathbf{Op}\,\mathbf{x}`
 
         ``2`` means :math:`\mathbf{x}` approximately solves the least-squares
         problem
@@ -399,7 +400,7 @@ def PreconditionedInversion(Op, P, data, x0=None, returninfo=False, **kwargs_sol
         Iteration number upon termination
     r1norm : :obj:`float`
         :math:`||\mathbf{r}||_2^2`, where :math:`\mathbf{r} = \mathbf{d} -
-        \mathbf{Op}\mathbf{x}`
+        \mathbf{Op}\,\mathbf{x}`
     r2norm : :obj:`float`
         :math:`\sqrt{\mathbf{r}^T\mathbf{r}  +  \epsilon^2
         \mathbf{x}^T\mathbf{x}}`. Equal to ``r1norm`` if :math:`\epsilon=0`
@@ -416,10 +417,10 @@ def PreconditionedInversion(Op, P, data, x0=None, returninfo=False, **kwargs_sol
     the data :math:`\mathbf{d}`
 
     .. math::
-        \mathbf{d} = \mathbf{Op} (\mathbf{P} \mathbf{p})
+        \mathbf{d} = \mathbf{Op}\,\mathbf{P} \mathbf{m}
 
-    where :math:`\mathbf{p}` is the solution in the preconditioned space
-    and :math:`\mathbf{x} = \mathbf{P}\mathbf{p}` is the solution in the
+    where :math:`\mathbf{m}` is the solution in the preconditioned space
+    and :math:`\mathbf{x} = \mathbf{P}\mathbf{m}` is the solution in the
     original space.
 
     """

--- a/pylops/optimization/solver.py
+++ b/pylops/optimization/solver.py
@@ -288,8 +288,9 @@ def lsqr(
         Damping coefficient
     atol, btol : :obj:`float`, optional
         Stopping tolerances. If both are 1.0e-9, the final residual norm
-        should be accurate to about 9 digits. (The final x will usually
-        have fewer correct digits, depending on cond(A) and the size of damp.)
+        should be accurate to about 9 digits. (The solution will usually
+        have fewer correct digits, depending on :math:`\cond(\mathbf{Op})`
+        and the size of ``damp``.)
     conlim : :obj:`float`, optional
         Stopping tolerance on :math:`\cond(\mathbf{Op})`
         exceeds ``conlim``. For square, ``conlim`` could be as large as 1.0e+12.

--- a/pylops/optimization/solver.py
+++ b/pylops/optimization/solver.py
@@ -144,7 +144,7 @@ def cgls(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
         Gives the reason for termination
 
         ``1`` means :math:`\mathbf{x}` is an approximate solution to
-        :math:`\mathbf{d} = \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{d} = \mathbf{Op}\,\mathbf{x}`
 
         ``2`` means :math:`\mathbf{x}` approximately solves the least-squares
         problem
@@ -152,7 +152,7 @@ def cgls(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
         Iteration number upon termination
     r1norm : :obj:`float`
         :math:`||\mathbf{r}||_2`, where
-        :math:`\mathbf{r} = \mathbf{d} - \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{r} = \mathbf{d} - \mathbf{Op}\,\mathbf{x}`
     r2norm : :obj:`float`
         :math:`\sqrt{\mathbf{r}^T\mathbf{r}  +
         \epsilon^2 \mathbf{x}^T\mathbf{x}}`.
@@ -273,6 +273,9 @@ def lsqr(
     Solve an overdetermined system of equations given an operator ``Op`` and
     data ``y`` using LSQR iterations.
 
+    .. math::
+      \DeclareMathOperator{\cond}{cond}
+
     Parameters
     ----------
     Op : :obj:`pylops.LinearOperator`
@@ -288,8 +291,8 @@ def lsqr(
         should be accurate to about 9 digits. (The final x will usually
         have fewer correct digits, depending on cond(A) and the size of damp.)
     conlim : :obj:`float`, optional
-        Stopping tolerance on :math:`cond(\mathbf{Op})`
-        exceeds conlim. For square, ``conlim`` could be as large as 1.0e+12.
+        Stopping tolerance on :math:`\cond(\mathbf{Op})`
+        exceeds ``conlim``. For square, ``conlim`` could be as large as 1.0e+12.
         For least-squares problems, ``conlim`` should be less than 1.0e+8.
         Maximum precision can be obtained by setting
         ``atol = btol = conlim = 0``, but the number of iterations may
@@ -315,38 +318,38 @@ def lsqr(
         ``0`` means the exact solution is :math:`\mathbf{x}=0`
 
         ``1`` means :math:`\mathbf{x}` is an approximate solution to
-        :math:`\mathbf{y} = \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{y} = \mathbf{Op}\,\mathbf{x}`
 
         ``2`` means :math:`\mathbf{x}` approximately solves the least-squares
         problem
 
-        ``3`` means the estimate of :math:`cond(\bar{\mathbf{Op}})`
-        has exceeded conlim
+        ``3`` means the estimate of :math:`\cond(\overline{\mathbf{Op}})`
+        has exceeded ``conlim``
 
-        ``4`` means :math:`\mathbf{y} - \mathbf{Op}\mathbf{x}` is small enough
+        ``4`` means :math:`\mathbf{y} - \mathbf{Op}\,\mathbf{x}` is small enough
         for this machine
 
         ``5`` means the least-squares solution is good enough for this machine
 
-        ``6`` means :math:`cond(\bar{\mathbf{Op}})` seems to be too large for
+        ``6`` means :math:`\cond(\overline{\mathbf{Op}})` seems to be too large for
         this machine
 
         ``7`` means the iteration limit has been reached
 
     r1norm : :obj:`float`
         :math:`||\mathbf{r}||_2^2`, where
-        :math:`\mathbf{r} = \mathbf{y} - \mathbf{Op}\mathbf{x}`
+        :math:`\mathbf{r} = \mathbf{y} - \mathbf{Op}\,\mathbf{x}`
     r2norm : :obj:`float`
         :math:`\sqrt{\mathbf{r}^T\mathbf{r}  +
         \epsilon^2 \mathbf{x}^T\mathbf{x}}`.
         Equal to ``r1norm`` if :math:`\epsilon=0`
     anorm : :obj:`float`
-        Estimate of Frobenius norm of :math:`\bar{\mathbf{Op}} =
+        Estimate of Frobenius norm of :math:`\overline{\mathbf{Op}} =
         [\mathbf{Op} \; \epsilon \mathbf{I}]`
     acond : :obj:`float`
-        Estimate of :math:`cond(\bar{\mathbf{Op}})`
+        Estimate of :math:`\cond(\overline{\mathbf{Op}})`
     arnorm : :obj:`float`
-        Estimate of norm of :math:`cond(\mathbf{Op}^H\mathbf{r}-
+        Estimate of norm of :math:`\cond(\mathbf{Op}^H\mathbf{r}-
         \epsilon^2\mathbf{x})`
     var : :obj:`float`
         Diagonals of :math:`(\mathbf{Op}^H\mathbf{Op})^{-1}` (if ``damp=0``)
@@ -360,7 +363,7 @@ def lsqr(
     Minimize the following functional using LSQR iterations [1]_:
 
     .. math::
-        J = || \mathbf{y} -  \mathbf{Opx} ||_2^2 +
+        J = || \mathbf{y} -  \mathbf{Op}\,\mathbf{x} ||_2^2 +
         \epsilon^2 || \mathbf{x} ||_2^2
 
     where :math:`\epsilon` is the damping coefficient.

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -718,10 +718,12 @@ def ISTA(
     eps : :obj:`float`, optional
         Sparsity damping
     alpha : :obj:`float`, optional
-        Step size (:math:`\alpha \le 1/\lambda_\text{max}(\mathbf{Op}^H\mathbf{Op})`
-        guarantees convergence. If ``None``, the maximum eigenvalue is
-        estimated and the optimal step size is chosen. If provided, the
-        condition will not be checked internally).
+        Step size. To guarantee convergence, ensure
+        :math:`\alpha \le 1/\lambda_\text{max}`, where :math:`\lambda_\text{max}`
+        is the largest eigenvalue of :math:`\mathbf{Op}^H\mathbf{Op}`.
+        If ``None``, the maximum eigenvalue is estimated and the optimal step size
+        is chosen as :math:`1/\lambda_\text{max}`. If provided, the
+        convergence criterion will not be checked internally.
     eigsiter : :obj:`float`, optional
         Number of iterations for eigenvalue estimation if ``alpha=None``
     eigstol : :obj:`float`, optional
@@ -1042,11 +1044,12 @@ def FISTA(
         Number of iterations
     eps : :obj:`float`, optional
         Sparsity damping
-    alpha : :obj:`float`, optional
-        Step size (:math:`\alpha \le 1/\lambda_\text{max}(\mathbf{Op}^H\mathbf{Op})`
-        guarantees convergence. If ``None``, the maximum eigenvalue is
-        estimated and the optimal step size is chosen. If provided, the
-        condition will not be checked internally).
+        Step size. To guarantee convergence, ensure
+        :math:`\alpha \le 1/\lambda_\text{max}`, where :math:`\lambda_\text{max}`
+        is the largest eigenvalue of :math:`\mathbf{Op}^H\mathbf{Op}`.
+        If ``None``, the maximum eigenvalue is estimated and the optimal step size
+        is chosen as :math:`1/\lambda_\text{max}`. If provided, the
+        convergence criterion will not be checked internally.
     eigsiter : :obj:`int`, optional
         Number of iterations for eigenvalue estimation if ``alpha=None``
     eigstol : :obj:`float`, optional

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -28,7 +28,7 @@ def _hardthreshold(x, thresh):
     r"""Hard thresholding.
 
     Applies hard thresholding to vector ``x`` (equal to the proximity
-    operator for :math:`||\mathbf{x}||_0`) as shown in [1]_.
+    operator for :math:`\|\mathbf{x}\|_0`) as shown in [1]_.
 
     .. [1] Chen, Y., Chen, K., Shi, P., Wang, Y., “Irregular seismic
        data reconstruction using a percentile-half-thresholding algorithm”,
@@ -56,7 +56,7 @@ def _softthreshold(x, thresh):
     r"""Soft thresholding.
 
     Applies soft thresholding to vector ``x`` (equal to the proximity
-    operator for :math:`||\mathbf{x}||_1`) as shown in [1]_.
+    operator for :math:`\|\mathbf{x}\|_1`) as shown in [1]_.
 
     .. [1] Chen, Y., Chen, K., Shi, P., Wang, Y., “Irregular seismic
        data reconstruction using a percentile-half-thresholding algorithm”,
@@ -88,7 +88,7 @@ def _halfthreshold(x, thresh):
     r"""Half thresholding.
 
     Applies half thresholding to vector ``x`` (equal to the proximity
-    operator for :math:`||\mathbf{x}||_{1/2}^{1/2}`) as shown in [1]_.
+    operator for :math:`\|\mathbf{x}\|_{1/2}^{1/2}`) as shown in [1]_.
 
     .. [1] Chen, Y., Chen, K., Shi, P., Wang, Y., “Irregular seismic
        data reconstruction using a percentile-half-thresholding algorithm”,
@@ -354,8 +354,8 @@ def IRLS(
 ):
     r"""Iteratively reweighted least squares.
 
-    Solve an optimization problem with :math:`L1` cost function (data IRLS)
-    or :math:`L1` regularization term (model IRLS) given the operator ``Op``
+    Solve an optimization problem with :math:`L^1` cost function (data IRLS)
+    or :math:`L^1` regularization term (model IRLS) given the operator ``Op``
     and data ``y``.
 
     In the *data IRLS*, the cost function is minimized by iteratively solving a
@@ -416,58 +416,59 @@ def IRLS(
     :math:`\mathbf{Op}` and the data :math:`\mathbf{d}`:
 
     .. math::
-        J = ||\mathbf{d} - \mathbf{Op} \mathbf{x}||_1
+        J = \|\mathbf{d} - \mathbf{Op}\,\mathbf{x}\|_1
 
     by a set of outer iterations which require to repeatedly solve a
     weighted least squares problem of the form:
 
     .. math::
-        \mathbf{x}^{(i+1)} = \operatorname*{arg\,min}_\mathbf{x} ||\mathbf{d} -
-        \mathbf{Op} \mathbf{x}||_{2, \mathbf{R}^{(i)}}^2 +
-        \epsilon_I^2 ||\mathbf{x}||_2^2
+        \DeclareMathOperator*{\argmin}{arg\,min}
+        \mathbf{x}^{(i+1)} = \argmin_\mathbf{x} \|\mathbf{d} -
+        \mathbf{Op}\,\mathbf{x}\|_{2, \mathbf{R}^{(i)}}^2 +
+        \epsilon_\mathbf{I}^2 \|\mathbf{x}\|_2^2
 
     where :math:`\mathbf{R}^{(i)}` is a diagonal weight matrix
     whose diagonal elements at iteration :math:`i` are equal to the absolute
     inverses of the residual vector :math:`\mathbf{r}^{(i)} =
-    \mathbf{y} - \mathbf{Op} \mathbf{x}^{(i)}` at iteration :math:`i`.
-    More specifically the j-th element of the diagonal of
+    \mathbf{y} - \mathbf{Op}\,\mathbf{x}^{(i)}` at iteration :math:`i`.
+    More specifically the :math:`j`-th element of the diagonal of
     :math:`\mathbf{R}^{(i)}` is
 
     .. math::
-        R^{(i)}_{j,j} = \frac{1}{|r^{(i)}_j|+\epsilon_R}
+        R^{(i)}_{j,j} = \frac{1}{\left| r^{(i)}_j \right| + \epsilon_\mathbf{R}}
 
     or
 
     .. math::
-        R^{(i)}_{j,j} = \frac{1}{max(|r^{(i)}_j|, \epsilon_R)}
+        R^{(i)}_{j,j} = \frac{1}{\max\{\left|r^{(i)}_j\right|, \epsilon_\mathbf{R}\}}
 
     depending on the choice ``threshR``. In either case,
-    :math:`\epsilon_R` is the user-defined stabilization/thresholding
+    :math:`\epsilon_\mathbf{R}` is the user-defined stabilization/thresholding
     factor [1]_.
 
     Similarly *model IRLS* solves the following optimization problem for the
     operator :math:`\mathbf{Op}` and the data :math:`\mathbf{d}`:
 
     .. math::
-        J = ||\mathbf{x}||_1 \quad s.t. \quad
-        \mathbf{d} = \mathbf{Op} \mathbf{x}
+        J = \|\mathbf{x}\|_1 \quad \text{subject to} \quad
+        \mathbf{d} = \mathbf{Op}\,\mathbf{x}
 
     by a set of outer iterations which require to repeatedly solve a
     weighted least squares problem of the form [2]_:
 
     .. math::
         \mathbf{x}^{(i+1)} = \operatorname*{arg\,min}_\mathbf{x}
-        ||\mathbf{x}||_{2, \mathbf{R}^{(i)}}^2 \quad s.t. \quad
-        \mathbf{d} = \mathbf{Op} \mathbf{x}
+        \|\mathbf{x}\|_{2, \mathbf{R}^{(i)}}^2 \quad \text{subject to} \quad
+        \mathbf{d} = \mathbf{Op}\,\mathbf{x}
 
     where :math:`\mathbf{R}^{(i)}` is a diagonal weight matrix
     whose diagonal elements at iteration :math:`i` are equal to the absolutes
     of the model vector :math:`\mathbf{x}^{(i)}` at iteration
-    :math:`i`. More specifically the j-th element of the diagonal of
+    :math:`i`. More specifically the :math:`j`-th element of the diagonal of
     :math:`\mathbf{R}^{(i)}` is
 
     .. math::
-        R^{(i)}_{j,j} = |x^{(i)}_j|
+        R^{(i)}_{j,j} = \left|x^{(i)}_j\right|.
 
     .. [1] https://en.wikipedia.org/wiki/Iteratively_reweighted_least_squares
     .. [2] Chartrand, R., and Yin, W. "Iteratively reweighted algorithms for
@@ -505,7 +506,7 @@ def OMP(
 ):
     r"""Orthogonal Matching Pursuit (OMP).
 
-    Solve an optimization problem with :math:`L0` regularization function given
+    Solve an optimization problem with :math:`L^0` regularization function given
     the operator ``Op`` and data ``y``. The operator can be real or complex,
     and should ideally be either square :math:`N=M` or underdetermined
     :math:`N<M`.
@@ -522,7 +523,7 @@ def OMP(
         Number of iterations of inner loop. By choosing ``niter_inner=0``, the
         Matching Pursuit (MP) algorithm is implemented.
     sigma : :obj:`list`
-        Maximum L2 norm of residual. When smaller stop iterations.
+        Maximum :math:`L^2` norm of residual. When smaller stop iterations.
     normalizecols : :obj:`list`, optional
         Normalize columns (``True``) or not (``False``). Note that this can be
         expensive as it requires applying the forward operator
@@ -554,24 +555,26 @@ def OMP(
     :math:`\mathbf{Op}` and the data :math:`\mathbf{d}`:
 
     .. math::
-            ||\mathbf{x}||_0 \quad  subj. to \quad
-            ||\mathbf{Op}\mathbf{x}-\mathbf{b}||_2^2 <= \sigma^2,
+            \|\mathbf{x}\|_0 \quad  \text{subject to} \quad
+            \|\mathbf{Op}\,\mathbf{x}-\mathbf{b}\|_2^2 \leq \sigma^2,
 
     using Orthogonal Matching Pursuit (OMP). This is a very
     simple iterative algorithm which applies the following step:
 
     .. math::
-        \Lambda_k = \Lambda_{k-1} \cup \{ arg max_j
-        |\mathbf{Op}_j^H \mathbf{r}_k| \} \\
-        \mathbf{x}_k = arg min_{\mathbf{x}}
-        ||\mathbf{Op}_{\Lambda_k} \mathbf{x} - \mathbf{b}||_2^2
+        \DeclareMathOperator*{\argmin}{arg\,min}
+        \DeclareMathOperator*{\argmax}{arg\,max}
+        \Lambda_k = \Lambda_{k-1} \cup \left\{\argmax_j
+        \left|\mathbf{Op}_j^H\,\mathbf{r}_k\right| \right\} \\
+        \mathbf{x}_k = \argmin_{\mathbf{x}}
+        \left\|\mathbf{Op}_{\Lambda_k}\,\mathbf{x} - \mathbf{b}\right\|_2^2
 
     Note that by choosing ``niter_inner=0`` the basic Matching Pursuit (MP)
     algorithm is implemented instead. In other words, instead of solving an
     optimization at each iteration to find the best :math:`\mathbf{x}` for the
     currently selected basis functions, the vector :math:`\mathbf{x}` is just
     updated at the new basis function by taking directly the value from
-    the inner product :math:`\mathbf{Op}_j^H \mathbf{r}_k`.
+    the inner product :math:`\mathbf{Op}_j^H\,\mathbf{r}_k`.
 
     In this case it is highly reccomended to provide a normalized basis
     function. If different basis have different norms, the solver is likely
@@ -699,7 +702,7 @@ def ISTA(
 ):
     r"""Iterative Shrinkage-Thresholding Algorithm (ISTA).
 
-    Solve an optimization problem with :math:`L_p, \; p=0, 1/2, 1`
+    Solve an optimization problem with :math:`L^p, \; p=0, 0.5, 1`
     regularization, given the operator ``Op`` and data ``y``. The operator
     can be real or complex, and should ideally be either square :math:`N=M`
     or underdetermined :math:`N<M`.
@@ -715,7 +718,7 @@ def ISTA(
     eps : :obj:`float`, optional
         Sparsity damping
     alpha : :obj:`float`, optional
-        Step size (:math:`\alpha \le 1/\lambda_{max}(\mathbf{Op}^H\mathbf{Op})`
+        Step size (:math:`\alpha \le 1/\lambda_\text{max}(\mathbf{Op}^H\mathbf{Op})`
         guarantees convergence. If ``None``, the maximum eigenvalue is
         estimated and the optimal step size is chosen. If provided, the
         condition will not be checked internally).
@@ -779,38 +782,38 @@ def ISTA(
     :math:`\mathbf{Op}` and the data :math:`\mathbf{d}`:
 
     .. math::
-        J = ||\mathbf{d} - \mathbf{Op} \mathbf{x}||_2^2 +
-            \epsilon ||\mathbf{x}||_p
+        J = \|\mathbf{d} - \mathbf{Op}\,\mathbf{x}\|_2^2 +
+            \epsilon \|\mathbf{x}\|_p
 
     or the analysis problem:
 
     .. math::
-        J = ||\mathbf{d} - \mathbf{Op} \mathbf{x}||_2^2 +
-            \epsilon ||\mathbf{SOp}^H\mathbf{x}||_p
+        J = \|\mathbf{d} - \mathbf{Op}\,\mathbf{x}\|_2^2 +
+            \epsilon \|\mathbf{SOp}^H\,\mathbf{x}\|_p
 
     if ``SOp`` is provided. Note that in the first case, ``SOp`` should be
     assimilated in the modelling operator (i.e., ``Op=GOp * SOp``).
 
     The Iterative Shrinkage-Thresholding Algorithms (ISTA) [1]_ is used, where
-    :math:`p=0, 1, 1/2`. This is a very simple iterative algorithm which
+    :math:`p=0, 0.5, 1`. This is a very simple iterative algorithm which
     applies the following step:
 
     .. math::
-        \mathbf{x}^{(i+1)} = T_{(\epsilon \alpha /2, p)} (\mathbf{x}^{(i)} +
-        \alpha \mathbf{Op}^H (\mathbf{d} - \mathbf{Op} \mathbf{x}^{(i)}))
+        \mathbf{x}^{(i+1)} = T_{(\epsilon \alpha /2, p)} \left(\mathbf{x}^{(i)} +
+        \alpha\,\mathbf{Op}^H \left(\mathbf{d} - \mathbf{Op}\,\mathbf{x}^{(i)}\right)\right)
 
     or
 
     .. math::
-        \mathbf{x}^{(i+1)} = \mathbf{SOp}(T_{(\epsilon \alpha /2, p)}
-        (\mathbf{SOp}^H(\mathbf{x}^{(i)} + \alpha \mathbf{Op}^H (\mathbf{d} -
-        \mathbf{Op} \mathbf{x}^{(i)}))))
+        \mathbf{x}^{(i+1)} = \mathbf{SOp}\,\left\{T_{(\epsilon \alpha /2, p)}
+        \mathbf{SOp}^H\,\left(\mathbf{x}^{(i)} + \alpha\,\mathbf{Op}^H \left(\mathbf{d} -
+        \mathbf{Op} \,\mathbf{x}^{(i)}\right)\right)\right\}
 
     where :math:`\epsilon \alpha /2` is the threshold and :math:`T_{(\tau, p)}`
     is the thresholding rule. The most common variant of ISTA uses the
     so-called soft-thresholding rule :math:`T(\tau, p=1)`. Alternatively an
-    hard-thresholding rule is used in the case of `p=0` or a half-thresholding
-    rule is used in the case of `p=1/2`. Finally, percentile bases thresholds
+    hard-thresholding rule is used in the case of :math:`p=0` or a half-thresholding
+    rule is used in the case of :math:`p=1/2`. Finally, percentile bases thresholds
     are also implemented: the damping factor is not used anymore an the
     threshold changes at every iteration based on the computed percentile.
 
@@ -1024,7 +1027,7 @@ def FISTA(
 ):
     r"""Fast Iterative Shrinkage-Thresholding Algorithm (FISTA).
 
-    Solve an optimization problem with :math:`L_p, \; p=0, 1/2, 1`
+    Solve an optimization problem with :math:`L^p, \; p=0, 0.5, 1`
     regularization, given the operator ``Op`` and data ``y``.
     The operator can be real or complex, and should ideally be either square
     :math:`N=M` or underdetermined :math:`N<M`.
@@ -1040,7 +1043,7 @@ def FISTA(
     eps : :obj:`float`, optional
         Sparsity damping
     alpha : :obj:`float`, optional
-        Step size (:math:`\alpha \le 1/\lambda_{max}(\mathbf{Op}^H\mathbf{Op})`
+        Step size (:math:`\alpha \le 1/\lambda_\text{max}(\mathbf{Op}^H\mathbf{Op})`
         guarantees convergence. If ``None``, the maximum eigenvalue is
         estimated and the optimal step size is chosen. If provided, the
         condition will not be checked internally).
@@ -1102,19 +1105,19 @@ def FISTA(
     :math:`\mathbf{Op}` and the data :math:`\mathbf{d}`:
 
     .. math::
-        J = ||\mathbf{d} - \mathbf{Op} \mathbf{x}||_2^2 +
-            \epsilon ||\mathbf{x}||_p
+        J = \|\mathbf{d} - \mathbf{Op}\,\mathbf{x}\|_2^2 +
+            \epsilon \|\mathbf{x}\|_p
 
     or the analysis problem:
 
     .. math::
-        J = ||\mathbf{d} - \mathbf{Op} \mathbf{x}||_2^2 +
-            \epsilon ||\mathbf{SOp}^H\mathbf{x}||_p
+        J = \|\mathbf{d} - \mathbf{Op}\,\mathbf{x}\|_2^2 +
+            \epsilon \|\mathbf{SOp}^H\,\mathbf{x}\|_p
 
     if ``SOp`` is provided.
 
     The Fast Iterative Shrinkage-Thresholding Algorithm (FISTA) [1]_ is used,
-    where :math:`p=0, 1, 1/2`. This is a modified version of ISTA solver with
+    where :math:`p=0, 0.5, 1`. This is a modified version of ISTA solver with
     improved convergence properties and limited additional computational cost.
     Similarly to the ISTA solver, the choice of the thresholding algorithm to
     apply at every iteration is based on the choice of :math:`p`.
@@ -1344,45 +1347,45 @@ def SPGL1(Op, data, SOp=None, tau=0, sigma=0, x0=None, **kwargs_spgl1):
     info : :obj:`dict`
         Dictionary with the following information:
 
-        ``tau``, final value of tau (see sigma above)
+        - ``tau``, final value of tau (see sigma above)
 
-        ``rnorm``, two-norm of the optimal residual
+        - ``rnorm``, two-norm of the optimal residual
 
-        ``rgap``, relative duality gap (an optimality measure)
+        - ``rgap``, relative duality gap (an optimality measure)
 
-        ``gnorm``, Lagrange multiplier of (LASSO)
+        - ``gnorm``, Lagrange multiplier of (LASSO)
 
-        ``stat``,
-           ``1``: found a BPDN solution,
-           ``2``: found a BP solution; exit based on small gradient,
-           ``3``: found a BP solution; exit based on small residual,
-           ``4``: found a LASSO solution,
-           ``5``: error, too many iterations,
-           ``6``: error, linesearch failed,
-           ``7``: error, found suboptimal BP solution,
-           ``8``: error, too many matrix-vector products.
+        - ``stat``, final status of solver
+           * ``1``: found a BPDN solution,
+           * ``2``: found a BP solution; exit based on small gradient,
+           * ``3``: found a BP solution; exit based on small residual,
+           * ``4``: found a LASSO solution,
+           * ``5``: error, too many iterations,
+           * ``6``: error, linesearch failed,
+           * ``7``: error, found suboptimal BP solution,
+           * ``8``: error, too many matrix-vector products.
 
-        ``niters``, number of iterations
+        - ``niters``, number of iterations
 
-        ``nProdA``, number of multiplications with A
+        - ``nProdA``, number of multiplications with A
 
-        ``nProdAt``, number of multiplications with A'
+        - ``nProdAt``, number of multiplications with A'
 
-        ``n_newton``, number of Newton steps
+        - ``n_newton``, number of Newton steps
 
-        ``time_project``, projection time (seconds)
+        - ``time_project``, projection time (seconds)
 
-        ``time_matprod``, matrix-vector multiplications time (seconds)
+        - ``time_matprod``, matrix-vector multiplications time (seconds)
 
-        ``time_total``, total solution time (seconds)
+        - ``time_total``, total solution time (seconds)
 
-        ``niters_lsqr``, number of lsqr iterations (if ``subspace_min=True``)
+        - ``niters_lsqr``, number of lsqr iterations (if ``subspace_min=True``)
 
-        ``xnorm1``, L1-norm model solution history through iterations
+        - ``xnorm1``, L1-norm model solution history through iterations
 
-        ``rnorm2``, L2-norm residual history through iterations
+        - ``rnorm2``, L2-norm residual history through iterations
 
-        ``lambdaa``, Lagrange multiplier history through iterations
+        - ``lambdaa``, Lagrange multiplier history through iterations
 
     Raises
     ------
@@ -1398,15 +1401,16 @@ def SPGL1(Op, data, SOp=None, tau=0, sigma=0, x0=None, **kwargs_spgl1):
     its cost function is
 
         .. math::
-            ||\mathbf{x}||_1 \quad  subj. to \quad
-            ||\mathbf{Op}\mathbf{S}^H\mathbf{x}-\mathbf{b}||_2^2 <= \sigma,
+            \|\mathbf{x}\|_1 \quad  \text{subject to} \quad
+            \left\|\mathbf{Op}\,\mathbf{S}^H\mathbf{x}-\mathbf{b}\right\|_2^2
+            \leq \sigma,
 
-    while the second problem is the *l1-regularized least-squares or LASSO*
+    while the second problem is the *ℓ₁-regularized least-squares or LASSO*
     problem and its cost function is
 
         .. math::
-            ||\mathbf{Op}\mathbf{S}^H\mathbf{x}-\mathbf{b}||_2^2 \quad  subj.
-            to \quad  ||\mathbf{x}||_1  <= \tau
+            \left\|\mathbf{Op}\,\mathbf{S}^H\mathbf{x}-\mathbf{b}\right\|_2^2
+            \quad \text{subject to} \quad  \|\mathbf{x}\|_1  \leq \tau
 
     .. [1] van den Berg E., Friedlander M.P., "Probing the Pareto frontier
        for basis pursuit solutions", SIAM J. on Scientific Computing,
@@ -1448,16 +1452,17 @@ def SplitBregman(
 ):
     r"""Split Bregman for mixed L2-L1 norms.
 
-    Solve an unconstrained system of equations with mixed L2-L1 regularization
-    terms given the operator ``Op``, a list of L1 regularization terms
-    ``RegsL1``, and an optional list of L2 regularization terms ``RegsL2``.
+    Solve an unconstrained system of equations with mixed :math:`L^2` and :math:`L^1`
+    regularization terms given the operator ``Op``, a list of :math:`L^1`
+    regularization terms ``RegsL1``, and an optional list of :math:`L^2`
+    regularization terms ``RegsL2``.
 
     Parameters
     ----------
     Op : :obj:`pylops.LinearOperator`
         Operator to invert
     RegsL1 : :obj:`list`
-        L1 regularization operators
+        :math:`L^1` regularization operators
     data : :obj:`numpy.ndarray`
         Data
     niter_outer : :obj:`int`
@@ -1468,19 +1473,19 @@ def SplitBregman(
         for many applications optimal efficiency is obtained when only one
         iteration is performed.
     RegsL2 : :obj:`list`
-        Additional L2 regularization operators
-        (if ``None``, L2 regularization is not added to the problem)
+        Additional :math:`L^2` regularization operators
+        (if ``None``, :math:`L^2` regularization is not added to the problem)
     dataregsL2 : :obj:`list`, optional
-        L2 Regularization data (must have the same number of elements
+        :math:`L^2` Regularization data (must have the same number of elements
         of ``RegsL2`` or equal to ``None`` to use a zero data for every
         regularization operator in ``RegsL2``)
     mu : :obj:`float`, optional
          Data term damping
     epsRL1s : :obj:`list`
-         L1 Regularization dampings (must have the same number of elements
+         :math:`L^1` Regularization dampings (must have the same number of elements
          as ``RegsL1``)
     epsRL2s : :obj:`list`
-         L2 Regularization dampings (must have the same number of elements
+         :math:`L^2` Regularization dampings (must have the same number of elements
          as ``RegsL2``)
     tol : :obj:`float`, optional
         Tolerance. Stop outer iterations if difference between inverted model
@@ -1509,18 +1514,22 @@ def SplitBregman(
     Notes
     -----
     Solve the following system of unconstrained, regularized equations
-    given the operator :math:`\mathbf{Op}` and a set of mixed norm (L2 and L1)
-    regularization terms :math:`\mathbf{R_{L2,i}}` and
-    :math:`\mathbf{R_{L1,i}}`, respectively:
+    given the operator :math:`\mathbf{Op}` and a set of mixed norm
+    (:math:`L^2` and :math:`L^1`)
+    regularization terms :math:`\mathbf{R}_{2,i}` and
+    :math:`\mathbf{R}_{1,i}`, respectively:
 
     .. math::
-        J = \mu/2 ||\textbf{d} - \textbf{Op} \textbf{x} |||_2^2 +
-        \sum_i \epsilon_{{R}_{L2,i}}/2 ||\mathbf{d_{{R}_{L2,i}}} -
-        \mathbf{R_{L2,i}} \textbf{x} |||_2^2 +
-        \sum_i || \mathbf{R_{L1,i}} \textbf{x} |||_1
+        J = \frac{\mu}{2} \|\textbf{d} - \textbf{Op}\,\textbf{x} \|_2^2 +
+        \frac{1}{2}\sum_i \epsilon_{\mathbf{R}_{2,i}} \|\mathbf{d}_{\mathbf{R}_{2,i}} -
+        \mathbf{R}_{2,i} \textbf{x} \|_2^2 +
+        \sum_i \epsilon_{\mathbf{R}_{1,i}} \| \mathbf{R}_{1,i} \textbf{x} \|_1
 
-    where :math:`\mu` and :math:`\epsilon_{{R}_{L2,i}}` are the damping factors
-    used to weight the different L2 regularization terms of the cost function.
+    where :math:`\mu` is the reconstruction damping, :math:`\epsilon_{\mathbf{R}_{2,i}}`
+    are the damping factors used to weight the different :math:`L^2` regularization
+    terms of the cost function and :math:`\epsilon_{\mathbf{R}_{1,i}}`
+    are the damping factors used to weight the different :math:`L^1` regularization
+    terms of the cost function.
 
     The generalized Split-Bergman algorithm [1]_ is used to solve such cost
     function: the algorithm is composed of a sequence of unconstrained
@@ -1530,26 +1539,30 @@ def SplitBregman(
     problem:
 
     .. math::
-        J = \mu/2 ||\textbf{d} - \textbf{Op} \textbf{x}||_2^2 +
-        \sum_i \epsilon_{{R}_{L2,i}}/2 ||\mathbf{d_{{R}_{L2,i}}} -
-        \mathbf{R_{L2,i}} \textbf{x}||_2^2 +
-        \sum_i || \textbf{y}_i ||_1 \quad s.t \quad
-        \textbf{y}_i = \mathbf{R_{L1,i}} \textbf{x} \quad \forall i
+        J = \frac{\mu}{2} \|\textbf{d} - \textbf{Op}\,\textbf{x}\|_2^2 +
+        \frac{1}{2}\sum_i \epsilon_{\mathbf{R}_{2,i}} \|\mathbf{d}_{\mathbf{R}_{2,i}} -
+        \mathbf{R}_{2,i} \textbf{x}\|_2^2 +
+        \sum_i \| \textbf{y}_i \|_1 \quad \text{subject to} \quad
+        \textbf{y}_i = \mathbf{R}_{1,i} \textbf{x} \quad \forall i
 
     and solved as follows:
 
     .. math::
+        \DeclareMathOperator*{\argmin}{arg\,min}
+        \begin{align}
         (\textbf{x}^{k+1}, \textbf{y}_i^{k+1}) =
-        \operatorname*{arg\,min}_{\mathbf{x}, \mathbf{y}_i}
-        ||\textbf{d} - \textbf{Op} \textbf{x}||_2^2 +
-        \sum_i \epsilon_{{R}_{L2,i}}/2 ||\mathbf{d_{{R}_{L2,i}}} -
-        \mathbf{R_{L2,i}} \textbf{x}||_2^2 + \sum_i || \textbf{y}_i ||_1 +
-        \sum_i \epsilon_{{R}_{L1,i}}/2 ||\textbf{y}_i -
-        \mathbf{R_{L1,i}} \textbf{x} - \textbf{b}_i^k||_2^2
+        \argmin_{\mathbf{x}, \mathbf{y}_i}
+        \|\textbf{d} - \textbf{Op}\,\textbf{x}\|_2^2
+        &+ \frac{1}{2}\sum_i \epsilon_{\mathbf{R}_{2,i}} \|\mathbf{d}_{\mathbf{R}_{2,i}} -
+        \mathbf{R}_{2,i} \textbf{x}\|_2^2 \\
+        &+ \frac{1}{2}\sum_i \epsilon_{\mathbf{R}_{1,i}} \|\textbf{y}_i -
+        \mathbf{R}_{1,i} \textbf{x} - \textbf{b}_i^k\|_2^2 \\
+        &+ \sum_i \| \textbf{y}_i \|_1
+        \end{align}
 
     .. math::
         \textbf{b}_i^{k+1}=\textbf{b}_i^k +
-        (\mathbf{R_{L1,i}} \textbf{x}^{k+1} - \textbf{y}^{k+1})
+        (\mathbf{R}_{1,i} \textbf{x}^{k+1} - \textbf{y}^{k+1})
 
     The :py:func:`scipy.sparse.linalg.lsqr` solver and a fast shrinkage
     algorithm are used within a inner loop to solve the first step. The entire

--- a/pylops/signalprocessing/Bilinear.py
+++ b/pylops/signalprocessing/Bilinear.py
@@ -26,7 +26,7 @@ class Bilinear(LinearOperator):
     Parameters
     ----------
     iava : :obj:`list` or :obj:`numpy.ndarray`
-         Array of size :math:`[2 \times n_{ava}]` containing
+         Array of size :math:`[2 \times n_\text{ava}]` containing
          pairs of floating indices of locations of available samples
          for interpolation.
     dims : :obj:`list`
@@ -59,7 +59,7 @@ class Bilinear(LinearOperator):
             w^0_{i} (1-w^1_{i}) x_{l^{r,0}_i, l^{l,1}_i} +
             (1-w^0_{i}) w^1_{i} x_{l^{l,0}_i, l^{r,1}_i} +
             w^0_{i} w^1_{i} x_{l^{r,0}_i, l^{r,1}_i}
-        \quad \forall i=1,2,...,M
+        \quad \forall i=1,2,\ldots,M
 
     where :math:`\mathbf{l^{l,0}}=[\lfloor l_1^0 \rfloor,
     \lfloor l_2^0 \rfloor, ..., \lfloor l_N^0 \rfloor]`,

--- a/pylops/signalprocessing/ChirpRadon2D.py
+++ b/pylops/signalprocessing/ChirpRadon2D.py
@@ -28,9 +28,9 @@ class ChirpRadon2D(LinearOperator):
         Spatial axis
     pmax : :obj:`np.ndarray`
         Maximum slope defined as :math:`\tan` of maximum stacking angle in
-        :math:`x` direction :math:`p_{max} = \tan(\alpha_{x, max})`.
+        :math:`x` direction :math:`p_\text{max} = \tan(\alpha_{x, \text{max}})`.
         If one operates in terms of minimum velocity :math:`c_0`, set
-        :math:`p_{x, max}=c_0 dy/dt`.
+        :math:`p_{x, \text{max}}=c_0 \,\mathrm{d}y/\mathrm{d}t`.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 

--- a/pylops/signalprocessing/ChirpRadon3D.py
+++ b/pylops/signalprocessing/ChirpRadon3D.py
@@ -45,11 +45,11 @@ class ChirpRadon3D(LinearOperator):
     hyaxis : :obj:`np.ndarray`
         Slow spatial axis
     pmax : :obj:`np.ndarray`
-        Two element array :math:`(p_{y,max}, p_{x,max})` of :math:`\tan`
+        Two element array :math:`(p_{y,\text{max}}, p_{x,\text{max}})` of :math:`\tan`
         of maximum stacking angles in :math:`y` and :math:`x` directions
-        :math:`(\tan(\alpha_{y,max}), \tan(\alpha_{x,max}))`. If one operates
+        :math:`(\tan(\alpha_{y,\text{max}}), \tan(\alpha_{x,\text{max}}))`. If one operates
         in terms of minimum velocity :math:`c_0`, then
-        :math:`p_{y.max}=c_0dy/dt` and :math:`p_{x,max}=c_0dx/dt`
+        :math:`p_{y,\text{max}}=c_0\,\mathrm{d}y/\mathrm{d}t` and :math:`p_{x,\text{max}}=c_0\,\mathrm{d}x/\mathrm{d}t`
     engine : :obj:`str`, optional
         Engine used for fft computation (``numpy`` or ``fftw``)
     dtype : :obj:`str`, optional

--- a/pylops/signalprocessing/Convolve1D.py
+++ b/pylops/signalprocessing/Convolve1D.py
@@ -81,12 +81,12 @@ class Convolve1D(LinearOperator):
     :math:`x(t)` and a compact filter kernel :math:`h(t)` in forward model:
 
     .. math::
-        y(t) = \int_{-\inf}^{\inf} h(t-\tau) x(\tau) d\tau
+        y(t) = \int\limits_{-\infty}^{\infty} h(t-\tau) x(\tau) \,\mathrm{d}\tau
 
     This operation can be discretized as follows
 
     .. math::
-        y[n] = \sum_{m=-\inf}^{\inf} h[n-m] x[m]
+        y[n] = \sum_{m=-\infty}^{\infty} h[n-m] x[m]
 
     as well as performed in the frequency domain.
 
@@ -106,7 +106,7 @@ class Convolve1D(LinearOperator):
     In time domain:
 
     .. math::
-        x(t) = \int_{-\inf}^{\inf} h(t+\tau) x(\tau) d\tau
+        x(t) = \int\limits_{-\infty}^{\infty} h(t+\tau) x(\tau) \,\mathrm{d}\tau
 
     or in frequency domain:
 

--- a/pylops/signalprocessing/Convolve2D.py
+++ b/pylops/signalprocessing/Convolve2D.py
@@ -20,7 +20,7 @@ def Convolve2D(N, h, dims, offset=(0, 0), nodir=None, dtype="float64", method="f
         Indeces of the center of the compact filter
     nodir : :obj:`int`, optional
         Direction along which convolution is NOT applied
-        (set to None for 2d arrays)
+        (set to ``None`` for 2d arrays)
     dtype : :obj:`str`, optional
         Type of elements in input array.
     method : :obj:`str`, optional
@@ -38,13 +38,13 @@ def Convolve2D(N, h, dims, offset=(0, 0), nodir=None, dtype="float64", method="f
     :math:`h(t,x)` in forward model:
 
     .. math::
-        y(t,x) = \int_{-\inf}^{\inf}\int_{-\inf}^{\inf}
-        h(t-\tau,x-\chi) d(\tau,\chi) d\tau d\chi
+        y(t,x) = \iint\limits_{-\infty}^{\infty}
+        h(t-\tau,x-\chi) d(\tau,\chi) \,\mathrm{d}\tau \,\mathrm{d}\chi
 
     This operation can be discretized as follows
 
     .. math::
-        y[i,n] = \sum_{j=-\inf}^{\inf} \sum_{m=-\inf}^{\inf} h[i-j,n-m] d[j,m]
+        y[i,n] = \sum_{j=-\infty}^{\infty} \sum_{m=-\infty}^{\infty} h[i-j,n-m] d[j,m]
 
 
     as well as performed in the frequency domain.
@@ -62,8 +62,8 @@ def Convolve2D(N, h, dims, offset=(0, 0), nodir=None, dtype="float64", method="f
     In time domain:
 
     .. math::
-        y(t,x) = \int_{-\inf}^{\inf}\int_{-\inf}^{\inf}
-        h(t+\tau,x+\chi) d(\tau,\chi) d\tau d\chi
+        y(t,x) = \iint\limits_{-\infty}^{\infty}
+        h(t+\tau,x+\chi) d(\tau,\chi) \,\mathrm{d}\tau \,\mathrm{d}\chi
 
     or in frequency domain:
 

--- a/pylops/signalprocessing/DWT.py
+++ b/pylops/signalprocessing/DWT.py
@@ -71,7 +71,7 @@ class DWT(LinearOperator):
         Operator shape
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------

--- a/pylops/signalprocessing/DWT2D.py
+++ b/pylops/signalprocessing/DWT2D.py
@@ -47,7 +47,7 @@ class DWT2D(LinearOperator):
         Operator shape
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -385,11 +385,11 @@ def FFT(
     forward mode, and to :py:func:`scipy.fft.ifft` (or :py:func:`scipy.fft.irfft`
     for real models) in adjoint mode.
 
-    When using `real=True`, the result of the forward is also multiplied by
+    When using ``real=True``, the result of the forward is also multiplied by
     :math:`\sqrt{2}` for all frequency bins except zero and Nyquist, and the input of
     the adjoint is multiplied by :math:`1 / \sqrt{2}` for the same frequencies.
 
-    For a real valued input signal, it is advised to use the flag `real=True`
+    For a real valued input signal, it is advised to use the flag ``real=True``
     as it stores the values of the Fourier transform at positive frequencies only as
     values at negative frequencies are simply their complex conjugates.
 
@@ -404,13 +404,16 @@ def FFT(
     sampling : :obj:`float`, optional
         Sampling step ``dt``.
     norm : `{"ortho", "none", "1/n"}`, optional
-        * "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
-        where :math:`N_F` is the number of samples in the Fourier domain given by ``nfft``.
-        * "none": Does not scale the forward or the adjoint FFT transforms.
-        * "1/n": Scales both the forward and adjoint FFT transforms by
-        :math:`1/N_F`.
-        Note that for "none" and "1/n", the operator is not unitary, that is,
-        the adjoint is not the inverse. To invert the operator, simply use `Op \ y`.
+        - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
+          where :math:`N_F` is the number of samples in the Fourier domain given by ``nfft``.
+
+        - "none": Does not scale the forward or the adjoint FFT transforms.
+
+        - "1/n": Scales both the forward and adjoint FFT transforms by
+          :math:`1/N_F`.
+
+        .. note:: For "none" and "1/n", the operator is not unitary, that is, the
+          adjoint is not the inverse. To invert the operator, simply use ``Op \ y``.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -438,7 +441,7 @@ def FFT(
         Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
         In addition, note that neither the NumPy nor the FFTW backends supports
-        returning ``dtype``s different than ``complex128``. As such, when using either
+        returning ``dtype`` different than ``complex128``. As such, when using either
         backend, arrays will be force-casted to types corresponding to the supplied ``dtype``.
         The SciPy backend supports all precisions natively.
         Under all backends, when a real ``dtype`` is supplied, a real result will be
@@ -450,12 +453,13 @@ def FFT(
     Attributes
     ----------
     dims_fft : :obj:`tuple`
-        Shape of the array after the forward, but before linearization. E.g.
-        ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+        Shape of the array after the forward, but before linearization.
+
+        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
     f : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies
     real : :obj:`bool`
-        When True, uses ``rfft``/``irfft``
+        When ``True``, uses ``rfft``/``irfft``
     rdtype : :obj:`bool`
         Expected input type to the forward
     cdtype : :obj:`bool`
@@ -467,35 +471,41 @@ def FFT(
         ``dtype`` is not a complex type.
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------
     ValueError
-        If ``dims`` is provided and ``dir`` is bigger than ``len(dims)``
-        If ``norm`` is not one of "ortho", "none", or "1/n".
+        - If ``dims`` is provided and ``dir`` is bigger than ``len(dims)``.
+        - If ``norm`` is not one of "ortho", "none", or "1/n".
     NotImplementedError
         If ``engine`` is neither ``numpy``, ``fftw``, nor ``scipy``.
 
+    See Also
+    --------
+    FFT2D: Two-dimensional FFT
+    FFTND: N-dimensional FFT
+
+
     Notes
     -----
-    The FFT operator (using `norm="ortho"`) applies the forward Fourier transform to
+    The FFT operator (using ``norm="ortho"``) applies the forward Fourier transform to
     a signal
     :math:`d(t)` in forward mode:
 
     .. math::
-        D(f) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}} \int d(t) e^{-j2\pi ft} dt
+        D(f) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}} \int\limits_{-\infty}^\infty d(t) e^{-j2\pi ft} \,\mathrm{d}t
 
     Similarly, the inverse Fourier transform is applied to the Fourier spectrum
     :math:`D(f)` in adjoint mode:
 
     .. math::
-        d(t) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}} \int D(f) e^{j2\pi ft} df
+        d(t) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}} \int\limits_{-\infty}^\infty D(f) e^{j2\pi ft} \,\mathrm{d}f
 
     where :math:`N_F` is the number of samples in the Fourier domain ``nfft``.
     Both operators are effectively discretized and solved by a fast iterative
     algorithm known as Fast Fourier Transform. Note that the FFT operator
-    (using `norm="ortho"`) is a special operator in that the adjoint is also
+    (using ``norm="ortho"``) is a special operator in that the adjoint is also
     the inverse of the forward mode. For other norms, this does not hold (see ``norm``
     help). However, for any norm, the Fourier transform is Hermitian for real input
     signals.

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -227,14 +227,13 @@ def FFT2D(
     forward mode, and to :py:func:`scipy.fft.ifft2` (or :py:func:`scipy.fft.irfft2`
     for real models) in adjoint mode.
 
-    When using `real=True`, the result of the forward is also multiplied by
+    When using ``real=True``, the result of the forward is also multiplied by
     :math:`\sqrt{2}` for all frequency bins except zero and Nyquist, and the input of
     the adjoint is multiplied by :math:`1 / \sqrt{2}` for the same frequencies.
 
     For a real valued input signal, it is advised to use the flag ``real=True``
     as it stores the values of the Fourier transform of the last direction at positive
     frequencies only as values at negative frequencies are simply their complex conjugates.
-
 
     Parameters
     ----------
@@ -251,17 +250,20 @@ def FFT2D(
         equivalent to ``nffts=(None, None)``.
     sampling : :obj:`tuple` or :obj:`float`, optional
         Sampling steps for each direction. When supplied a single value, it is used
-        for both directions. Unlike ``nffts``, ``None``s will not be converted to the
+        for both directions. Unlike ``nffts``, any ``None`` will not be converted to the
         default value.
     norm : `{"ortho", "none", "1/n"}`, optional
-        * "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
-        where :math:`N_F` is the number of samples in the Fourier domain given by
-        product of all elements of ``nffts``.
-        * "none": Does not scale the forward or the adjoint FFT transforms.
-        * "1/n": Scales both the forward and adjoint FFT transforms by
-        :math:`1/N_F`.
-        Note that for "none" and "1/n", the operator is not unitary, that is,
-        the adjoint is not the inverse. To invert the operator, simply use `Op \ y`.
+        - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
+          where :math:`N_F` is the number of samples in the Fourier domain given by
+          product of all elements of ``nffts``.
+
+        - "none": Does not scale the forward or the adjoint FFT transforms.
+
+        - "1/n": Scales both the forward and adjoint FFT transforms by
+          :math:`1/N_F`.
+
+        .. note:: For "none" and "1/n", the operator is not unitary, that is, the
+          adjoint is not the inverse. To invert the operator, simply use ``Op \ y``.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -290,7 +292,7 @@ def FFT2D(
     dtype : :obj:`str`, optional
         Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
-        In addition, note that the NumPy backend does not support returning ``dtype``s
+        In addition, note that the NumPy backend does not support returning ``dtype``
         different than ``complex128``. As such, when using the NumPy backend, arrays will
         be force-casted to types corresponding to the supplied ``dtype``.
         The SciPy backend supports all precisions natively.
@@ -300,14 +302,15 @@ def FFT2D(
     Attributes
     ----------
     dims_fft : :obj:`tuple`
-        Shape of the array after the forward, but before linearization. E.g.
-        ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+        Shape of the array after the forward, but before linearization.
+
+        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
     f1 : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies along ``dir[0]``
     f2 : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies along ``dir[1]``
     real : :obj:`bool`
-        When True, uses ``rfft2``/``irfft2``
+        When ``True``, uses ``rfft2``/``irfft2``
     rdtype : :obj:`bool`
         Expected input type to the forward
     cdtype : :obj:`bool`
@@ -319,40 +322,45 @@ def FFT2D(
         ``dtype`` is not a complex type.
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------
     ValueError
-        If ``dims`` has less than two elements.
-        If ``dirs`` does not have exactly two elements.
-        If ``nffts`` or ``sampling`` are not either a single value or a tuple with
-        two elements.
-        If ``norm`` is not one of "ortho", "none", or "1/n".
+        - If ``dims`` has less than two elements.
+        - If ``dirs`` does not have exactly two elements.
+        - If ``nffts`` or ``sampling`` are not either a single value or a tuple with
+          two elements.
+        - If ``norm`` is not one of "ortho", "none", or "1/n".
     NotImplementedError
         If ``engine`` is neither ``numpy``, nor ``scipy``.
 
+    See Also
+    --------
+    FFT: One-dimensional FFT
+    FFTND: N-dimensional FFT
+
     Notes
     -----
-    The FFT2D operator (using `norm="ortho"`) applies the two-dimensional forward
+    The FFT2D operator (using ``norm="ortho"``) applies the two-dimensional forward
     Fourier transform to a signal :math:`d(y, x)` in forward mode:
 
     .. math::
-        D(k_y, k_x) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}} \int \int d(y, x) e^{-j2\pi k_yy}
-        e^{-j2\pi k_xx} dy dx
+        D(k_y, k_x) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}} \iint\limits_{-\infty}^\infty d(y, x) e^{-j2\pi k_yy}
+        e^{-j2\pi k_xx} \,\mathrm{d}y \,\mathrm{d}x
 
     Similarly, the  two-dimensional inverse Fourier transform is applied to
     the Fourier spectrum :math:`D(k_y, k_x)` in adjoint mode:
 
     .. math::
-        d(y,x) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}} \int \int D(k_y, k_x) e^{j2\pi k_yy}
-        e^{j2\pi k_xx} dk_y  dk_x
+        d(y,x) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}} \iint\limits_{-\infty}^\infty D(k_y, k_x) e^{j2\pi k_yy}
+        e^{j2\pi k_xx} \,\mathrm{d}k_y  \,\mathrm{d}k_x
 
     where :math:`N_F` is the number of samples in the Fourier domain given by the
     product of the element of ``nffts``.
     Both operators are effectively discretized and solved by a fast iterative
     algorithm known as Fast Fourier Transform. Note that the FFT2D operator
-    (using `norm="ortho"`) is a special operator in that the adjoint is also
+    (using ``norm="ortho"``) is a special operator in that the adjoint is also
     the inverse of the forward mode. For other norms, this does not hold (see ``norm``
     help). However, for any norm, the 2D Fourier transform is Hermitian for real input
     signals.

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -209,7 +209,7 @@ def FFTND(
     forward mode, and to :py:func:`scipy.fft.ifftn` (or :py:func:`scipy.fft.irfftn`
     for real models) in adjoint mode.
 
-    When using `real=True`, the result of the forward is also multiplied by
+    When using ``real=True``, the result of the forward is also multiplied by
     :math:`\sqrt{2}` for all frequency bins except zero and Nyquist along the last
     direction of ``dirs``, and the input of the adjoint is multiplied by
     :math:`1 / \sqrt{2}` for the same frequencies.
@@ -233,17 +233,20 @@ def FFTND(
         equivalent to ``nffts=(None,..., None)``.
     sampling : :obj:`tuple` or :obj:`float`, optional
         Sampling steps for each direction. When supplied a single value, it is used
-        for all directions. Unlike ``nffts``, ``None``s will not be converted to the
+        for all directions. Unlike ``nffts``, any ``None`` will not be converted to the
         default value.
     norm : `{"ortho", "none", "1/n"}`, optional
-        * "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
-        where :math:`N_F` is the number of samples in the Fourier domain given by
-        product of all elements of ``nffts``.
-        * "none": Does not scale the forward or the adjoint FFT transforms.
-        * "1/n": Scales both the forward and adjoint FFT transforms by
-        :math:`1/N_F`.
-        Note that for "none" and "1/n", the operator is not unitary, that is,
-        the adjoint is not the inverse. To invert the operator, simply use `Op \ y`.
+        - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
+          where :math:`N_F` is the number of samples in the Fourier domain given by
+          product of all elements of ``nffts``.
+
+        - "none": Does not scale the forward or the adjoint FFT transforms.
+
+        - "1/n": Scales both the forward and adjoint FFT transforms by
+          :math:`1/N_F`.
+
+        .. note:: For "none" and "1/n", the operator is not unitary, that is, the
+          adjoint is not the inverse. To invert the operator, simply use ``Op \ y``.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -272,7 +275,7 @@ def FFTND(
     dtype : :obj:`str`, optional
         Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
-        In addition, note that the NumPy backend does not support returning ``dtype``s
+        In addition, note that the NumPy backend does not support returning ``dtype``
         different than ``complex128``. As such, when using the NumPy backend, arrays will
         be force-casted to types corresponding to the supplied ``dtype``.
         The SciPy backend supports all precisions natively.
@@ -282,13 +285,14 @@ def FFTND(
     Attributes
     ----------
     dims_fft : :obj:`tuple`
-        Shape of the array after the forward, but before linearization. E.g.
-        ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+        Shape of the array after the forward, but before linearization.
+
+        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
     fs : :obj:`tuple`
         Each element of the tuple corresponds to the Discrete Fourier Transform
         sample frequencies along the respective direction given by ``dirs``.
     real : :obj:`bool`
-        When True, uses ``rfftn``/``irfftn``
+        When ``True``, uses ``rfftn``/``irfftn``
     rdtype : :obj:`bool`
         Expected input type to the forward
     cdtype : :obj:`bool`
@@ -300,44 +304,50 @@ def FFTND(
         ``dtype`` is not a complex type.
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
+
+    See Also
+    --------
+    FFT: One-dimensional FFT
+    FFT2D: Two-dimensional FFT
 
     Raises
     ------
     ValueError
-        If ``nffts`` or ``sampling`` are not either a single value or tuple with
-        the same dimension ``dirs``.
-        If ``norm`` is not one of "ortho", "none", or "1/n".
+        - If ``nffts`` or ``sampling`` are not either a single value or tuple with
+          the same dimension ``dirs``.
+        - If ``norm`` is not one of "ortho", "none", or "1/n".
     NotImplementedError
         If ``engine`` is neither ``numpy``, nor ``scipy``.
 
     Notes
     -----
-    The FFTND operator applies the N-dimensional forward Fourier transform
-    to a multi-dimensional array. Considering an N-dimensional signal
-    :math:`d(x_1, \ldots, x_N)`.
-    The FFTND in forward mode is:
+    The FFTND operator (using ``norm="ortho"``) applies the N-dimensional forward
+    Fourier transform to a multi-dimensional array. Considering an N-dimensional
+    signal :math:`d(x_1, \ldots, x_N)`. The FFTND in forward mode is:
 
     .. math::
-        D(k_1, \ldots, k_N) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}} \int \int
+        D(k_1, \ldots, k_N) = \mathscr{F} (d) = \frac{1}{\sqrt{N_F}}
+        \int\limits_{-\infty}^\infty \cdots \int\limits_{-\infty}^\infty
         d(x_1, \ldots, x_N)
         e^{-j2\pi k_1 x_1} \cdots
-        e^{-j 2 \pi k_N x_N}  dx_1 \cdots dx_N
+        e^{-j 2 \pi k_N x_N}  \,\mathrm{d}x_1 \cdots \mathrm{d}x_N
 
     Similarly, the  three-dimensional inverse Fourier transform is applied to
     the Fourier spectrum :math:`D(k_z, k_y, k_x)` in adjoint mode:
 
     .. math::
-        d(x_1, \ldots, x_N) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}}  \int \int
+        d(x_1, \ldots, x_N) = \mathscr{F}^{-1} (D) = \frac{1}{\sqrt{N_F}}
+        \int\limits_{-\infty}^\infty \cdots \int\limits_{-\infty}^\infty
         D(k_1, \ldots, k_N)
         e^{-j2\pi k_1 x_1} \cdots
-        e^{-j 2 \pi k_N x_N} dk_1 \cdots  dk_N
+        e^{-j 2 \pi k_N x_N} \,\mathrm{d}k_1 \cdots  \mathrm{d}k_N
 
     where :math:`N_F` is the number of samples in the Fourier domain given by the
     product of the element of ``nffts``.
     Both operators are effectively discretized and solved by a fast iterative
     algorithm known as Fast Fourier Transform. Note that the FFTND operator
-    (using `norm="ortho"`) is a special operator in that the adjoint is also
+    (using ``norm="ortho"``) is a special operator in that the adjoint is also
     the inverse of the forward mode. For other norms, this does not hold (see ``norm``
     help). However, for any norm, the N-dimensional Fourier transform is Hermitian
     for real input signals.

--- a/pylops/signalprocessing/Fredholm1.py
+++ b/pylops/signalprocessing/Fredholm1.py
@@ -19,12 +19,12 @@ class Fredholm1(LinearOperator):
     ----------
     G : :obj:`numpy.ndarray`
         Multi-dimensional convolution kernel of size
-        :math:`[n_{slice} \times n_x \times n_y]`
+        :math:`[n_{\text{slice}} \times n_x \times n_y]`
     nz : :obj:`numpy.ndarray`, optional
         Additional dimension of model
     saveGt : :obj:`bool`, optional
-        Save ``G`` and ``G^H`` to speed up the computation of adjoint
-        (``True``) or create ``G^H`` on-the-fly (``False``)
+        Save ``G`` and ``G.H`` to speed up the computation of adjoint
+        (``True``) or create ``G.H`` on-the-fly (``False``)
         Note that ``saveGt=True`` will double the amount of required memory
     usematmul : :obj:`bool`, optional
         Use :func:`numpy.matmul` (``True``) or for-loop with :func:`numpy.dot`
@@ -50,31 +50,31 @@ class Fredholm1(LinearOperator):
 
     .. math::
 
-        d(sl, x, z) = \int{G(sl, x, y) m(sl, y, z) dy}
-        \quad \forall sl=1,n_{slice}
+        d(k, x, z) = \int{G(k, x, y) m(k, y, z) \,\mathrm{d}y}
+        \quad \forall k=1,\ldots,n_{slice}
 
     on the other hand its adjoin is expressed as
 
     .. math::
 
-        m(sl, y, z) = \int{G^*(sl, y, x) d(sl, x, z) dx}
-        \quad \forall sl=1,n_{slice}
+        m(k, y, z) = \int{G^*(k, y, x) d(k, x, z) \,\mathrm{d}x}
+        \quad \forall k=1,\ldots,n_{\text{slice}}
 
     In discrete form, this operator can be seen as a block-diagonal
     matrix multiplication:
 
     .. math::
         \begin{bmatrix}
-            \mathbf{G}_{sl1}  & \mathbf{0}       &  ... & \mathbf{0} \\
-            \mathbf{0}        & \mathbf{G}_{sl2} &  ... & \mathbf{0} \\
-            ...               & ...              &  ... & ...        \\
-            \mathbf{0}        & \mathbf{0}       &  ... & \mathbf{G}_{slN}
+            \mathbf{G}_{k=1}  & \mathbf{0}       &  \ldots & \mathbf{0} \\
+            \mathbf{0}        & \mathbf{G}_{k=2} &  \ldots & \mathbf{0} \\
+            \vdots            & \vdots           &  \ddots & \vdots        \\
+            \mathbf{0}        & \mathbf{0}       &  \ldots & \mathbf{G}_{k=N}
         \end{bmatrix}
         \begin{bmatrix}
-            \mathbf{m}_{sl1}  \\
-            \mathbf{m}_{sl2}  \\
-            ...     \\
-            \mathbf{m}_{slN}
+            \mathbf{m}_{k=1}  \\
+            \mathbf{m}_{k=2}  \\
+            \vdots            \\
+            \mathbf{m}_{k=N}
         \end{bmatrix}
 
     """

--- a/pylops/signalprocessing/Interp.py
+++ b/pylops/signalprocessing/Interp.py
@@ -167,11 +167,11 @@ def Interp(M, iava, dims=None, dir=0, kind="linear", dtype="float64"):
     .. math::
 
         y_i = (1-w_i) x_{l^{l}_i} + w_i x_{l^{r}_i}
-        \quad \forall i=1,2,...,N
+        \quad \forall i=1,2,\ldots,N
 
-    where :math:`\mathbf{l^l}=[\lfloor l_1 \rfloor, \lfloor l_2 \rfloor,...,
+    where :math:`\mathbf{l^l}=[\lfloor l_1 \rfloor, \lfloor l_2 \rfloor,\ldots,
     \lfloor l_N \rfloor]` and :math:`\mathbf{l^r}=[\lfloor l_1 \rfloor +1,
-    \lfloor l_2 \rfloor +1,...,
+    \lfloor l_2 \rfloor +1,\ldots,
     \lfloor l_N \rfloor +1]` are vectors containing the indeces
     of the original array at which samples are taken, and
     :math:`\mathbf{w}=[l_1 - \lfloor l_1 \rfloor, l_2 - \lfloor l_2 \rfloor,
@@ -185,8 +185,8 @@ def Interp(M, iava, dims=None, dir=0, kind="linear", dtype="float64"):
     :math:`M` can be expressed as:
 
     .. math::
-
-        y_i = \sum_{j=0}^{M} x_j sinc(i-j) \quad \forall i=1,2,...,N
+        \DeclareMathOperator{\sinc}{sinc}
+        y_i = \sum_{j=0}^{M} x_j \sinc(i-j) \quad \forall i=1,2,\ldots,N
 
     This operator can be implemented using the :class:`pylops.MatrixMult`
     operator with a matrix containing the values of the sinc function at all

--- a/pylops/signalprocessing/Radon2D.py
+++ b/pylops/signalprocessing/Radon2D.py
@@ -116,7 +116,7 @@ def Radon2D(
     r"""Two dimensional Radon transform.
 
     Apply two dimensional Radon forward (and adjoint) transform to a
-    2-dimensional array of size :math:`[n_{px} \times n_t]`
+    2-dimensional array of size :math:`[n_{p_x} \times n_t]`
     (and :math:`[n_x \times n_t]`).
 
     In forward mode this entails to spreading the model vector
@@ -135,7 +135,7 @@ def Radon2D(
     kind : :obj:`str`, optional
         Curve to be used for stacking/spreading (``linear``, ``parabolic``,
         and ``hyperbolic`` are currently supported) or a function that takes
-        (x, t0, px) as input and returns t as output
+        :math:`(x, t_0, p_x)` as input and returns :math:`t` as output
     centeredh : :obj:`bool`, optional
         Assume centered spatial axis (``True``) or not (``False``). If ``True``
         the original ``haxis`` is ignored and a new axis is created.
@@ -176,11 +176,11 @@ def Radon2D(
     size :math:`[n_x \times n_t]` in adjoint mode:
 
     .. math::
-        m(p_x, t_0) = \int{d(x, t = f(p_x, x, t))} dx
+        m(p_x, t_0) = \int{d(x, t = f(p_x, x, t))} \,\mathrm{d}x
 
-    where :math:`f(p_x, x, t) = t_0 + p_x * x` where
-    :math:`p_x = sin(\theta)/v` in linear mode,
-    :math:`f(p_x, x, t) = t_0 + p_x * x^2` in parabolic mode, and
+    where :math:`f(p_x, x, t) = t_0 + p_x x` where
+    :math:`p_x = \sin(\theta)/v` in linear mode,
+    :math:`f(p_x, x, t) = t_0 + p_x x^2` in parabolic mode, and
     :math:`f(p_x, x, t) = \sqrt{t_0^2 + x^2 / p_x^2}` in hyperbolic mode. Note
     that internally the :math:`p_x` axis will be normalized by the ratio of the
     spatial and time axes and used alongside unitless axes. Whilst this makes

--- a/pylops/signalprocessing/Radon3D.py
+++ b/pylops/signalprocessing/Radon3D.py
@@ -122,7 +122,7 @@ def Radon3D(
     r"""Three dimensional Radon transform.
 
     Apply three dimensional Radon forward (and adjoint) transform to a
-    3-dimensional array of size :math:`[n_{py} \times n_{px} \times n_t]`
+    3-dimensional array of size :math:`[n_{p_y} \times n_{p_x} \times n_t]`
     (and :math:`[n_y \times n_x \times n_t]`).
 
     In forward mode this entails to spreading the model vector
@@ -185,10 +185,10 @@ def Radon3D(
     size :math:`[n_y \times n_x \times n_t]` in adjoint mode:
 
     .. math::
-        m(p_y, p_x, t_0) = \int{d(y, x, t = f(p_y, p_x, y, x, t))} dx dy
+        m(p_y, p_x, t_0) = \int{d(y, x, t = f(p_y, p_x, y, x, t))} \,\mathrm{d}x \,\mathrm{d}y
 
-    where :math:`f(p_y, p_x, y, x, t) = t_0 + p_y * y + p_x * x` in linear
-    mode, :math:`f(p_y, p_x, y, x, t) = t_0 + p_y * y^2 + p_x * x^2` in
+    where :math:`f(p_y, p_x, y, x, t) = t_0 + p_y y + p_x x` in linear
+    mode, :math:`f(p_y, p_x, y, x, t) = t_0 + p_y y^2 + p_x x^2` in
     parabolic mode, and
     :math:`f(p_y, p_x, y, x, t) = \sqrt{t_0^2 + y^2 / p_y^2 + x^2 / p_x^2}`
     in hyperbolic mode. Note that internally the :math:`p_x` and :math:`p_y`

--- a/pylops/signalprocessing/Seislet.py
+++ b/pylops/signalprocessing/Seislet.py
@@ -257,7 +257,7 @@ class Seislet(LinearOperator):
         Operator shape
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------
@@ -318,44 +318,44 @@ class Seislet(LinearOperator):
 
     .. math::
         \begin{bmatrix}
-           \mathbf{r}_1  \\ \mathbf{r}_2  \\ ... \\ \mathbf{r}_N \\
-           \mathbf{c}_1  \\ \mathbf{c}_2  \\ ... \\ \mathbf{c}_N
+           \mathbf{r}_1  \\ \mathbf{r}_2  \\ \vdots \\ \mathbf{r}_N \\
+           \mathbf{c}_1  \\ \mathbf{c}_2  \\ \vdots \\ \mathbf{c}_N
         \end{bmatrix} =
         \begin{bmatrix}
-           \mathbf{I} & \mathbf{0} & ... & \mathbf{0} & -\mathbf{P} & \mathbf{0}  & ... & \mathbf{0}  \\
-           \mathbf{0} & \mathbf{I} & ... & \mathbf{0} & \mathbf{0}  & -\mathbf{P} & ... & \mathbf{0}  \\
-           ...        & ...        & ... & ...        & ...         & ...         & ... & ...         \\
-           \mathbf{0} & \mathbf{0} & ... & \mathbf{I} & \mathbf{0}  & \mathbf{0}  & ... & -\mathbf{P} \\
-           \mathbf{U} & \mathbf{0} & ... & \mathbf{0} & \mathbf{I}-\mathbf{UP} & \mathbf{0}  & ... & \mathbf{0}  \\
-           \mathbf{0} & \mathbf{U} & ... & \mathbf{0} & \mathbf{0}  & \mathbf{I}-\mathbf{UP} & ... & \mathbf{0}  \\
-           ...        & ...        & ... & ...        & ...         & ...         & ... & ...         \\
-           \mathbf{0} & \mathbf{0} & ... & \mathbf{U} & \mathbf{0}  & \mathbf{0}  & ... & \mathbf{I}-\mathbf{UP} \\
+           \mathbf{I} & \mathbf{0} & \ldots & \mathbf{0} & -\mathbf{P} & \mathbf{0}  & \ldots & \mathbf{0}  \\
+           \mathbf{0} & \mathbf{I} & \ldots & \mathbf{0} & \mathbf{0}  & -\mathbf{P} & \ldots & \mathbf{0}  \\
+           \vdots     & \vdots     & \ddots & \vdots     & \vdots      & \vdots      & \ddots & \vdots      \\
+           \mathbf{0} & \mathbf{0} & \ldots & \mathbf{I} & \mathbf{0}  & \mathbf{0}  & \ldots & -\mathbf{P} \\
+           \mathbf{U} & \mathbf{0} & \ldots & \mathbf{0} & \mathbf{I}-\mathbf{UP} & \mathbf{0}  & \ldots & \mathbf{0} \\
+           \mathbf{0} & \mathbf{U} & \ldots & \mathbf{0} & \mathbf{0}  & \mathbf{I}-\mathbf{UP} & \ldots & \mathbf{0} \\
+           \vdots     & \vdots     & \ddots & \vdots     & \vdots      & \vdots      & \ddots   & \vdots    \\
+           \mathbf{0} & \mathbf{0} & \ldots & \mathbf{U} & \mathbf{0}  & \mathbf{0}  & \ldots & \mathbf{I}-\mathbf{UP}
         \end{bmatrix}
         \begin{bmatrix}
-           \mathbf{o}_1  \\ \mathbf{o}_2  \\ ... \\ \mathbf{o}_N \\
-           \mathbf{e}_1  \\ \mathbf{e}_2  \\ ... \\ \mathbf{e}_N \\
+           \mathbf{o}_1  \\ \mathbf{o}_2  \\ \vdots \\ \mathbf{o}_N \\
+           \mathbf{e}_1  \\ \mathbf{e}_2  \\ \vdots \\ \mathbf{e}_N
         \end{bmatrix}
 
     Transposing the operator leads to:
 
     .. math::
         \begin{bmatrix}
-           \mathbf{o}_1  \\ \mathbf{o}_2  \\ ... \\ \mathbf{o}_N \\
-           \mathbf{e}_1  \\ \mathbf{e}_2  \\ ... \\ \mathbf{e}_N \\
+           \mathbf{o}_1  \\ \mathbf{o}_2  \\ \vdots \\ \mathbf{o}_N \\
+           \mathbf{e}_1  \\ \mathbf{e}_2  \\ \vdots \\ \mathbf{e}_N
         \end{bmatrix} =
         \begin{bmatrix}
-           \mathbf{I} & \mathbf{0} & ... & \mathbf{0} & -\mathbf{U^T} & \mathbf{0}  & ... & \mathbf{0}  \\
-           \mathbf{0} & \mathbf{I} & ... & \mathbf{0} & \mathbf{0} & -\mathbf{U^T} & ... & \mathbf{0}  \\
-           ...        & ...        & ... & ...        & ...        & ...        & ... & ...         \\
-           \mathbf{0} & \mathbf{0} & ... & \mathbf{I} & \mathbf{0} & \mathbf{0} & ... & -\mathbf{U^T} \\
-           \mathbf{P^T} & \mathbf{0} & ... & \mathbf{0} & \mathbf{I}-\mathbf{P^TU^T} & \mathbf{0} & ... & \mathbf{0}  \\
-           \mathbf{0} & \mathbf{P^T} & ... & \mathbf{0} & \mathbf{0} & \mathbf{I}-\mathbf{P^TU^T} & ... & \mathbf{0}  \\
-           ...        & ...        & ... & ...          & ...        & ...        & ... & ...         \\
-           \mathbf{0} & \mathbf{0} & ... & \mathbf{P^T} & \mathbf{0} & \mathbf{0} & ... & \mathbf{I}-\mathbf{P^TU^T} \\
+           \mathbf{I} & \mathbf{0} & \ldots & \mathbf{0} & -\mathbf{U^T} & \mathbf{0}    & \ldots & \mathbf{0}  \\
+           \mathbf{0} & \mathbf{I} & \ldots & \mathbf{0} & \mathbf{0}    & -\mathbf{U^T} & \ldots & \mathbf{0}  \\
+           \vdots     & \vdots     & \ddots & \vdots     & \vdots        & \vdots        & \ddots & \vdots      \\
+           \mathbf{0} & \mathbf{0} & \ldots & \mathbf{I} & \mathbf{0} & \mathbf{0} & \ldots & -\mathbf{U^T} \\
+           \mathbf{P^T} & \mathbf{0} & \ldots & \mathbf{0} & \mathbf{I}-\mathbf{P^T U^T} & \mathbf{0} & \ldots & \mathbf{0}  \\
+           \mathbf{0} & \mathbf{P^T} & \ldots & \mathbf{0} & \mathbf{0} & \mathbf{I}-\mathbf{P^T U^T} & \ldots & \mathbf{0}  \\
+           \vdots & \vdots & \ddots & \vdots & \vdots & \vdots & \ddots & \vdots \\
+           \mathbf{0} & \mathbf{0} & \ldots & \mathbf{P^T} & \mathbf{0} & \mathbf{0} & \ldots & \mathbf{I}-\mathbf{P^T U^T}
         \end{bmatrix}
         \begin{bmatrix}
-           \mathbf{r}_1  \\ \mathbf{r}_2  \\ ... \\ \mathbf{r}_N \\
-           \mathbf{c}_1  \\ \mathbf{c}_2  \\ ... \\ \mathbf{c}_N
+           \mathbf{r}_1  \\ \mathbf{r}_2  \\ \vdots \\ \mathbf{r}_N \\
+           \mathbf{c}_1  \\ \mathbf{c}_2  \\ \vdots \\ \mathbf{c}_N
         \end{bmatrix}
 
     which can be written more easily in the following two steps:

--- a/pylops/signalprocessing/Shift.py
+++ b/pylops/signalprocessing/Shift.py
@@ -17,7 +17,7 @@ def Shift(
 ):
     r"""Shift operator
 
-    Apply fractional shift in the frequency domain along a specific direction ]
+    Apply fractional shift in the frequency domain along a specific direction
     ``dir`` of a multi-dimensional array of size ``dim``.
 
     Parameters
@@ -25,20 +25,20 @@ def Shift(
     dims : :obj:`tuple`
         Number of samples for each dimension
     shift : :obj:`float`
-        Fractional shift to apply
+        Fractional shift to apply in the same unit as ``sampling``.
     dir : :obj:`int`, optional
         Direction along which FFT is applied.
     nfft : :obj:`int`, optional
         Number of samples in Fourier Transform (same as input if ``nfft=None``)
     sampling : :obj:`float`, optional
-        Sampling step ``dt``.
+        Sampling step :math:`\Delta t`.
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
         model is real.
     engine : :obj:`str`, optional
-        Engine used for fft computation (``numpy`` or ``fftw``). Choose
-        ``numpy`` when working with cupy arrays.
+        Engine used for fft computation (``numpy``, ``scipy``, or ``fftw``). Choose
+        ``numpy`` when working with CuPy arrays.
     dtype : :obj:`str`, optional
         Type of elements in input array.
     **kwargs_fftw
@@ -51,28 +51,29 @@ def Shift(
         Operator shape
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------
     ValueError
         If ``dims`` is provided and ``dir`` is bigger than ``len(dims)``
     NotImplementedError
-        If ``engine`` is neither ``numpy`` nor ``fftw``
+        If ``engine`` is neither ``numpy``, ``scipy``, nor ``fftw``
 
     Notes
     -----
     The Shift operator applies the forward Fourier transform, an element-wise
-    scaling, and inverse fourier transform
+    complex scaling, and inverse fourier transform
 
     .. math::
          \mathbf{y}= \mathbf{F}^{-1} \mathbf{S} \mathbf{F} \mathbf{x}
 
     Here :math:`\mathbf{S}` is a diagonal operator that scales the Fourier
-    transformed input by :math:`e^{-j2\pi f t_S}`, whee :math:`t_S` is the
+    transformed input by :math:`e^{-j2\pi f t_S}`, where :math:`t_S` is the
     chosen ``shift``.
 
     """
+    # TODO: Use offer the same keywords as new FFT
     Fop = FFT(
         dims, dir, nfft, sampling, real=real, engine=engine, dtype=dtype, **kwargs_fftw
     )

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -31,8 +31,15 @@ def dottest(
     tol : :obj:`float`, optional
         Dottest tolerance
     complexflag : :obj:`bool`, optional
-        generate random vectors with real (0) or complex numbers
-        (1: only model, 2: only data, 3:both)
+        Generate random vectors with
+
+        * ``0``: Real entries for model and data
+
+        * ``1``: Complex entries for model and real entries for data
+
+        * ``2``: Real entries for model and complex entries for data
+
+        * ``3``: Complex entries for model and  data
     raiseerror : :obj:`bool`, optional
         Raise error or simply return ``False`` when dottest fails
     verb : :obj:`bool`, optional
@@ -56,8 +63,8 @@ def dottest(
     within a numerical tolerance:
 
     .. math::
-        (\mathbf{Op}*\mathbf{u})^H*\mathbf{v} =
-        \mathbf{u}^H*(\mathbf{Op}^H*\mathbf{v})
+        (\mathbf{Op}\,\mathbf{u})^H\mathbf{v} =
+        \mathbf{u}^H(\mathbf{Op}^H\mathbf{v})
 
     """
     ncp = get_module(backend)

--- a/pylops/utils/estimators.py
+++ b/pylops/utils/estimators.py
@@ -44,16 +44,16 @@ def trace_hutchinson(
         Vectorize computations by sampling sketching matrices instead of
         vectors. Set this value to as high as permitted by memory, but there is
         no guarantee of speedup. Coerced to never exceed ``neval``. When using
-        **unitvector** as sampler, is coerced to not exceed `shape[1]`.
+        "unitvector" as sampler, is coerced to not exceed ``shape[1]``.
         Defaults to 100 or ``neval``.
     sampler : :obj:`str`, optional
         Sample sketching matrices from the following distributions:
 
-            - **gaussian**: Mean zero, unit variance Gaussian.
-            - **rayleigh**: Sample from mean zero, unit variance Gaussian and
+            - "gaussian": Mean zero, unit variance Gaussian.
+            - "rayleigh": Sample from mean zero, unit variance Gaussian and
               normalize the columns.
-            - **rademacher**: Random sign.
-            - **unitvector**: Samples from the unit vectors :math:`\mathrm{e}_i`
+            - "rademacher": Random sign.
+            - "unitvector": Samples from the unit vectors :math:`\mathrm{e}_i`
               without replacement.
 
     backend : :obj:`str`, optional
@@ -88,7 +88,7 @@ def trace_hutchinson(
     Prefer the Rademacher sampler if the goal is to minimize variance, but the
     Gaussian for a better probability of approximating the correct value. Use
     the Unit Vector approach if you are sampling a large number of ``neval``
-    (compared to `shape[1]`), especially if the operator is highly-structured.
+    (compared to ``shape[1]``), especially if the operator is highly-structured.
 
     .. [1] Hutchinson, M. F. (1990). *A stochastic estimator of the trace of
            the influence matrix for laplacian smoothing splines*.
@@ -151,10 +151,10 @@ def trace_hutchpp(Op, neval=None, sampler="rademacher", backend="numpy"):
     sampler : :obj:`str`, optional
         Sample sketching matrices from the following distributions:
 
-            - **gaussian**: Mean zero, unit variance Gaussian.
-            - **rayleigh**: Sample from mean zero, unit variance Gaussian and
+            - "gaussian": Mean zero, unit variance Gaussian.
+            - "rayleigh": Sample from mean zero, unit variance Gaussian and
               normalize the columns.
-            - **rademacher**: Random sign.
+            - "rademacher": Random sign.
 
     backend : :obj:`str`, optional
         Backend used to densify matrix (``numpy`` or ``cupy``). Note that
@@ -185,7 +185,7 @@ def trace_hutchpp(Op, neval=None, sampler="rademacher", backend="numpy"):
            from sub-Gaussian distributions.
         2. Compute reduced QR decomposition of :math:`\mathbf{Op}\,\mathbf{S}`,
            retaining only :math:`\mathbf{Q}`.
-        3. Return :math:`\operatorname{tr}(\mathbf{Q}^T\,\mathbf{Op}\,\mathbf{Q}) + \frac{1}{\lfloor k/3\rfloor}\operatorname{tr}(\mathbf{G}^T(\mathbf{I} - \mathbf{Q}\mathbf{Q}^T)\,\mathbf{Op}\,(\mathbf{I} - \mathbf{Q}\mathbf{Q}^T)\mathbf{G})`
+        3. Return :math:`\operatorname{tr}(\mathbf{Q}^T\,\mathbf{Op}\,\mathbf{Q}) + \frac{1}{\lfloor k/3\rfloor}\operatorname{tr}\left(\mathbf{G}^T(\mathbf{I} - \mathbf{Q}\mathbf{Q}^T)\,\mathbf{Op}\,(\mathbf{I} - \mathbf{Q}\mathbf{Q}^T)\mathbf{G}\right)`
 
     Use the Rademacher sampler unless you know what you are doing.
 
@@ -244,10 +244,10 @@ def trace_nahutchpp(
     sampler : :obj:`str`, optional
         Sample sketching matrices from the following distributions:
 
-            - **gaussian**: Mean zero, unit variance Gaussian.
-            - **rayleigh**: Sample from mean zero, unit variance Gaussian and
+            - "gaussian": Mean zero, unit variance Gaussian.
+            - "rayleigh": Sample from mean zero, unit variance Gaussian and
               normalize the columns.
-            - **rademacher**: Random sign.
+            - "rademacher": Random sign.
 
     c1 : :obj:`float`, optional
         Fraction of ``neval`` for sketching matrix :math:`\mathbf{S}`.

--- a/pylops/utils/seismicevents.py
+++ b/pylops/utils/seismicevents.py
@@ -13,9 +13,9 @@ def _filterdata(d, nt, wav, wcenter):
 def makeaxis(par):
     r"""Create axes t, x, and y axes
 
-    Create space and time axes from dictionary containing initial values :math:`(ot, ox, oy)`,
-    sampling steps :math:`(dt, dx, dy)` and number of elements :math:`(nt, nx, ny)`
-    for each axis
+    Create space and time axes from dictionary containing initial values ``ot``, ``ox``, ``oy``,
+    sampling steps ``dt``, dx``, ``dy`` and number of elements ``nt``, nx``, ``ny``
+    for each axis.
 
     Parameters
     ----------
@@ -25,13 +25,13 @@ def makeaxis(par):
     Returns
     -------
     t : :obj:`numpy.ndarray`
-        time axis
+        Time axis
     t2 : :obj:`numpy.ndarray`
-        double time axis (symmetric to zero)
+        Symmetric time axis
     x : :obj:`numpy.ndarray`
         x axis
     y : :obj:`numpy.ndarray`
-        y axis (``None``, if :math:`oy, dy, ny` are not provided)
+        y axis (``None``, if ``oy``, ``dy`` or ``ny`` are not provided)
 
     Examples
     --------
@@ -91,7 +91,7 @@ def linear2d(x, t, v, t0, theta, amp, wav):
     .. math::
         t_i(x) = t_{0,i} + p_{x,i} x
 
-    where :math:`p_{x,i}=sin( \theta_i)/v`
+    where :math:`p_{x,i}=\sin( \theta_i)/v`
 
     """
     if isinstance(t0, (float, int)):
@@ -232,7 +232,7 @@ def hyperbolic2d(x, t, t0, vrms, amp, wav):
     Each event is created using the following relation:
 
     .. math::
-        t_i(x) = \sqrt{t_{0,i}^2 + x^2 / v_{rms,i}^2}
+        t_i(x) = \sqrt{t_{0,i}^2 + \frac{x^2}{v_{\text{rms},i}^2}}
 
     """
     if isinstance(t0, (float, int)):
@@ -309,8 +309,8 @@ def linear3d(x, y, t, v, t0, theta, phi, amp, wav):
     .. math::
         t_i(x, y) = t_{0,i} + p_{x,i} x + p_{y,i} y
 
-    where :math:`p_{x,i}=sin( \theta_i)cos( \phi_i)/v`
-    and :math:`p_{x,i}=sin( \theta_i)sin( \phi_i)/v`.
+    where :math:`p_{x,i}=\frac{1}{v} \sin( \theta_i)\cos( \phi_i)`
+    and :math:`p_{x,i}=\frac{1}{v} \sin( \theta_i)\sin( \phi_i)`.
 
     """
     if isinstance(t0, (float, int)):
@@ -387,8 +387,8 @@ def hyperbolic3d(x, y, t, t0, vrms_x, vrms_y, amp, wav):
     Each event is created using the following relation:
 
     .. math::
-        t_i(x, y) = \sqrt{t_{0,i}^2 + x^2 / v_{rms_x, i}^2 +
-        y^2 / v_{rms_y, i}^2}
+        t_i(x, y) = \sqrt{t_{0,i}^2 + \frac{x^2}{v_{\text{rms}_x, i}^2} +
+        \frac{y^2}{v_{\text{rms}_y, i}^2}}
 
     Note that velocities do not have a physical meaning here (compared to the
     corresponding :func:`pylops.utils.seismicevents.hyperbolic2d`), they rather

--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -18,15 +18,15 @@ def convmtx(h, n):
     h : :obj:`np.ndarray`
         Convolution filter (1D array)
     n : :obj:`int`
-        Number of columns (if :math:`len(h) < n`) or rows
-        (if :math:`len(h) \geq n`) of convolution matrix
+        Number of columns (if :math:`\text{len}(h) < n`) or rows
+        (if :math:`\text{len}(h) \geq n`) of convolution matrix
 
     Returns
     -------
     C : :obj:`np.ndarray`
-        Convolution matrix of size :math:`len(h)+n-1 \times n`
-        (if :math:`len(h) < n`) or :math:`n \times len(h)+n-1`
-        (if :math:`len(h) \geq n`)
+        Convolution matrix of size :math:`\text{len}(h)+n-1 \times n`
+        (if :math:`\text{len}(h) < n`) or :math:`n \times \text{len}(h)+n-1`
+        (if :math:`\text{len}(h) \geq n`)
 
     """
     ncp = get_array_module(h)
@@ -52,7 +52,7 @@ def nonstationary_convmtx(H, n, hc=0, pad=(0, 0)):
     ----------
     H : :obj:`np.ndarray`
         Convolution filters (2D array of shape
-        :math:`[n_{filters} \times n_{h}]`
+        :math:`[n_\text{filters} \times n_{h}]`
     n : :obj:`int`
         Number of columns of convolution matrix
     hc : :obj:`np.ndarray`, optional
@@ -80,7 +80,7 @@ def slope_estimate(d, dz, dx, smooth=20):
     r"""Local slope estimation
 
     Local slopes are estimated using the *Structure Tensor* algorithm [1]_.
-    Note that slopes are returned as :math:`arctan(\theta)` where
+    Note that slopes are returned as :math:`\arctan(\theta)` where
     :math:`\theta` is an angle defined in a RHS coordinate system with z axis
     pointing upward.
 
@@ -105,11 +105,13 @@ def slope_estimate(d, dz, dx, smooth=20):
     Notes
     -----
     For each pixel of the input dataset :math:`\mathbf{d}` the local gradients
-    :math:`d \mathbf{d} / dz` and :math:`g_z = d\mathbf{d} \ dx` are computed
+    :math:`g_z = \frac{\partial \mathbf{d}}{\partial z}` and
+    :math:`g_x = \frac{\partial \mathbf{d}}{\partial x}` are computed
     and used to define the following three quantities:
-    :math:`g_{zz} = (d\mathbf{d} / dz) ^ 2`,
-    :math:`g_{xx} = (d\mathbf{d} / dx) ^ 2`, and
-    :math:`g_{zx} = d\mathbf{d} / dz * d\mathbf{d} / dx`. Such quantities are
+    :math:`g_{zz} = \left(\frac{\partial \mathbf{d}}{\partial z}\right)^2`,
+    :math:`g_{xx} = \left(\frac{\partial \mathbf{d}}{\partial x}\right)^2`, and
+    :math:`g_{zx} = \frac{\partial \mathbf{d}}{\partial z}\cdot\frac{\partial \mathbf{d}}{\partial x}`.
+    Such quantities are
     spatially smoothed and at each pixel their smoothed versions are
     arranged in a :math:`2 \times 2` matrix called the *smoothed
     gradient-square tensor*:
@@ -123,7 +125,8 @@ def slope_estimate(d, dz, dx, smooth=20):
 
 
     Local slopes can be expressed as
-    :math:`p = arctan(\frac{\lambda_{max} - g_{xx}}{g_{zx}})`.
+    :math:`p = \arctan\left(\frac{\lambda_\text{max} - g_{xx}}{g_{zx}}\right)`,
+    where :math:`\lambda_\text{max}` is the largest eigenvalue of :math:`\mathbf{G}`.
 
     .. [1] Van Vliet, L. J.,  Verbeek, P. W., "Estimators for orientation and
         anisotropy in digitized images", Journal ASCI Imaging Workshop. 1995.

--- a/pylops/utils/tapers.py
+++ b/pylops/utils/tapers.py
@@ -121,7 +121,7 @@ def taper(nmask, ntap, tapertype):
 def taper2d(nt, nmask, ntap, tapertype="hanning"):
     r"""2D taper
 
-    Create 2d mask of size :math:`[n_{mask} \times n_t]`
+    Create 2d mask of size :math:`[n_\text{mask} \times n_t]`
     with tapering of size ``ntap`` along the first (and possibly
     second) dimensions
 
@@ -141,7 +141,7 @@ def taper2d(nt, nmask, ntap, tapertype="hanning"):
     -------
     taper : :obj:`numpy.ndarray`
         2d mask with tapering along first dimension
-        of size :math:`[n_{mask} \times n_t]`
+        of size :math:`[n_\text{mask} \times n_t]`
 
     """
     # create 1d window along first dimension
@@ -167,7 +167,7 @@ def taper2d(nt, nmask, ntap, tapertype="hanning"):
 def taper3d(nt, nmask, ntap, tapertype="hanning"):
     r"""3D taper
 
-    Create 2d mask of size :math:`[n_{mask}[0] \times n_{mask}[1] \times n_t]`
+    Create 2d mask of size :math:`[n_\text{mask}[0] \times n_\text{mask}[1] \times n_t]`
     with tapering of size ``ntap`` along the first and second dimension
 
     Parameters
@@ -186,7 +186,7 @@ def taper3d(nt, nmask, ntap, tapertype="hanning"):
     -------
     taper : :obj:`numpy.ndarray`
         2d mask with tapering along first dimension
-        of size :math:`[n_{mask,0} \times n_{mask,1} \times n_t]`
+        of size :math:`[n_\text{mask,0} \times n_\text{mask,1} \times n_t]`
 
     """
     nmasky, nmaskx = nmask[0], nmask[1]

--- a/pylops/waveeqprocessing/lsm.py
+++ b/pylops/waveeqprocessing/lsm.py
@@ -63,11 +63,11 @@ def _traveltime_table(z, x, srcs, recs, vel, y=None, mode="eikonal"):
     x : :obj:`numpy.ndarray`
         Spatial axis
     srcs : :obj:`numpy.ndarray`
-        Sources in array of size :math:`\lbrack 2/3 \times n_s \rbrack`
+        Sources in array of size :math:`\lbrack 2 (3) \times n_s \rbrack`
     recs : :obj:`numpy.ndarray`
-        Receivers in array of size :math:`\lbrack 2/3 \times n_r \rbrack`
+        Receivers in array of size :math:`\lbrack 2 (3) \times n_r \rbrack`
     vel : :obj:`numpy.ndarray` or :obj:`float`
-        Velocity model of size :math:`\lbrack (n_y \times) n_x
+        Velocity model of size :math:`\lbrack (n_y \times)\, n_x
         \times n_z \rbrack` (or constant)
     y : :obj:`numpy.ndarray`
         Additional spatial axis (for 3-dimensional problems)
@@ -77,14 +77,14 @@ def _traveltime_table(z, x, srcs, recs, vel, y=None, mode="eikonal"):
     Returns
     -------
     trav : :obj:`numpy.ndarray`
-        Total traveltime table of size :math:`\lbrack (n_y*) n_x*n_z
-        \times n_s*n_r \rbrack`
+        Total traveltime table of size :math:`\lbrack (n_y) n_x n_z
+        \times n_s n_r \rbrack`
     trav_srcs : :obj:`numpy.ndarray`
         Source-to-subsurface traveltime table of size
-        :math:`\lbrack (n_y*) n_x*n_z \times n_s \rbrack` (or constant)
+        :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack` (or constant)
     trav_recs : :obj:`numpy.ndarray`
         Receiver-to-subsurface traveltime table of size
-        :math:`\lbrack (n_y*) n_x*n_z \times n_r \rbrack`
+        :math:`\lbrack (n_y) n_x n_z \times n_r \rbrack`
 
     """
     ndims, shiftdim, _, ny, nx, nz, ns, nr, _, _, _, dsamp, origin = _identify_geometry(
@@ -176,13 +176,13 @@ def Demigration(
     t : :obj:`numpy.ndarray`
         Time axis for data
     srcs : :obj:`numpy.ndarray`
-        Sources in array of size :math:`\lbrack 2/3 \times n_s \rbrack`
+        Sources in array of size :math:`\lbrack 2 (3) \times n_s \rbrack`
         The first axis should be ordered as (``y``,) ``x``, ``z``.
     recs : :obj:`numpy.ndarray`
-        Receivers in array of size :math:`\lbrack 2/3 \times n_r \rbrack`
+        Receivers in array of size :math:`\lbrack 2 (3) \times n_r \rbrack`
         The first axis should be ordered as (``y``,) ``x``, ``z``.
     vel : :obj:`numpy.ndarray` or :obj:`float`
-        Velocity model of size :math:`\lbrack (n_y \times) n_x
+        Velocity model of size :math:`\lbrack (n_y\,\times)\; n_x
         \times n_z \rbrack` (or constant)
     wav : :obj:`numpy.ndarray`
         Wavelet
@@ -195,7 +195,7 @@ def Demigration(
         more details)
     trav : :obj:`numpy.ndarray`, optional
         Traveltime table of size
-        :math:`\lbrack (n_y*) n_x*n_z \times n_r \rbrack` (to be provided if
+        :math:`\lbrack (n_y) n_x n_z \times n_r \rbrack` (to be provided if
         ``mode='byot'``)
 
     Returns
@@ -216,8 +216,8 @@ def Demigration(
 
     .. math::
         d(\mathbf{x_r}, \mathbf{x_s}, t) =
-        w(t) * \int_V G(\mathbf{x}, \mathbf{x_s}, t)
-        G(\mathbf{x_r}, \mathbf{x}, t) m(\mathbf{x}) d\mathbf{x}
+        w(t) * \int_V G(\mathbf{x_r}, \mathbf{x}, t)
+        m(\mathbf{x}) G(\mathbf{x}, \mathbf{x_s}, t)\,\mathrm{d}\mathbf{x}
 
     where :math:`m(\mathbf{x})` is the model and it represents the reflectivity
     at every location in the subsurface, :math:`G(\mathbf{x}, \mathbf{x_s}, t)`
@@ -291,11 +291,11 @@ class LSM:
     t : :obj:`numpy.ndarray`
         Time axis for data
     srcs : :obj:`numpy.ndarray`
-        Sources in array of size :math:`\lbrack 2/3 \times n_s \rbrack`
+        Sources in array of size :math:`\lbrack 2(3) \times n_s \rbrack`
     recs : :obj:`numpy.ndarray`
-        Receivers in array of size :math:`\lbrack 2/3 \times n_r \rbrack`
+        Receivers in array of size :math:`\lbrack 2(3) \times n_r \rbrack`
     vel : :obj:`numpy.ndarray` or :obj:`float`
-        Velocity model of size :math:`\lbrack (n_y \times) n_x
+        Velocity model of size :math:`\lbrack (n_y \times)\, n_x
         \times n_z \rbrack` (or constant)
     wav : :obj:`numpy.ndarray`
         Wavelet

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -30,16 +30,16 @@ def directwave(wav, trav, nt, dt, nfft=None, dist=None, kind="2d", derivative=Tr
         wavelet with same amplitude spectrum as provided by ``wav``
     trav : :obj:`numpy.ndarray`
         Traveltime of first arrival from subsurface point to
-        surface receivers of size :math:`\lbrack nr \times 1 \rbrack`
+        surface receivers of size :math:`\lbrack n_r \times 1 \rbrack`
     nt : :obj:`float`, optional
         Number of samples in time
     dt : :obj:`float`, optional
         Sampling in time
     nfft : :obj:`int`, optional
-        Number of samples in fft time (if ``None``, :math:`nfft=nt`)
+        Number of samples in fft time (if ``None``, ``nfft=nt``)
     dist: :obj:`numpy.ndarray`
         Distance between subsurface point to
-        surface receivers of size :math:`\lbrack nr \times 1 \rbrack`
+        surface receivers of size :math:`\lbrack n_r \times 1 \rbrack`
     kind : :obj:`str`, optional
         2-dimensional (``2d``) or 3-dimensional (``3d``)
     derivative : :obj:`bool`, optional
@@ -49,7 +49,7 @@ def directwave(wav, trav, nt, dt, nfft=None, dist=None, kind="2d", derivative=Tr
     -------
     direct : :obj:`numpy.ndarray`
         Direct arrival in time domain of size
-        :math:`\lbrack nt \times nr \rbrack`
+        :math:`\lbrack n_t \times n_r \rbrack`
 
     Notes
     -----
@@ -67,10 +67,10 @@ def directwave(wav, trav, nt, dt, nfft=None, dist=None, kind="2d", derivative=Tr
     a point source of volume injection. In case the response to a point source
     of volume injection rate is desired, a :math:`j\omega` scaling (which is
     equivalent to applying a first derivative in time domain) must be applied.
-    Here this is accomplished by setting ``derivative==True``.
+    Here this is accomplished by setting ``derivative=True``.
 
     .. [1] Snieder, R. "A Guided Tour of Mathematical Methods for the
-    Physical Sciences", Cambridge University Press, pp. 302, 2004.
+       Physical Sciences", Cambridge University Press, pp. 302, 2004.
 
     """
     ncp = get_array_module(wav)
@@ -105,8 +105,8 @@ class Marchenko:
     ----------
     R : :obj:`numpy.ndarray`
         Multi-dimensional reflection response in time or frequency
-        domain of size :math:`[n_s \times n_r \times n_t/n_{fmax}]`. If
-        provided in time, `R` should not be of complex type. Note that the
+        domain of size :math:`[n_s \times n_r \times n_t (n_{f_\text{max}}}]`. If
+        provided in time, ``R`` should not be of complex type. Note that the
         reflection response should have already been multiplied by 2.
     R1 : :obj:`bool`, optional
         *Deprecated*, will be removed in v2.0.0. Simply kept for
@@ -128,9 +128,9 @@ class Marchenko:
     dtype : :obj:`bool`, optional
         Type of elements in input array.
     saveRt : :obj:`bool`, optional
-        Save ``R`` and ``R^H`` to speed up the computation of adjoint of
+        Save ``R`` and ``R.H`` to speed up the computation of adjoint of
         :class:`pylops.signalprocessing.Fredholm1` (``True``) or create
-        ``R^H`` on-the-fly (``False``) Note that ``saveRt=True`` will be
+        ``R.H`` on-the-fly (``False``) Note that ``saveRt=True`` will be
         faster but double the amount of required memory
     prescaled : :obj:`bool`, optional
         Apply scaling to ``R`` (``False``) or not (``False``)
@@ -151,7 +151,7 @@ class Marchenko:
         Operator shape
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
-        (True) or not (False)
+        (``True``) or not (``False``)
 
     Raises
     ------

--- a/pylops/waveeqprocessing/mdd.py
+++ b/pylops/waveeqprocessing/mdd.py
@@ -160,12 +160,12 @@ def MDC(
 
     Apply multi-dimensional convolution between two datasets. If
     ``transpose=True``, model and data should be provided after flattening
-    2- or 3-dimensional arrays of size :math:`[n_r (\times n_{vs}) \times n_t]`
-    and :math:`[n_s (\times n_{vs}) \times n_t]` (or :math:`2*n_t-1` for
+    2- or 3-dimensional arrays of size :math:`[n_r \;(\times n_{vs}) \times n_t]`
+    and :math:`[n_s \;(\times n_{vs}) \times n_t]` (or :math:`2n_t-1` for
     ``twosided=True``), respectively. If ``transpose=False``, model and data
     should be provided after flattening 2- or 3-dimensional arrays of size
-    :math:`[n_t \times n_r (\times n_{vs})]` and
-    :math:`[n_t \times n_s (\times n_{vs})]` (or :math:`2*n_t-1` for
+    :math:`[n_t \times n_r \;(\times n_{vs})]` and
+    :math:`[n_t \times n_s \;(\times n_{vs})]` (or :math:`2n_t-1` for
     ``twosided=True``), respectively.
 
     .. warning:: A new implementation of MDC is provided in v1.5.0. This
@@ -179,17 +179,17 @@ def MDC(
     ----------
     G : :obj:`numpy.ndarray`
         Multi-dimensional convolution kernel in frequency domain of size
-        :math:`[n_s \times n_r \times n_{fmax}]` if ``transpose=True``
-        or size :math:`[n_{fmax} \times n_s \times n_r]` if ``transpose=False``
+        :math:`[n_s \times n_r \times n_{f_\text{max}}]` if ``transpose=True``
+        or size :math:`[n_{f_\text{max}} \times n_s \times n_r]` if ``transpose=False``
     nt : :obj:`int`
         Number of samples along time axis for model and data (note that this
-        must be equal to ``2*n_t-1`` when working with ``twosided=True``.
+        must be equal to :math:`2n_t-1` when working with ``twosided=True``.
     nv : :obj:`int`
         Number of samples along virtual source axis
     dt : :obj:`float`, optional
-        Sampling of time integration axis
+        Sampling of time integration axis :math:`\Delta t`
     dr : :obj:`float`, optional
-        Sampling of receiver integration axis
+        Sampling of receiver integration axis :math:`\Delta r`
     twosided : :obj:`bool`, optional
         MDC operator has both negative and positive time (``True``) or
         only positive (``False``)
@@ -205,9 +205,9 @@ def MDC(
         will be removed in v2.0.0 where time/frequency axis will be required
         to be in first dimension for efficiency reasons.
     saveGt : :obj:`bool`, optional
-        Save ``G`` and ``G^H`` to speed up the computation of adjoint of
+        Save ``G`` and ``G.H`` to speed up the computation of adjoint of
         :class:`pylops.signalprocessing.Fredholm1` (``True``) or create
-        ``G^H`` on-the-fly (``False``) Note that ``saveGt=True`` will be
+        ``G.H`` on-the-fly (``False``) Note that ``saveGt=True`` will be
         faster but double the amount of required memory
     conj : :obj:`str`, optional
         Perform Fredholm integral computation with complex conjugate of ``G``
@@ -238,15 +238,15 @@ def MDC(
 
     .. math::
         y(t, s, v) = \mathscr{F}^{-1} \Big( \int_S G(f, s, r)
-        \mathscr{F}(x(t, r, v)) dr \Big)
+        \mathscr{F}(x(t, r, v))\,\mathrm{d}r \Big)
 
     which is discretized as follows:
 
     .. math::
-        y(t, s, v) = \mathscr{F}^{-1} \Big( \sum_{i_r=0}^{n_r}
-        (\sqrt{n_t} * d_t * d_r) G(f, s, i_r) \mathscr{F}(x(t, i_r, v)) \Big)
+        y(t, s, v) = \sqrt{n_t} \Delta t \Delta r\mathscr{F}^{-1} \Big( \sum_{i_r=0}^{n_r}
+        G(f, s, i_r) \mathscr{F}(x(t, i_r, v)) \Big)
 
-    where :math:`(\sqrt{n_t} * d_t * d_r)` is not applied if ``prescaled=True``.
+    where :math:`\sqrt{n_t} \Delta t \Delta r` is not applied if ``prescaled=True``.
 
     This operation can be discretized and performed by means of a
     linear operator
@@ -314,14 +314,14 @@ def MDD(
         :math:`[n_s \times n_r \times n_t]` for ``twosided=False`` or
         ``twosided=True`` and ``add_negative=True``
         (with only positive times) or size
-        :math:`[n_s \times n_r \times 2*n_t-1]` for ``twosided=True`` and
+        :math:`[n_s \times n_r \times 2n_t-1]` for ``twosided=True`` and
         ``add_negative=False``
         (with both positive and negative times)
     d : :obj:`numpy.ndarray`
-        Data in time domain :math:`[n_s (\times n_{vs}) \times n_t]` if
+        Data in time domain :math:`[n_s \,(\times n_{vs}) \times n_t]` if
         ``twosided=False`` or ``twosided=True`` and ``add_negative=True``
         (with only positive times) or size
-        :math:`[n_s (\times n_{vs}) \times 2*n_t-1]` if ``twosided=True``
+        :math:`[n_s \,(\times n_{vs}) \times 2n_t-1]` if ``twosided=True``
     dt : :obj:`float`, optional
         Sampling of time integration axis
     dr : :obj:`float`, optional
@@ -352,9 +352,9 @@ def MDD(
     dottest : :obj:`bool`, optional
         Apply dot-test
     saveGt : :obj:`bool`, optional
-        Save ``G`` and ``G^H`` to speed up the computation of adjoint of
+        Save ``G`` and ``G.H`` to speed up the computation of adjoint of
         :class:`pylops.signalprocessing.Fredholm1` (``True``) or create
-        ``G^H`` on-the-fly (``False``) Note that ``saveGt=True`` will be
+        ``G.H`` on-the-fly (``False``) Note that ``saveGt=True`` will be
         faster but double the amount of required memory
     fftengine : :obj:`str`, optional
         Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
@@ -367,21 +367,21 @@ def MDD(
     Returns
     -------
     minv : :obj:`numpy.ndarray`
-        Inverted model of size :math:`[n_r (\times n_{vs}) \times n_t]`
+        Inverted model of size :math:`[n_r \,(\times n_{vs}) \times n_t]`
         for ``twosided=False`` or
-        :math:`[n_r (\times n_vs) \times 2*n_t-1]` for ``twosided=True``
+        :math:`[n_r \,(\times n_vs) \times 2n_t-1]` for ``twosided=True``
     madj : :obj:`numpy.ndarray`
-        Adjoint model of size :math:`[n_r (\times n_{vs}) \times n_t]`
+        Adjoint model of size :math:`[n_r \,(\times n_{vs}) \times n_t]`
         for ``twosided=False`` or
-        :math:`[n_r (\times n_r) \times 2*n_t-1]` for ``twosided=True``
+        :math:`[n_r \,(\times n_r) \times 2n_t-1]` for ``twosided=True``
     psfinv : :obj:`numpy.ndarray`
         Inverted psf of size :math:`[n_r \times n_r \times n_t]`
         for ``twosided=False`` or
-        :math:`[n_r \times n_r \times 2*n_t-1]` for ``twosided=True``
+        :math:`[n_r \times n_r \times 2n_t-1]` for ``twosided=True``
     psfadj : :obj:`numpy.ndarray`
         Adjoint psf of size :math:`[n_r \times n_r \times n_t]`
         for ``twosided=False`` or
-        :math:`[n_r \times n_r \times 2*n_t-1]` for ``twosided=True``
+        :math:`[n_r \times n_r \times 2n_t-1]` for ``twosided=True``
 
     See Also
     --------

--- a/pylops/waveeqprocessing/oneway.py
+++ b/pylops/waveeqprocessing/oneway.py
@@ -103,7 +103,7 @@ def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64"):
     Apply positive (forward) phase shift with constant velocity in
     forward mode, and negative (backward) phase shift with constant velocity in
     adjoint mode. Input model and data should be 2- or 3-dimensional arrays
-    in time-space domain of size :math:`[n_t \times n_x (\times n_y)]`.
+    in time-space domain of size :math:`[n_t \times n_x \;(\times n_y)]`.
 
     Parameters
     ----------
@@ -136,16 +136,16 @@ def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64"):
     transformation to the input model:
 
     .. math::
-        d(f, k_x, k_y) = m(f, k_x, k_y) *
-        e^{-j \sqrt{\omega^2/v^2 - k_x^2 - k_y^2} \Delta z}
+        d(f, k_x, k_y) = m(f, k_x, k_y)
+        e^{-j \Delta z \sqrt{\omega^2/v^2 - k_x^2 - k_y^2}}
 
     where :math:`v` is the constant propagation velocity and
     :math:`\Delta z` is the propagation depth. In adjoint mode, the data is
     propagated backward using the following transformation:
 
     .. math::
-        m(f, k_x, k_y) = d(f, k_x, k_y) *
-        e^{j \sqrt{\omega^2/v^2 - k_x^2 - k_y^2} \Delta z}
+        m(f, k_x, k_y) = d(f, k_x, k_y)
+        e^{j \Delta z \sqrt{\omega^2/v^2 - k_x^2 - k_y^2}}
 
     Effectively, the input model and data are assumed to be in time-space
     domain and forward Fourier transform is applied to both dimensions, leading
@@ -210,11 +210,11 @@ def Deghosting(
     Parameters
     ----------
     p : :obj:`np.ndarray`
-        Pressure data of of size :math:`\lbrack n_{r_x} (\times n_{r_y})
-        \times n_t \rbrack` (or :math:`\lbrack n_{r_{x,sub}}
-        (\times n_{r_{y,sub}}) \times n_t \rbrack`
+        Pressure data of of size :math:`\lbrack n_{r_x}\,(\times n_{r_y})
+        \times n_t \rbrack` (or :math:`\lbrack n_{r_{x,\text{sub}}}\,
+        (\times n_{r_{y,\text{sub}}}) \times n_t \rbrack`
         in case a ``restriction`` operator is provided. Note that
-        :math:`n_{r_{x,sub}}` (and :math:`n_{r_{y,sub}}`)
+        :math:`n_{r_{x,\text{sub}}}` (and :math:`n_{r_{y,\text{sub}}}`)
         must agree with the size of the output of this operator)
     nt : :obj:`int`
         Number of samples along the time axis
@@ -264,19 +264,19 @@ def Deghosting(
 
     Notes
     -----
-    Up- and down-going components of seismic data (:math:`p^-(x, t)`
-    and :math:`p^+(x, t)`) can be estimated from single-component data
-    (:math:`p(x, t)`) using a ghost model.
+    Up- and down-going components of seismic data :math:`p^-(x, t)`
+    and :math:`p^+(x, t)` can be estimated from single-component data
+    :math:`p(x, t)` using a ghost model.
 
-    The basic idea is that of using a one-way propagator in the f-k domain
+    The basic idea [1]_ is that of using a one-way propagator in the f-k domain
     (also referred to as ghost model) to predict the down-going field
     from the up-going one (excluded the direct arrival and its source
     ghost referred here to as :math:`p_d(x, t)`):
 
     .. math::
-        p^+ - p_d = e^{-j k_z 2 z_{rec}} p^-
+        p^+ - p_d = e^{-j k_z 2 z_\text{rec}} p^-
 
-    where :math:`k_z` is the vertical wavenumber and :math:`z_{rec}` is the
+    where :math:`k_z` is the vertical wavenumber and :math:`z_\text{rec}` is the
     depth of the array of receivers
 
     In a matrix form we can thus write the total wavefield as:
@@ -286,6 +286,10 @@ def Deghosting(
 
     where :math:`\Phi` is one-way propagator implemented via the
     :class:`pylops.waveeqprocessing.PhaseShift` operator.
+
+    .. [1] Amundsen, L., 1993, Wavenumber-based filtering of marine point-source
+       data: GEOPHYSICS, 58, 1335–1348.
+
 
     """
     ndims = p.ndim

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -55,7 +55,7 @@ def SeismicInterpolation(
     ----------
     data : :obj:`np.ndarray`
         Irregularly sampled seismic data of size
-        :math:`[n_{r_y} (\times n_{r_x} \times n_t)]`
+        :math:`[n_{r_y} \,(\times n_{r_x} \times n_t)]`
     nrec : :obj:`int` or :obj:`tuple`
         Number of elements in the regularly sampled (reconstructed) spatial
         array, :math:`n_{R_y}` for 2-dimensional data and
@@ -134,7 +134,7 @@ def SeismicInterpolation(
     Returns
     -------
     recdata : :obj:`np.ndarray`
-        Reconstructed data of size :math:`[n_{R_y} (\times n_{R_x} \times n_t)]`
+        Reconstructed data of size :math:`[n_{R_y}\,(\times n_{R_x} \times n_t)]`
     recprec : :obj:`np.ndarray`
         Reconstructed data in the sparse or preconditioned domain in case of
         ``kind='fk'``, ``kind='radon-linear'``, ``kind='radon-parabolic'``,
@@ -157,11 +157,11 @@ def SeismicInterpolation(
         \mathbf{y} = \mathbf{R} \mathbf{x}
 
     where a restriction or interpolation operator is applied along the spatial
-    direction(s). Here :math:`\mathbf{y} = [\mathbf{y}_{R1}^T, \mathbf{y}_{R2}^T,...,
+    direction(s). Here :math:`\mathbf{y} = [\mathbf{y}_{R1}^T, \mathbf{y}_{R2}^T,\ldots,
     \mathbf{y}_{RN^T}]^T` where each vector :math:`\mathbf{y}_{Ri}`
     contains all time samples recorded in the seismic data at the specific
     receiver :math:`R_i`. Similarly, :math:`\mathbf{x} = [\mathbf{x}_{r1}^T,
-    \mathbf{x}_{r2}^T,..., \mathbf{x}_{rM}^T]`, contains all traces at the
+    \mathbf{x}_{r2}^T,\ldots, \mathbf{x}_{rM}^T]`, contains all traces at the
     regularly and finely sampled receiver locations :math:`r_i`.
 
     Several alternative approaches can be taken to solve such a problem. They

--- a/pylops/waveeqprocessing/wavedecomposition.py
+++ b/pylops/waveeqprocessing/wavedecomposition.py
@@ -227,7 +227,7 @@ def PressureToVelocity(
     Apply conversion from pressure to vertical velocity seismic wavefield
     (or vertical velocity to pressure). The input model and data required by
     the operator should be created by flattening the a wavefield of size
-    :math:`(\lbrack n_{r_y}) \times n_{r_x} \times n_t \rbrack`.
+    :math:`(\lbrack n_{r_y} \times n_{r_x} \times n_t \rbrack`.
 
     Parameters
     ----------
@@ -240,15 +240,15 @@ def PressureToVelocity(
     dr : :obj:`float` or :obj:`tuple`
         Sampling(s) along the receiver array
     rho : :obj:`float`
-        Density along the receiver array (must be constant)
+        Density :math:`\rho` along the receiver array (must be constant)
     vel : :obj:`float`
-        Velocity along the receiver array (must be constant)
+        Velocity :math:`c` along the receiver array (must be constant)
     nffts : :obj:`tuple`, optional
         Number of samples along the wavenumber and frequency axes
     critical : :obj:`float`, optional
         Percentage of angles to retain in obliquity factor. For example, if
         ``critical=100`` only angles below the critical angle
-        :math:`\sqrt{k_y^2 + k_x^2} < \frac{\omega}{vel}` will be retained
+        :math:`\sqrt{k_y^2 + k_x^2} < \frac{\omega}{c}` will be retained
     ntaper : :obj:`float`, optional
         Number of samples of taper applied to obliquity factor around critical
         angle
@@ -275,26 +275,26 @@ def PressureToVelocity(
 
     Notes
     -----
-    A pressure wavefield (:math:`p(x, t)`) can be converted into an equivalent
-    vertical particle velocity wavefield (:math:`v_z(x, t)`) by applying
+    A pressure wavefield :math:`p(x, t)` can be converted into an equivalent
+    vertical particle velocity wavefield :math:`v_z(x, t)` by applying
     the following frequency-wavenumber dependant scaling [1]_:
 
     .. math::
-        v_z(k_x, \omega) = \frac{k_z}{\omega \rho} p(k_x, \omega)
+        \hat{v}_z(k_x, \omega) = \frac{k_z}{\omega \rho} \hat{p}(k_x, \omega)
 
     where the vertical wavenumber :math:`k_z` is defined as
-    :math:`k_z=\sqrt{\omega^2/c^2 - k_x^2}`.
+    :math:`k_z=\sqrt{\frac{\omega^2}{c^2} - k_x^2}`.
 
     Similarly a vertical particle velocity can be converted into an equivalent
     pressure wavefield by applying the following frequency-wavenumber
     dependant scaling [1]_:
 
     .. math::
-        p(k_x, \omega) = \frac{\omega \rho}{k_z} v_z(k_x, \omega)
+        \hat{p}(k_x, \omega) = \frac{\omega \rho}{k_z} \hat{v}_z(k_x, \omega)
 
     For 3-dimensional applications the only difference is represented
     by the vertical wavenumber :math:`k_z`, which is defined as
-    :math:`k_z=\sqrt{\omega^2/c^2 - k_x^2 - k_y^2}`.
+    :math:`k_z=\sqrt{\frac{\omega^2}{c^2} - k_x^2 - k_y^2}`.
 
     In both cases, this operator is implemented as a concatanation of
     a 2 or 3-dimensional forward FFT (:class:`pylops.signalprocessing.FFT2` or
@@ -377,15 +377,15 @@ def UpDownComposition2D(
     dr : :obj:`float`
         Sampling along the receiver array
     rho : :obj:`float`
-        Density along the receiver array (must be constant)
+        Density :math:`\rho` along the receiver array (must be constant)
     vel : :obj:`float`
-        Velocity along the receiver array (must be constant)
+        Velocity :math:`c` along the receiver array (must be constant)
     nffts : :obj:`tuple`, optional
         Number of samples along the wavenumber and frequency axes
     critical : :obj:`float`, optional
         Percentage of angles to retain in obliquity factor. For example, if
         ``critical=100`` only angles below the critical angle
-        :math:`|k_x| < \frac{f(k_x)}{vel}` will be retained
+        :math:`|k_x| < \frac{f(k_x)}{c}` will be retained
         will be retained
     ntaper : :obj:`float`, optional
         Number of samples of taper applied to obliquity factor around critical
@@ -410,7 +410,7 @@ def UpDownComposition2D(
 
     Notes
     -----
-    Multi-component seismic data (:math:`p(x, t)` and :math:`v_z(x, t)`) can be
+    Multi-component seismic data :math:`p(x, t)` and :math:`v_z(x, t)` can be
     synthesized in the frequency-wavenumber domain
     as the superposition of the up- and downgoing constituents of
     the pressure wavefield (:math:`p^-(x, t)` and :math:`p^+(x, t)`)
@@ -418,20 +418,20 @@ def UpDownComposition2D(
 
     .. math::
         \begin{bmatrix}
-            \mathbf{p}(k_x, \omega)  \\
-            \mathbf{v_z}(k_x, \omega)
-        \end{bmatrix} =
+            \hat{p}  \\
+            \hat{v_z}
+        \end{bmatrix}(k_x, \omega) =
         \begin{bmatrix}
             1  & 1 \\
             \frac{k_z}{\omega \rho}  & - \frac{k_z}{\omega \rho}  \\
         \end{bmatrix}
         \begin{bmatrix}
-            \mathbf{p^+}(k_x, \omega)  \\
-            \mathbf{p^-}(k_x, \omega)
-        \end{bmatrix}
+            \hat{p^+}  \\
+            \hat{p^-}
+        \end{bmatrix}(k_x, \omega)
 
     where the vertical wavenumber :math:`k_z` is defined as
-    :math:`k_z=\sqrt{\omega^2/c^2 - k_x^2}`.
+    :math:`k_z=\sqrt{\frac{\omega^2}{c^2} - k_x^2}`.
 
     We can write the entire composition process in a compact
     matrix-vector notation as follows:
@@ -439,11 +439,11 @@ def UpDownComposition2D(
     .. math::
         \begin{bmatrix}
             \mathbf{p}  \\
-            s*\mathbf{v_z}
+            s\mathbf{v_z}
         \end{bmatrix} =
         \begin{bmatrix}
             \mathbf{F} & 0 \\
-            0 & s*\mathbf{F}
+            0 & s\mathbf{F}
         \end{bmatrix} \begin{bmatrix}
             \mathbf{I} & \mathbf{I} \\
             \mathbf{W}^+ & \mathbf{W}^-
@@ -543,16 +543,16 @@ def UpDownComposition3D(
     dr : :obj:`tuple`
         Samplings along the receiver array
     rho : :obj:`float`
-        Density along the receiver array (must be constant)
+        Density :math:`\rho` along the receiver array (must be constant)
     vel : :obj:`float`
-        Velocity along the receiver array (must be constant)
+        Velocity :math:`c` along the receiver array (must be constant)
     nffts : :obj:`tuple`, optional
         Number of samples along the wavenumbers and frequency axes (for the
         wavenumbers axes the same order as ``nr`` and ``dr`` must be followed)
     critical : :obj:`float`, optional
         Percentage of angles to retain in obliquity factor. For example, if
         ``critical=100`` only angles below the critical angle
-        :math:`\sqrt{k_y^2 + k_x^2} < \frac{\omega}{vel}` will be retained
+        :math:`\sqrt{k_y^2 + k_x^2} < \frac{\omega}{c}` will be retained
     ntaper : :obj:`float`, optional
         Number of samples of taper applied to obliquity factor around critical
         angle
@@ -576,14 +576,14 @@ def UpDownComposition3D(
 
     Notes
     -----
-    Multi-component seismic data (:math:`p(y, x, t)` and :math:`v_z(y, x, t)`)
+    Multi-component seismic data :math:`p(y, x, t)` and :math:`v_z(y, x, t)`
     can be synthesized in the frequency-wavenumber domain
     as the superposition of the up- and downgoing constituents of
     the pressure wavefield (:math:`p^-(y, x, t)` and :math:`p^+(y, x, t)`)
     as described :class:`pylops.waveeqprocessing.UpDownComposition2D`.
 
     Here the vertical wavenumber :math:`k_z` is defined as
-    :math:`k_z=\sqrt{\omega^2/c^2 - k_y^2 - k_x^2}`.
+    :math:`k_z=\sqrt{\frac{\omega^2}{c^2} - k_y^2 - k_x^2}`.
 
     """
     nffts = (
@@ -655,12 +655,12 @@ def WavefieldDecomposition(
     Parameters
     ----------
     p : :obj:`np.ndarray`
-        Pressure data of size :math:`\lbrack n_{r_x} (\times n_{r_y})
-        \times n_t \rbrack` (or :math:`\lbrack n_{r_{x,sub}}
-        (\times n_{r_{y,sub}}) \times n_t \rbrack`
+        Pressure data of size :math:`\lbrack n_{r_x} \,(\times n_{r_y})
+        \times n_t \rbrack` (or :math:`\lbrack n_{r_{x,\text{sub}}}
+        \,(\times n_{r_{y,\text{sub}}}) \times n_t \rbrack`
         in case a ``restriction`` operator is provided. Note that
-        :math:`n_{r_{x,sub}}` (and :math:`n_{r_{y,sub}}`)
-        must agree with the size of the output of this operator)
+        :math:`n_{r_{x,\text{sub}}}` (and :math:`n_{r_{y,\text{sub}}}`)
+        must agree with the size of the output of this operator.)
     vz : :obj:`np.ndarray`
         Vertical particle velocity data of same size as pressure data
     nt : :obj:`int`
@@ -672,14 +672,14 @@ def WavefieldDecomposition(
     dr : :obj:`float` or :obj:`tuple`
         Sampling along the receiver array (or axes)
     rho : :obj:`float`
-        Density along the receiver array (must be constant)
+        Density :math:`\rho` along the receiver array (must be constant)
     vel : :obj:`float`
-        Velocity along the receiver array (must be constant)
+        Velocity :math:`c` along the receiver array (must be constant)
     nffts : :obj:`tuple`, optional
         Number of samples along the wavenumber and frequency axes
     critical : :obj:`float`, optional
         Percentage of angles to retain in obliquity factor. For example, if
-        ``critical=100`` only angles below the critical angle :math:`\frac{f(k_x)}{v}`
+        ``critical=100`` only angles below the critical angle :math:`\frac{f(k_x)}{c}`
         will be retained
     ntaper : :obj:`float`, optional
         Number of samples of taper applied to obliquity factor around critical
@@ -717,24 +717,24 @@ def WavefieldDecomposition(
 
     Notes
     -----
-    Up- and down-going components of seismic data (:math:`p^-(x, t)`
-    and :math:`p^+(x, t)`) can be estimated from multi-component data
-    (:math:`p(x, t)` and :math:`v_z(x, t)`) by computing the following
+    Up- and down-going components of seismic data :math:`p^-(x, t)`
+    and :math:`p^+(x, t)` can be estimated from multi-component data
+    :math:`p(x, t)` and :math:`v_z(x, t)` by computing the following
     expression [1]_:
 
     .. math::
         \begin{bmatrix}
-            \mathbf{p^+}(k_x, \omega)  \\
-            \mathbf{p^-}(k_x, \omega)
-        \end{bmatrix} = \frac{1}{2}
+            \hat{p}^+  \\
+            \hat{p}^-
+        \end{bmatrix}(k_x, \omega) = \frac{1}{2}
         \begin{bmatrix}
             1  & \frac{\omega \rho}{k_z} \\
             1  & - \frac{\omega \rho}{k_z}  \\
         \end{bmatrix}
         \begin{bmatrix}
-            \mathbf{p}(k_x, \omega)  \\
-            \mathbf{v_z}(k_x, \omega)
-        \end{bmatrix}
+            \hat{p}  \\
+            \hat{v}_z
+        \end{bmatrix}(k_x, \omega)
 
     if ``kind='analytical'`` or alternatively by solving the equation in
     :func:`ptcpy.waveeqprocessing.UpDownComposition2D` as an inverse problem,
@@ -747,11 +747,11 @@ def WavefieldDecomposition(
     .. math::
         \begin{bmatrix}
             \mathbf{p}  \\
-            s*\mathbf{v_z}
+            s\mathbf{v_z}
         \end{bmatrix} =
         \begin{bmatrix}
             \mathbf{R}\mathbf{F} & 0 \\
-            0 & s*\mathbf{R}\mathbf{F}
+            0 & s\mathbf{R}\mathbf{F}
         \end{bmatrix} \mathbf{W} \begin{bmatrix}
             \mathbf{F}^H \mathbf{S} & 0 \\
             0 & \mathbf{F}^H \mathbf{S}

--- a/tutorials/ctscan.py
+++ b/tutorials/ctscan.py
@@ -28,7 +28,7 @@ np.random.seed(10)
 # such a type:
 #
 # .. math::
-#    t(r,\theta; x) = tan(90-\theta)*x + r/sin(\theta)
+#    t(r,\theta; x) = \tan(90°-\theta)x + \frac{r}{\sin(\theta)}
 #
 # where :math:`\theta` is the angle between the x-axis (:math:`x`) and
 # the perpendicular to the summation line and :math:`r` is the distance

--- a/tutorials/interpolation.py
+++ b/tutorials/interpolation.py
@@ -21,7 +21,7 @@ the regularly sampled signal :math:`\mathbf{x}` at random locations.
 The input and output signals are:
 
 .. math::
-   \mathbf{y}= [y_1, y_2,...,y_N]^T, \qquad \mathbf{x}= [x_1, x_2,...,x_M]^T, \qquad
+   \mathbf{y}= [y_1, y_2,\ldots,y_N]^T, \qquad \mathbf{x}= [x_1, x_2,\ldots,x_M]^T, \qquad
 
 with :math:`M>>N`.
 

--- a/tutorials/interpolation.py
+++ b/tutorials/interpolation.py
@@ -23,7 +23,7 @@ The input and output signals are:
 .. math::
    \mathbf{y}= [y_1, y_2,\ldots,y_N]^T, \qquad \mathbf{x}= [x_1, x_2,\ldots,x_M]^T, \qquad
 
-with :math:`M>>N`.
+with :math:`M \gg N`.
 
 """
 import matplotlib.pyplot as plt

--- a/tutorials/linearoperator.py
+++ b/tutorials/linearoperator.py
@@ -1,11 +1,11 @@
 """
 01. The LinearOpeator
 =====================
-This first tutorials is aimed at easing the use of the PyLops
+This first tutorial is aimed at easing the use of the PyLops
 library for both new users and developers.
 
 Since PyLops heavily relies  on the use of the
-:py:class:`scipy.sparse.linalg.LinearOperator` class of scipy, we will start
+:py:class:`scipy.sparse.linalg.LinearOperator` class of SciPy, we will start
 by looking at how to initialize a linear operator as well as
 different ways to apply the forward and adjoint operations. Finally we will
 investigate various *special methods*, also called *magic methods*

--- a/tutorials/lsm.py
+++ b/tutorials/lsm.py
@@ -14,8 +14,8 @@ a linear operator of such a kind:
 
 .. math::
         d(\mathbf{x_r}, \mathbf{x_s}, t) =
-        w(t) * \int_V G(\mathbf{x}, \mathbf{x_s}, t)
-        G(\mathbf{x_r}, \mathbf{x}, t) m(\mathbf{x}) d\mathbf{x}
+        w(t) * \int\limits_V G(\mathbf{x}, \mathbf{x_s}, t)
+        G(\mathbf{x_r}, \mathbf{x}, t) m(\mathbf{x})\,\mathrm{d}\mathbf{x}
 
 where :math:`m(\mathbf{x})` is the reflectivity
 at every location in the subsurface, :math:`G(\mathbf{x}, \mathbf{x_s}, t)`

--- a/tutorials/poststack.py
+++ b/tutorials/poststack.py
@@ -9,9 +9,9 @@ operator is used for modelling of both 1d and 2d synthetic post-stack seismic
 data from a profile or 2d model of the subsurface acoustic impedence.
 
 .. math::
-    d(t, \theta=0) = \frac{1}{2} w(t) * \frac{d\ln(AI(t))}{\quad dt}
+    d(t, \theta=0) = \frac{1}{2} w(t) * \frac{\mathrm{d}\ln \text{AI}(t)}{\mathrm{d}t}
 
-where :math:`AI(t)` is the acoustic impedance profile and :math:`w(t)` is
+where :math:`\text{AI}(t)` is the acoustic impedance profile and :math:`w(t)` is
 the time domain seismic wavelet. In compact form:
 
 .. math::

--- a/tutorials/prestack.py
+++ b/tutorials/prestack.py
@@ -16,7 +16,7 @@ data using 1d profiles or 2d models of different subsurface elastic parameters
 (P-wave velocity, S-wave velocity, and density) as input.
 
 .. math::
-    d(t, \theta) = w(t) * \sum_{i=1}^N G_i(t, \theta) \frac{d\ln(m_i(t))}{dt}
+    d(t, \theta) = w(t) * \sum_{i=1}^N G_i(t, \theta) \frac{\mathrm{d}\ln m_i(t)}{\mathrm{d}t}
 
 where :math:`\mathbf{m}(t)=[V_P(t), V_S(t), \rho(t)]` is a vector containing
 three elastic parameters at time :math:`t`, :math:`G_i(t, \theta)` are the

--- a/tutorials/realcomplex.py
+++ b/tutorials/realcomplex.py
@@ -16,13 +16,15 @@ the complex-valued problem:
 or the real-valued augmented system
 
 .. math::
+    \DeclareMathOperator{\Real}{Re}
+    \DeclareMathOperator{\Imag}{Im}
    \begin{bmatrix}
-       Re(\mathbf{y})  \\
-       Im(\mathbf{y})
+       \Real(\mathbf{y})  \\
+       \Imag(\mathbf{y})
    \end{bmatrix} =
    \begin{bmatrix}
-       Re(\mathbf{A})  \\
-       Im(\mathbf{A})
+       \Real(\mathbf{A})  \\
+       \Imag(\mathbf{A})
    \end{bmatrix}  \mathbf{x}
 
 Whilst we already know how to solve the first problem, let's see how we can

--- a/tutorials/seismicinterpolation.py
+++ b/tutorials/seismicinterpolation.py
@@ -10,11 +10,11 @@ operator which is applied along the spatial direction(s).
 .. math::
     \mathbf{y} = \mathbf{R} \mathbf{x}
 
-Here :math:`\mathbf{y} = [\mathbf{y}_{R1}^T, \mathbf{y}_{R2}^T,...,
+Here :math:`\mathbf{y} = [\mathbf{y}_{R1}^T, \mathbf{y}_{R2}^T,\ldots,
 \mathbf{y}_{RN^T}]^T` where each vector :math:`\mathbf{y}_{Ri}`
 contains all time samples recorded in the seismic data at the specific
 receiver :math:`R_i`. Similarly, :math:`\mathbf{x} = [\mathbf{x}_{r1}^T,
-\mathbf{x}_{r2}^T,..., \mathbf{x}_{rM}^T]`, contains all traces at the
+\mathbf{x}_{r2}^T,\ldots, \mathbf{x}_{rM}^T]`, contains all traces at the
 regularly and finely sampled receiver locations :math:`r_i`.
 
 By inverting such an equation we can create a regularized data with

--- a/tutorials/seismicinterpolation.py
+++ b/tutorials/seismicinterpolation.py
@@ -10,11 +10,11 @@ operator which is applied along the spatial direction(s).
 .. math::
     \mathbf{y} = \mathbf{R} \mathbf{x}
 
-Here :math:`\mathbf{y} = [\mathbf{y}_{R1}^T, \mathbf{y}_{R2}^T,\ldots,
-\mathbf{y}_{RN^T}]^T` where each vector :math:`\mathbf{y}_{Ri}`
+Here :math:`\mathbf{y} = [\mathbf{y}_{R_1}^T, \mathbf{y}_{R_2}^T,\ldots,
+\mathbf{y}_{R_N^T}]^T` where each vector :math:`\mathbf{y}_{R_i}`
 contains all time samples recorded in the seismic data at the specific
-receiver :math:`R_i`. Similarly, :math:`\mathbf{x} = [\mathbf{x}_{r1}^T,
-\mathbf{x}_{r2}^T,\ldots, \mathbf{x}_{rM}^T]`, contains all traces at the
+receiver :math:`R_i`. Similarly, :math:`\mathbf{x} = [\mathbf{x}_{r_1}^T,
+\mathbf{x}_{r_2}^T,\ldots, \mathbf{x}_{r_M}^T]`, contains all traces at the
 regularly and finely sampled receiver locations :math:`r_i`.
 
 By inverting such an equation we can create a regularized data with
@@ -101,15 +101,15 @@ axs[1].axis("tight")
 # * regularized inversion with second derivative along the spatial axis
 #
 #   .. math::
-#        J = ||\mathbf{y} - \mathbf{R} \mathbf{x}||_2 +
-#        \epsilon_\nabla ^2 ||\nabla \mathbf{x}||_2
+#        J = \|\mathbf{y} - \mathbf{R} \mathbf{x}\|_2 +
+#        \epsilon_\nabla ^2 \|\nabla \mathbf{x}\|_2
 #
 # * sparsity-promoting inversion with :py:class:`pylops.FFT2` operator used
 #   as sparsyfing transform
 #
 #   .. math::
-#        J = ||\mathbf{y} - \mathbf{R} \mathbf{F}^H \mathbf{x}||_2 +
-#        \epsilon ||\mathbf{F}^H \mathbf{x}||_1
+#        J = \|\mathbf{y} - \mathbf{R} \mathbf{F}^H \mathbf{x}\|_2 +
+#        \epsilon \|\mathbf{F}^H \mathbf{x}\|_1
 
 # smooth inversion
 D2op = pylops.SecondDerivative(

--- a/tutorials/solvers.py
+++ b/tutorials/solvers.py
@@ -28,7 +28,7 @@ elements from :math:`\mathbf{x}` at random locations is implemented using
     \mathbf{y}= [y_1, y_2,\ldots,y_N]^T, \qquad
     \mathbf{x}= [x_1, x_2,\ldots,x_M]^T, \qquad
 
-with :math:`M>>N`.
+with :math:`M \gg N`.
 
 """
 
@@ -97,7 +97,7 @@ plt.title("Data restriction")
 # without regularization*. We aim here to minimize the following cost function:
 #
 #   .. math::
-#        J = ||\mathbf{y} - \mathbf{R} \mathbf{x}||_2^2
+#        J = \|\mathbf{y} - \mathbf{R} \mathbf{x}\|_2^2
 #
 # Depending on the choice of the operator :math:`\mathbf{R}`, such problem can
 # be solved using explicit matrix solvers as well as iterative solvers. In
@@ -236,7 +236,7 @@ xreg = pylops.optimization.leastsquares.RegularizedInversion(
 # We can also write a preconditioned problem, whose cost function is
 #
 #   .. math::
-#       J= ||\mathbf{y} - \mathbf{R} \mathbf{P} \mathbf{p}||_2^2
+#       J= \|\mathbf{y} - \mathbf{R} \mathbf{P} \mathbf{p}\|_2^2
 #
 # where :math:`\mathbf{P}` is the precondioned operator, :math:`\mathbf{p}` is
 # the projected model in the preconditioned space, and
@@ -293,8 +293,8 @@ subax.set_xlim(0.05, 0.3)
 # (i.e., three spikes in the Fourier domain). Our new cost function is:
 #
 #   .. math::
-#        J_1 = ||\mathbf{y} - \mathbf{R} \mathbf{F} \mathbf{p}||_2^2 +
-#              \epsilon ||\mathbf{p}||_1
+#        J_1 = \|\mathbf{y} - \mathbf{R} \mathbf{F} \mathbf{p}\|_2^2 +
+#              \epsilon \|\mathbf{p}\|_1
 #
 # where :math:`\mathbf{F}` is the FFT operator. We will thus use the
 # :py:class:`pylops.optimization.sparsity.ISTA` and
@@ -348,9 +348,9 @@ plt.tight_layout()
 # case we try to solve a constrained problem):
 #
 #   .. math::
-#        J_1 = ||\mathbf{p}||_1
-#              \quad subj.to \quad  ||\mathbf{y} -
-#              \mathbf{R} \mathbf{F} \mathbf{p}||
+#        J_1 = \|\mathbf{p}\|_1
+#              \quad \text{subject to} \quad  \|\mathbf{y} -
+#              \mathbf{R} \mathbf{F} \mathbf{p}\|
 #
 # A very popular solver to solve such kind of cost function is called *spgl1*
 # and can be accessed via :py:class:`pylops.optimization.sparsity.SPGL1`.

--- a/tutorials/solvers.py
+++ b/tutorials/solvers.py
@@ -25,8 +25,8 @@ elements from :math:`\mathbf{x}` at random locations is implemented using
 :py:class:`pylops.Restriction`, and
 
 .. math::
-    \mathbf{y}= [y_1, y_2,...,y_N]^T, \qquad
-    \mathbf{x}= [x_1, x_2,...,x_M]^T, \qquad
+    \mathbf{y}= [y_1, y_2,\ldots,y_N]^T, \qquad
+    \mathbf{x}= [x_1, x_2,\ldots,x_M]^T, \qquad
 
 with :math:`M>>N`.
 


### PR DESCRIPTION
This PR improves documentation, mostly through bettering the math notation, but also fixing minor bugs and adding improved descriptions. In addition, the second commit removes the "Shared" and "Others" submenus under PyLops Utilities in favor of a single section for all utilities.

I have opened this PR as a draft for two reasons. First, the second commit may be removed if anyone disagrees with it. Second, there were some issues I identified during the preparation of this PR which need to be looked over.

* In [`pylops/avo/avo.py#448` ](https://github.com/PyLops/pylops/blob/bd3a919655ddbf91d9c6c63c456d99d3926b7517/pylops/avo/avo.py#L448), no `G_1` appears in the equation despite appearing in the returns. Please make sure this is correct.
* ISTA and FISTA require `alpha` which according to the documentation must be less than 1/λ(Op^H Op). It is not clear if this means 1 / [λ(Op^H Op)] or (1/λ) Op^H Op.