### PR TITLE
feature: Vectorize slope_estimate

### DIFF
--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -139,17 +139,11 @@ def slope_estimate(d, dz, dx, smooth=20):
         gzx = gaussian_filter(gzx, sigma=smooth)
         gxx = gaussian_filter(gxx, sigma=smooth)
 
-    slopes = np.zeros((nz, nx))
-    linearity = np.zeros((nz, nx))
-    for iz in range(nz):
-        for ix in range(nx):
-            lcommon1 = (0.5 * (gzz[iz, ix] + gxx[iz, ix]),)
-            lcommon2 = 0.5 * np.sqrt(
-                (gzz[iz, ix] - gxx[iz, ix]) ** 2 + 4 * gzx[iz, ix] ** 2
-            )
-            l1 = lcommon1 + lcommon2
-            l2 = lcommon1 - lcommon2
-            slopes[iz, ix] = np.arctan((l1 - gzz[iz, ix]) / gzx[iz, ix])
-            linearity[iz, ix] = 1 - l2 / l1
+    lcommon1 = 0.5 * (gzz + gxx)
+    lcommon2 = 0.5 * np.sqrt((gzz - gxx) ** 2 + 4 * gzx ** 2)
+    l1 = lcommon1 + lcommon2
+    l2 = lcommon1 - lcommon2
+    slopes = np.arctan((l1 - gzz) / gzx)
     slopes[np.isnan(slopes)] = 0.0
+    linearity = 1 - l2 / l1
     return slopes, linearity

--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -129,7 +129,6 @@ def slope_estimate(d, dz, dx, smooth=20):
         anisotropy in digitized images", Journal ASCI Imaging Workshop. 1995.
 
     """
-    nz, nx = d.shape
     gz, gx = np.gradient(d, dz, dx)
     gzz, gzx, gxx = gz * gz, gz * gx, gx * gx
 


### PR DESCRIPTION
This PR vectorizes the loops in `slope_estimate`. The seislet example improves by a factor of ~90x on my machine:

```python
%%timeit -n 100
slope = -pylops.utils.signalprocessing.slope_estimate(d.T, dt, dx, smooth=6)[0]
# New: 8.29 ms ± 144 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# Old: 754 ms ± 24.3 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```