### PR TITLE
Improvements to `slope_estimate`

### DIFF
--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -76,7 +76,7 @@ def nonstationary_convmtx(H, n, hc=0, pad=(0, 0)):
     return C
 
 
-def slope_estimate(d, dz, dx, smooth=5, eps=0):
+def slope_estimate(d, dz=1.0, dx=1.0, smooth=5, eps=0):
     r"""Local slope estimation
 
     Local slopes are estimated using the *Structure Tensor* algorithm [1]_.


### PR DESCRIPTION
This PR contains several improvements to `slope_estimate`, as well as its usage in `plot_seislet.py`.

### `slope_estimate`
Breaking changes:
* `slope_estimate` now returns slopes in the unit `dz/dx`. Motivation: the `slope_estimate` help claims it returns slopes and not angles. Indeed the usage in the seislet transform requires slopes and not angles. However, the current implementation returns `np.arctan((l1 - gzz) / gzx)`, which is an angle, and not a slope. **The new implementation returns `(l1 - gzz) / gzx`**. NB: Luckily the seislet example remains almost the same. Due to fact that x is in meters in the examples, the slopes are in the unit dt/dx, which is very very small, making the small angle approximation (tan θ ≈ θ) valid.
* `smooth` default has been decreased from 20 to 5. Motivation: When `dz` and `dx` are in the same order of magnitude, the slope estimate becomes much more stable. Very strong smoothing (like 20) destroys the local slope information. A good value seems to be 5.
* Added default values for samplings

Non-breaking changes:
* `gaussian_filter` is now called directly (without checking if `smooth > 0`). This allows setting ``smooth`` to an iterable, which in turn allows a smoothing value for each dimension.
* `eps` option is now available to regularize the slope. Default is set to 0 to not break previous code. This option is useful when little to no smoothing is used.
* Several improvements to the documentation, which was wrong in some locations.
* Second output renamed to `anistropies` from `linearity`. A high number should equal higher anisotropy, which was unclear before.

### `plot_seislet.py`
* Change x axis unit to km. It is very important to use samplings of the same order of magnitude in `slope_estimate`. Using `dx=8` and `dt=0.004`, for example, requires a very strong smoothing to work properly.
* Use `smooth=2.5` for slope estimate. Now that the units are commensurate, we can diminish the smoothing to improve the accuracy of the slope estimate.
* Set `aspect=2` to better visualize slopes.
* Slope unit should be s/km (y axis is t, x axis is x). By inspection, the slope on the top part of the image should be around `-0.11 = -0.2 (seconds) /1.75 (km)`. This agrees with the image, that puts the top values around `-0.12`
* Cosmetic changes to the images, including always centering colorscales around 0 and removing interpolation for the sparse transform domains.