### PR TITLE
Bug: fix issue with nfft<nt

### DIFF
--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -100,7 +100,7 @@ class _FFT_numpy(_BaseFFT):
             y *= self._scale
 
         if self.nfft > self.dims[self.dir]:
-            y = np.take(y, np.arange(0, self.dims[self.dir]), axis=self.dir)
+            y = np.take(y, range(0, self.dims[self.dir]), axis=self.dir)
         elif self.nfft < self.dims[self.dir]:
             y = np.pad(y, self.ifftpad)
 
@@ -191,7 +191,7 @@ class _FFT_scipy(_BaseFFT):
             y *= self._scale
 
         if self.nfft > self.dims[self.dir]:
-            y = np.take(y, np.arange(0, self.dims[self.dir]), axis=self.dir)
+            y = np.take(y, range(0, self.dims[self.dir]), axis=self.dir)
         elif self.nfft < self.dims[self.dir]:
             y = np.pad(y, self.ifftpad)
 
@@ -307,7 +307,7 @@ class _FFT_fftw(_BaseFFT):
         if self.dopad:
             x = np.pad(x, self.pad, "constant", constant_values=0)
         elif self.doifftpad:
-            x = np.take(x, np.arange(0, self.nfft), axis=self.dir)
+            x = np.take(x, range(0, self.nfft), axis=self.dir)
 
         # self.fftplan() always uses byte-alligned self.x as input array and
         # returns self.y as output array. As such, self.x must be copied so as
@@ -352,7 +352,7 @@ class _FFT_fftw(_BaseFFT):
             y *= self._scale
 
         if self.nfft > self.dims[self.dir]:
-            y = np.take(y, np.arange(0, self.dims[self.dir]), axis=self.dir)
+            y = np.take(y, range(0, self.dims[self.dir]), axis=self.dir)
         elif self.nfft < self.dims[self.dir]:
             y = np.pad(y, self.ifftpad)
 

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -97,9 +97,7 @@ class _FFT2D_numpy(_BaseFFTND):
             y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
         if self.nffts[1] > self.dims[self.dirs[1]]:
             y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])
-        if (self.nffts[0] < self.dims[self.dirs[0]]) or (
-            self.nffts[1] < self.dims[self.dirs[1]]
-        ):
+        if self.doifftpad:
             y = np.pad(y, self.ifftpad)
         if not self.clinear:
             y = np.real(y)

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -93,8 +93,14 @@ class _FFT2D_numpy(_BaseFFTND):
             y = np.fft.ifft2(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         if self.norm is _FFTNorms.NONE:
             y *= self._scale
-        y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
-        y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])
+        if self.nffts[0] > self.dims[self.dirs[0]]:
+            y = np.take(y, range(self.dims[self.dirs[0]]), axis=self.dirs[0])
+        if self.nffts[1] > self.dims[self.dirs[1]]:
+            y = np.take(y, range(self.dims[self.dirs[1]]), axis=self.dirs[1])
+        if (self.nffts[0] < self.dims[self.dirs[0]]) or (
+            self.nffts[1] < self.dims[self.dirs[1]]
+        ):
+            y = np.pad(y, self.ifftpad)
         if not self.clinear:
             y = np.real(y)
         y = y.astype(self.rdtype)

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -87,12 +87,7 @@ class _FFTND_numpy(_BaseFFTND):
         for direction, nfft in zip(self.dirs, self.nffts):
             if nfft > self.dims[direction]:
                 y = np.take(y, range(self.dims[direction]), axis=direction)
-        if any(
-            [
-                nfft < self.dims[direction]
-                for direction, nfft in zip(self.dirs, self.nffts)
-            ]
-        ):
+        if self.doifftpad:
             y = np.pad(y, self.ifftpad)
         if not self.clinear:
             y = np.real(y)
@@ -180,12 +175,7 @@ class _FFTND_scipy(_BaseFFTND):
         for direction, nfft in zip(self.dirs, self.nffts):
             if nfft > self.dims[direction]:
                 y = np.take(y, range(self.dims[direction]), axis=direction)
-        if any(
-            [
-                nfft < self.dims[direction]
-                for direction, nfft in zip(self.dirs, self.nffts)
-            ]
-        ):
+        if self.doifftpad:
             y = np.pad(y, self.ifftpad)
         if not self.clinear:
             y = np.real(y)

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -84,8 +84,16 @@ class _FFTND_numpy(_BaseFFTND):
             y = np.fft.ifftn(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         if self.norm is _FFTNorms.NONE:
             y *= self._scale
-        for direction in self.dirs:
-            y = np.take(y, range(self.dims[direction]), axis=direction)
+        for direction, nfft in zip(self.dirs, self.nffts):
+            if nfft > self.dims[direction]:
+                y = np.take(y, range(self.dims[direction]), axis=direction)
+        if any(
+            [
+                nfft < self.dims[direction]
+                for direction, nfft in zip(self.dirs, self.nffts)
+            ]
+        ):
+            y = np.pad(y, self.ifftpad)
         if not self.clinear:
             y = np.real(y)
         y = y.astype(self.rdtype)
@@ -169,8 +177,16 @@ class _FFTND_scipy(_BaseFFTND):
             y = scipy.fft.ifftn(x, s=self.nffts, axes=self.dirs, **self._norm_kwargs)
         if self.norm is _FFTNorms.NONE:
             y *= self._scale
-        for direction in self.dirs:
-            y = np.take(y, range(self.dims[direction]), axis=direction)
+        for direction, nfft in zip(self.dirs, self.nffts):
+            if nfft > self.dims[direction]:
+                y = np.take(y, range(self.dims[direction]), axis=direction)
+        if any(
+            [
+                nfft < self.dims[direction]
+                for direction, nfft in zip(self.dirs, self.nffts)
+            ]
+        ):
+            y = np.pad(y, self.ifftpad)
         if not self.clinear:
             y = np.real(y)
         if self.ifftshift_before.any():

--- a/pylops/signalprocessing/Seislet.py
+++ b/pylops/signalprocessing/Seislet.py
@@ -97,7 +97,6 @@ def _predict_haar(traces, dt, dx, slopes, repeat=0, backward=False, adj=False):
         pred_tmp = traces[ix]
         if adj:
             for irepeat in range(repeat - 1, -1, -1):
-                # print('Slope at', ix * slopejump + iback * repeat + idir * irepeat)
                 pred_tmp = _predict_trace(
                     pred_tmp,
                     t,
@@ -108,7 +107,6 @@ def _predict_haar(traces, dt, dx, slopes, repeat=0, backward=False, adj=False):
                 )
         else:
             for irepeat in range(repeat):
-                # print('Slope at', ix * slopejump + iback * repeat + idir * irepeat)
                 pred_tmp = _predict_trace(
                     pred_tmp,
                     t,
@@ -139,14 +137,11 @@ def _predict_lin(traces, dt, dx, slopes, repeat=0, backward=False, adj=False):
     pred = np.zeros_like(traces)
     for ix in range(nx):
         pred_tmp = traces[ix]
-        # print('Data+ at', ix * slopejump)
         if adj:
             if not ((ix == 0 and not backward) or (ix == nx - 1 and backward)):
                 pred_tmp1 = traces[ix - idir]
-            # if ix > 0: print('Data- at', (ix - idir) * slopejump)
             for irepeat in range(repeat - 1, -1, -1):
                 if (ix == 0 and not backward) or (ix == nx - 1 and backward):
-                    # print('Slope+ at', ix * slopejump + iback * repeat + idir * irepeat)
                     pred_tmp = _predict_trace(
                         pred_tmp,
                         t,
@@ -157,8 +152,6 @@ def _predict_lin(traces, dt, dx, slopes, repeat=0, backward=False, adj=False):
                     )
                     pred_tmp1 = 0
                 else:
-                    # print('Slope+ at', ix * slopejump + iback * repeat + idir * irepeat)
-                    # print('Slope- at', ix * slopejump + iback * repeat - idir * irepeat)
                     pred_tmp = _predict_trace(
                         pred_tmp,
                         t,
@@ -178,10 +171,8 @@ def _predict_lin(traces, dt, dx, slopes, repeat=0, backward=False, adj=False):
         else:
             if not ((ix == nx - 1 and not backward) or (ix == 0 and backward)):
                 pred_tmp1 = traces[ix + idir]
-            # if ix < nx - 1: print('Data- at', (ix + idir) * slopejump)
             for irepeat in range(repeat):
                 if (ix == nx - 1 and not backward) or (ix == 0 and backward):
-                    # print('Slope+ at', ix * slopejump + iback * repeat + idir * irepeat)
                     pred_tmp = _predict_trace(
                         pred_tmp,
                         t,
@@ -191,8 +182,6 @@ def _predict_lin(traces, dt, dx, slopes, repeat=0, backward=False, adj=False):
                     )
                     pred_tmp1 = 0
                 else:
-                    # print('Slope+ at', ix * slopejump + iback * repeat + idir * irepeat)
-                    # print('Slope- at', (ix + idir) * slopejump + iback * repeat - idir * irepeat)
                     pred_tmp = _predict_trace(
                         pred_tmp,
                         t,
@@ -348,10 +337,10 @@ class Seislet(LinearOperator):
            \mathbf{0} & \mathbf{I} & ... & \mathbf{0} & \mathbf{0} & -\mathbf{U^T} & ... & \mathbf{0}  \\
            ...        & ...        & ... & ...        & ...        & ...        & ... & ...         \\
            \mathbf{0} & \mathbf{0} & ... & \mathbf{I} & \mathbf{0} & \mathbf{0} & ... & -\mathbf{U^T} \\
-           \mathbf{P^T} & \mathbf{0} & ... & \mathbf{0} & \mathbf{I}-\mathbf{P^TU^T} & \mathbf{0} & ... & \mathbf{0}  \\
-           \mathbf{0} & \mathbf{P^T} & ... & \mathbf{0} & \mathbf{0} & \mathbf{I}-\mathbf{P^TU^T} & ... & \mathbf{0}  \\
+           \mathbf{P^T} & \mathbf{0} & ... & \mathbf{0} & \mathbf{I}-\mathbf{P^T U^T} & \mathbf{0} & ... & \mathbf{0}  \\
+           \mathbf{0} & \mathbf{P^T} & ... & \mathbf{0} & \mathbf{0} & \mathbf{I}-\mathbf{P^T U^T} & ... & \mathbf{0}  \\
            ...        & ...        & ... & ...          & ...        & ...        & ... & ...         \\
-           \mathbf{0} & \mathbf{0} & ... & \mathbf{P^T} & \mathbf{0} & \mathbf{0} & ... & \mathbf{I}-\mathbf{P^TU^T} \\
+           \mathbf{0} & \mathbf{0} & ... & \mathbf{P^T} & \mathbf{0} & \mathbf{0} & ... & \mathbf{I}-\mathbf{P^T U^T} \\
         \end{bmatrix}
         \begin{bmatrix}
            \mathbf{r}_1  \\ \mathbf{r}_2  \\ ... \\ \mathbf{r}_N \\

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -253,7 +253,8 @@ class _BaseFFTND(LinearOperator):
             nfft < self.dims[direction]
             for direction, nfft in zip(self.dirs, self.nffts)
         ]
-        if any(nfftshort):
+        self.doifftpad = any(nfftshort)
+        if self.doifftpad:
             self.ifftpad = [(0, 0)] * self.ndim
             for idir, (direction, nfshort) in enumerate(zip(self.dirs, nfftshort)):
                 if nfshort:

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -102,7 +102,7 @@ class _BaseFFT(LinearOperator):
             nfft = nffts[0]
         self.nfft = nfft
 
-        # Check if the user provided nnft smaller than n (size of signal in
+        # Check if the user provided nfft smaller than n (size of signal in
         # original domain). If so, raise a warning as this is unlikely a
         # wanted behavoir (since FFT routines cut some of the input signal
         # before applying fft, which is lost forever) and set a flag such that
@@ -247,7 +247,7 @@ class _BaseFFTND(LinearOperator):
                 )
             )
 
-        # Check if the user provided nnft smaller than n. See _BaseFFT for
+        # Check if the user provided nfft smaller than n. See _BaseFFT for
         # details
         nfftshort = [
             nfft < self.dims[direction]


### PR DESCRIPTION
This `PR` handles https://github.com/PyLops/pylops/issues/295 for all FFT operators.

Two changes are made:

1. A warning is raised when user selects `nfft<nt`;
2. When the above condition arises, the output of the adjoint is padded after ifft such as it has size `nt`. This way a user can select `nfft<nt` without getting an error when the adjoint is invoked