### PR TITLE
Drastically reduce warnings by patching `spartisty.py` and `leastsquares.py`

### DIFF
--- a/pylops/optimization/leastsquares.py
+++ b/pylops/optimization/leastsquares.py
@@ -144,6 +144,8 @@ def NormalEquationsInversion(
     if x0 is not None:
         y_normal = y_normal - Op_normal * x0
     if ncp == np:
+        if "atol" not in kwargs_solver:
+            kwargs_solver["atol"] = "legacy"
         xinv, istop = sp_cg(Op_normal, y_normal, **kwargs_solver)
     else:
         xinv = cg(

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -107,7 +107,10 @@ def _halfthreshold(x, thresh):
         Tresholded vector
 
     """
-    phi = 2.0 / 3.0 * np.arccos((thresh / 8.0) * (np.abs(x) / 3.0) ** (-1.5))
+    arg = np.ones_like(x)
+    arg[x != 0] = (thresh / 8.0) * (np.abs(x[x != 0]) / 3.0) ** (-1.5)
+    arg = np.clip(arg, -1, 1)
+    phi = 2.0 / 3.0 * np.arccos(arg)
     x1 = 2.0 / 3.0 * x * (1 + np.cos(2.0 * np.pi / 3.0 - phi))
     # x1[np.abs(x) <= 1.5 * thresh ** (2. / 3.)] = 0
     x1[np.abs(x) <= (54 ** (1.0 / 3.0) / 4.0) * thresh ** (2.0 / 3.0)] = 0


### PR DESCRIPTION
## Description
Running `pytests/test_sparsity.py` currently produces over 100,000 warnings, mostly due to an issue with how `_halfthreshold` is implemented in `pylops/optimization/sparsity.py`. Currently, it allows division by zero and arccos of values |x| > 1.

In addition, the SciPy cg solver is issuing warnings when it is called without `atol`.

## Solution
Regarding the first issue, we need to protect division from zero, and clip values above 1 and below -1 so as to be able to apply arrcos.

For the second issue, we add atol='legacy' when atol is not supplied by users.