### PR TITLE
Patch docs - v1.17 edition

### DIFF
--- a/docs/source/api/others.rst
+++ b/docs/source/api/others.rst
@@ -8,7 +8,7 @@ performing universal tasks that are used by several operators or simply within o
 the preparation of input data and subsequent visualization of results.
 
 Dot-test
-------
+--------
 
 .. currentmodule:: pylops.utils
 
@@ -18,7 +18,7 @@ Dot-test
     dottest
 
 Describe
-------
+--------
 
 .. currentmodule:: pylops.utils.describe
 
@@ -28,7 +28,7 @@ Describe
     describe
 
 Estimators
-------
+----------
 
 .. currentmodule:: pylops.utils
 
@@ -40,7 +40,7 @@ Estimators
     trace_nahutchpp
 
 Scalability test
-------
+----------------
 
 .. currentmodule:: pylops.utils
 
@@ -50,7 +50,7 @@ Scalability test
     scalability_test
 
 Synthetics
-------
+----------
 
 .. currentmodule:: pylops.utils
 
@@ -74,7 +74,7 @@ Synthetics
 
 
 Signal-processing
-------
+-----------------
 
 .. currentmodule:: pylops.utils
 
@@ -99,7 +99,7 @@ Tapers
 
 
 Wavelets
-------
+--------
 
 .. currentmodule:: pylops.utils
 
@@ -111,7 +111,7 @@ Wavelets
 
 
 Geophysical Reservoir characterization
-------
+--------------------------------------
 
 .. currentmodule:: pylops.avo
 

--- a/examples/plot_causalintegration.py
+++ b/examples/plot_causalintegration.py
@@ -19,7 +19,7 @@ plt.close("all")
 ###############################################################################
 # Let's start with a 1D example. Define the input parameters: number of samples
 # of input signal (``nt``), sampling step (``dt``) as well as the input
-# signal which will be equal to :math:`x(t)=sin(t)`:
+# signal which will be equal to :math:`x(t)=\sin(t)`:
 nt = 81
 dt = 0.3
 t = np.arange(nt) * dt
@@ -28,7 +28,7 @@ x = np.sin(t)
 ###############################################################################
 # We can now create our causal integration operator and apply it to the input
 # signal. We can also compute the analytical integral
-# :math:`y(t)=\int sin(t)dt=-cos(t)` and compare the results. We can also
+# :math:`y(t)=\int \sin(t)\,\mathrm{d}t=-\cos(t)` and compare the results. We can also
 # invert the integration operator and by remembering that this is equivalent
 # to a first order derivative, we will compare our inverted model with the
 # result obtained by simply applying the :py:class:`pylops.FirstDerivative`
@@ -37,7 +37,7 @@ x = np.sin(t)
 # Note that, as explained in details in :py:class:`pylops.CausalIntegration`,
 # integration has no unique solution, as any constant :math:`c` can be added
 # to the integrated signal :math:`y`, for example if :math:`x(t)=t^2` the
-# :math:`y(t) = \int t^2 dt = \frac{t^3}{3} + c`. We thus subtract first
+# :math:`y(t) = \int t^2 \,\mathrm{d}t = \frac{t^3}{3} + c`. We thus subtract first
 # sample from the analytical integral to obtain the same result as the
 # numerical one.
 

--- a/examples/plot_linearregr.py
+++ b/examples/plot_linearregr.py
@@ -10,7 +10,7 @@ coefficients, namely intercept :math:`\mathbf{x_0}` and gradient
 :math:`\mathbf{x_1}`, for this equation:
 
     .. math::
-        y_i = x_0 + x_1 t_i   \qquad \forall i=1,2,\ldots,N
+        y_i = x_0 + x_1 t_i   \qquad \forall i=0,1,\ldots,N-1
 
 As we can express this problem in a matrix form:
 

--- a/examples/plot_regr.py
+++ b/examples/plot_regr.py
@@ -9,7 +9,7 @@ In short, polynomial regression is the problem of finding the best fitting
 coefficients for the following equation:
 
     .. math::
-        y_i = \sum_{n=0}^{order} x_n t_i^n  \qquad \forall i=1,2,\ldots,N
+        y_i = \sum_{n=0}^\text{order} x_n t_i^n  \qquad \forall i=0,1,\ldots,N-1
 
 As we can express this problem in a matrix form:
 

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -42,7 +42,10 @@ class LinearOperator(spLinearOperator):
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly
         (``True``) or not (``False``)
+    clinear : :obj:`bool`
+        .. versionadded:: 1.17
 
+        Operator is complex-linear.
     """
 
     def __init__(self, Op=None, explicit=False, clinear=None):
@@ -773,7 +776,7 @@ class _ScaledLinearOperator(spLinearOperator):
     Modified version of scipy _ScaledLinearOperator which uses a modified
     _get_dtype where the scalar and operator types are passed separately to
     np.find_common_type. Passing them together does lead to problems when using
-    np.float32 operators which are casted to no.float64
+    np.float32 operators which are cast to np.float64
 
     """
 

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -43,7 +43,7 @@ class LinearOperator(spLinearOperator):
         Operator contains a matrix that can be solved explicitly
         (``True``) or not (``False``)
     clinear : :obj:`bool`
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Operator is complex-linear.
     """

--- a/pylops/avo/prestack.py
+++ b/pylops/avo/prestack.py
@@ -232,7 +232,7 @@ def PrestackWaveletModelling(
         variable will define that of the operator
     theta : :obj:`int`
         Incident angles in degrees. Must have same ``dtype`` of ``m`` (or
-        it will be automatically casted to it)
+        it will be automatically cast to it)
     nwav : :obj:`np.ndarray`
         Number of samples of wavelet to be applied/estimated
     wavc : :obj:`int`, optional

--- a/pylops/basicoperators/Block.py
+++ b/pylops/basicoperators/Block.py
@@ -47,10 +47,10 @@ def Block(ops, nproc=1, dtype=None):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_{1,1}}  & \mathbf{L_{1,2}} &  \ldots & \mathbf{L_{1,M}}  \\
-            \mathbf{L_{2,1}}  & \mathbf{L_{2,2}} &  \ldots & \mathbf{L_{2,M}}  \\
+            \mathbf{L}_{1,1}  & \mathbf{L}_{1,2} &  \ldots & \mathbf{L}_{1,M}  \\
+            \mathbf{L}_{2,1}  & \mathbf{L}_{2,2} &  \ldots & \mathbf{L}_{2,M}  \\
             \vdots            & \vdots           &  \ddots & \vdots            \\
-            \mathbf{L_{N,1}}  & \mathbf{L_{N,2}} &  \ldots & \mathbf{L_{N,M}}
+            \mathbf{L}_{N,1}  & \mathbf{L}_{N,2} &  \ldots & \mathbf{L}_{N,M}
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{x}_{1}  \\
@@ -59,26 +59,23 @@ def Block(ops, nproc=1, dtype=None):
             \mathbf{x}_{M}
         \end{bmatrix} =
         \begin{bmatrix}
-            \mathbf{L_{1,1}} \mathbf{x}_{1} + \mathbf{L_{1,2}} \mathbf{x}_{2} +
-            \mathbf{L_{1,M}} \mathbf{x}_{M} \\
-            \mathbf{L_{2,1}} \mathbf{x}_{1} + \mathbf{L_{2,2}} \mathbf{x}_{2} +
-            \mathbf{L_{2,M}} \mathbf{x}_{M} \\
+            \mathbf{L}_{1,1} \mathbf{x}_{1} + \mathbf{L}_{1,2} \mathbf{x}_{2} +
+            \mathbf{L}_{1,M} \mathbf{x}_{M} \\
+            \mathbf{L}_{2,1} \mathbf{x}_{1} + \mathbf{L}_{2,2} \mathbf{x}_{2} +
+            \mathbf{L}_{2,M} \mathbf{x}_{M} \\
             \vdots     \\
-            \mathbf{L_{N,1}} \mathbf{x}_{1} + \mathbf{L_{N,2}} \mathbf{x}_{2} +
-            \mathbf{L_{N,M}} \mathbf{x}_{M}
+            \mathbf{L}_{N,1} \mathbf{x}_{1} + \mathbf{L}_{N,2} \mathbf{x}_{2} +
+            \mathbf{L}_{N,M} \mathbf{x}_{M}
         \end{bmatrix}
 
     while its application in adjoint mode leads to
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_{1,1}}^H  & \mathbf{L_{2,1}}^H &  \ldots &
-            \mathbf{L_{N,1}}^H  \\
-            \mathbf{L_{1,2}}^H  & \mathbf{L_{2,2}}^H &  \ldots &
-            \mathbf{L_{N,2}}^H  \\
-            \vdots                 & \vdots                &  \ddots & \vdots \\
-            \mathbf{L_{1,M}}^H  & \mathbf{L_{2,M}}^H &  \ldots &
-            \mathbf{L_{N,M}}^H  \\
+            \mathbf{L}_{1,1}^H  & \mathbf{L}_{2,1}^H & \ldots & \mathbf{L}_{N,1}^H  \\
+            \mathbf{L}_{1,2}^H  & \mathbf{L}_{2,2}^H & \ldots & \mathbf{L}_{N,2}^H  \\
+            \vdots              & \vdots             & \ddots & \vdots \\
+            \mathbf{L}_{1,M}^H  & \mathbf{L}_{2,M}^H & \ldots & \mathbf{L}_{N,M}^H
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{y}_{1}  \\
@@ -87,16 +84,16 @@ def Block(ops, nproc=1, dtype=None):
             \mathbf{y}_{N}
         \end{bmatrix} =
         \begin{bmatrix}
-            \mathbf{L_{1,1}}^H \mathbf{y}_{1} +
-            \mathbf{L_{2,1}}^H \mathbf{y}_{2} +
-            \mathbf{L_{N,1}}^H \mathbf{y}_{N} \\
-            \mathbf{L_{1,2}}^H \mathbf{y}_{1} +
-            \mathbf{L_{2,2}}^H \mathbf{y}_{2} +
-            \mathbf{L_{N,2}}^H \mathbf{y}_{N} \\
+            \mathbf{L}_{1,1}^H \mathbf{y}_{1} +
+            \mathbf{L}_{2,1}^H \mathbf{y}_{2} +
+            \mathbf{L}_{N,1}^H \mathbf{y}_{N} \\
+            \mathbf{L}_{1,2}^H \mathbf{y}_{1} +
+            \mathbf{L}_{2,2}^H \mathbf{y}_{2} +
+            \mathbf{L}_{N,2}^H \mathbf{y}_{N} \\
             \vdots     \\
-            \mathbf{L_{1,M}}^H \mathbf{y}_{1} +
-            \mathbf{L_{2,M}}^H \mathbf{y}_{2} +
-            \mathbf{L_{N,M}}^H \mathbf{y}_{N}
+            \mathbf{L}_{1,M}^H \mathbf{y}_{1} +
+            \mathbf{L}_{2,M}^H \mathbf{y}_{2} +
+            \mathbf{L}_{N,M}^H \mathbf{y}_{N}
         \end{bmatrix}
 
     """

--- a/pylops/basicoperators/BlockDiag.py
+++ b/pylops/basicoperators/BlockDiag.py
@@ -46,10 +46,10 @@ class BlockDiag(LinearOperator):
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_1}  & \mathbf{0}   &  \ldots &  \mathbf{0}  \\
-            \mathbf{0}    & \mathbf{L_2} &  \ldots &  \mathbf{0}  \\
+            \mathbf{L}_1  & \mathbf{0}   &  \ldots &  \mathbf{0}  \\
+            \mathbf{0}    & \mathbf{L}_2 &  \ldots &  \mathbf{0}  \\
             \vdots        & \vdots       &  \ddots &  \vdots         \\
-            \mathbf{0}    & \mathbf{0}   &  \ldots &  \mathbf{L_N}
+            \mathbf{0}    & \mathbf{0}   &  \ldots &  \mathbf{L}_N
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{x}_{1}  \\
@@ -58,20 +58,20 @@ class BlockDiag(LinearOperator):
             \mathbf{x}_{N}
         \end{bmatrix} =
         \begin{bmatrix}
-            \mathbf{L_1} \mathbf{x}_{1}  \\
-            \mathbf{L_2} \mathbf{x}_{2}  \\
+            \mathbf{L}_1 \mathbf{x}_{1}  \\
+            \mathbf{L}_2 \mathbf{x}_{2}  \\
             \vdots     \\
-            \mathbf{L_N} \mathbf{x}_{N}
+            \mathbf{L}_N \mathbf{x}_{N}
         \end{bmatrix}
 
     while its application in adjoint mode leads to
 
     .. math::
         \begin{bmatrix}
-            \mathbf{L_1}^H  & \mathbf{0}     & \ldots & \mathbf{0}  \\
-            \mathbf{0}      & \mathbf{L_2}^H & \ldots & \mathbf{0}  \\
+            \mathbf{L}_1^H  & \mathbf{0}     & \ldots & \mathbf{0}  \\
+            \mathbf{0}      & \mathbf{L}_2^H & \ldots & \mathbf{0}  \\
             \vdots          & \vdots         & \ddots & \vdots      \\
-            \mathbf{0}      & \mathbf{0}     & \ldots & \mathbf{L_N}^H
+            \mathbf{0}      & \mathbf{0}     & \ldots & \mathbf{L}_N^H
         \end{bmatrix}
         \begin{bmatrix}
             \mathbf{y}_{1}  \\
@@ -80,10 +80,10 @@ class BlockDiag(LinearOperator):
             \mathbf{y}_{N}
         \end{bmatrix} =
         \begin{bmatrix}
-            \mathbf{L_1}^H \mathbf{y}_{1}  \\
-            \mathbf{L_2}^H \mathbf{y}_{2}  \\
+            \mathbf{L}_1^H \mathbf{y}_{1}  \\
+            \mathbf{L}_2^H \mathbf{y}_{2}  \\
             \vdots     \\
-            \mathbf{L_N}^H \mathbf{y}_{N}
+            \mathbf{L}_N^H \mathbf{y}_{N}
         \end{bmatrix}
 
     """

--- a/pylops/basicoperators/LinearRegression.py
+++ b/pylops/basicoperators/LinearRegression.py
@@ -43,7 +43,7 @@ def LinearRegression(taxis, dtype="float64"):
     The LinearRegression operator solves the following problem:
 
     .. math::
-        y_i = x_0 + x_1 t_i  \qquad \forall i=1,2,\ldots,N
+        y_i = x_0 + x_1 t_i  \qquad \forall i=0,1,\ldots,N-1
 
     We can express this problem in a matrix form
 
@@ -53,17 +53,17 @@ def LinearRegression(taxis, dtype="float64"):
     where
 
     .. math::
-        \mathbf{y}= [y_1, y_2,\ldots,y_N]^T, \qquad \mathbf{x}= [x_0, x_1]^T
+        \mathbf{y}= [y_0, y_1,\ldots,y_{N-1}]^T, \qquad \mathbf{x}= [x_0, x_1]^T
 
     and
 
     .. math::
         \mathbf{A}
         = \begin{bmatrix}
+            1       & t_{0}  \\
             1       & t_{1}  \\
-            1       & t_{2}  \\
             \vdots      & \vdots     \\
-            1       & t_{N}
+            1       & t_{N-1}
         \end{bmatrix}
 
     Note that this is a particular case of the :py:class:`pylops.Regression`

--- a/pylops/basicoperators/MatrixMult.py
+++ b/pylops/basicoperators/MatrixMult.py
@@ -69,7 +69,7 @@ class MatrixMult(LinearOperator):
         if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=self.dtype)):
             self.dtype = A.dtype
             logging.warning(
-                "Matrix A is a complex object, dtype " "casted to %s" % self.dtype
+                "Matrix A is a complex object, dtype cast to %s" % self.dtype
             )
 
     def _matvec(self, x):

--- a/pylops/basicoperators/Regression.py
+++ b/pylops/basicoperators/Regression.py
@@ -48,9 +48,9 @@ class Regression(LinearOperator):
     The Regression operator solves the following problem:
 
     .. math::
-        y_i = \sum_{n=0}^\text{order} x_n t_i^n  \qquad \forall i=1,2,\ldots,N
+        y_i = \sum_{n=0}^\text{order} x_n t_i^n  \qquad \forall i=0,1,\ldots,N-1
 
-    where :math:`N` represents the order of the chosen polynomial. We can
+    where :math:`N` represents the number of points in ``taxis``. We can
     express this problem in a matrix form
 
     .. math::
@@ -59,7 +59,7 @@ class Regression(LinearOperator):
     where
 
     .. math::
-        \mathbf{y}= [y_1, y_2,\ldots,y_N]^T,
+        \mathbf{y}= [y_0, y_1,\ldots,y_{N-1}]^T,
         \qquad \mathbf{x}= [x_0, x_1,\ldots,x_\text{order}]^T
 
     and
@@ -67,11 +67,11 @@ class Regression(LinearOperator):
     .. math::
         \mathbf{A}
         = \begin{bmatrix}
+            1      & t_{0}  & t_{0}^2 & \ldots & t_{0}^\text{order}  \\
             1      & t_{1}  & t_{1}^2 & \ldots & t_{1}^\text{order}  \\
-            1      & t_{2}  & t_{2}^2 & \ldots & t_{1}^\text{order}  \\
             \vdots & \vdots & \vdots  & \ddots & \vdots             \\
-            1      & t_{N}  & t_{N}^2 & \ldots & t_{N}^\text{order}
-        \end{bmatrix}
+            1      & t_{N-1}  & t_{N-1}^2 & \ldots & t_{N-1}^\text{order}
+        \end{bmatrix}_{N\times \text{order}+1}
 
     """
 

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -63,18 +63,18 @@ class Restriction(LinearOperator):
 
     .. math::
 
-        y_i = x_{l_i}  \quad \forall i=1,2,\ldots,N
+        y_i = x_{l_i}  \quad \forall i=0,1,\ldots,N-1
 
-    where :math:`\mathbf{l}=[l_1, l_2,\ldots, l_N]` is a vector containing the indeces
+    where :math:`\mathbf{l}=[l_0, l_1,\ldots, l_{N-1}]` is a vector containing the indeces
     of the original array at which samples are taken.
 
     Conversely, in adjoint mode the available values in the data vector
     :math:`\mathbf{y}` are placed at locations
-    :math:`\mathbf{l}=[l_1, l_2,\ldots, l_M]` in the model vector:
+    :math:`\mathbf{l}=[l_0, l_1,\ldots, l_{M-1}]` in the model vector:
 
     .. math::
 
-        x_{l_i} = y_i  \quad \forall i=1,2,\ldots,N
+        x_{l_i} = y_i  \quad \forall i=0,1,\ldots,N-1
 
     and :math:`x_{j}=0` for :math:`j \neq l_i` (i.e., at all other locations in input
     vector).

--- a/pylops/optimization/leastsquares.py
+++ b/pylops/optimization/leastsquares.py
@@ -64,6 +64,9 @@ def NormalEquationsInversion(
         :py:func:`pylops.optimization.solver.cg` are used as default for numpy
         and cupy `data`, respectively)
 
+        .. note::
+            When user does not supply ``atol``, it is set to "legacy".
+
     Returns
     -------
     xinv : :obj:`numpy.ndarray`

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -107,7 +107,7 @@ def _halfthreshold(x, thresh):
         Tresholded vector
 
         .. warning::
-            Since version 1.17 does not produce ``np.nan`` on bad input.
+            Since version 1.17.0 does not produce ``np.nan`` on bad input.
 
     """
     arg = np.ones_like(x)

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -106,6 +106,9 @@ def _halfthreshold(x, thresh):
     x1 : :obj:`numpy.ndarray`
         Tresholded vector
 
+        .. warning::
+            Since version 1.17 does not produce ``np.nan`` on bad input.
+
     """
     arg = np.ones_like(x)
     arg[x != 0] = (thresh / 8.0) * (np.abs(x[x != 0]) / 3.0) ** (-1.5)

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -252,7 +252,7 @@ class _FFT_fftw(_BaseFFT):
         )
         if self.cdtype != np.complex128:
             warnings.warn(
-                f"fftw backend returns complex128 dtype. To respect the passed dtype, data will be casted to {self.cdtype}."
+                f"fftw backend returns complex128 dtype. To respect the passed dtype, data will be cast to {self.cdtype}."
             )
 
         self.dims_t = self.dims.copy()
@@ -417,6 +417,8 @@ def FFT(
     sampling : :obj:`float`, optional
         Sampling step ``dt``.
     norm : `{"ortho", "none", "1/n"}`, optional
+        .. versionadded:: 1.17
+
         - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
           where :math:`N_F` is the number of samples in the Fourier domain given by ``nfft``.
 
@@ -427,13 +429,18 @@ def FFT(
 
         .. note:: For "none" and "1/n", the operator is not unitary, that is, the
           adjoint is not the inverse. To invert the operator, simply use ``Op \ y``.
+
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
         model is real.
     fftshift : :obj:`bool`, optional
-        Note: ``fftshift`` is deprecated, use ``ifftshift_before``.
+        .. deprecated:: 1.17
+
+            Use ``ifftshift_before``.
     ifftshift_before : :obj:`bool`, optional
+        .. versionadded:: 1.17
+
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
         with respect to the zero value sample. This will shift the zero value sample to
@@ -442,6 +449,8 @@ def FFT(
         Transform.
         Defaults to not applying ifftshift.
     fftshift_after : :obj:`bool`, optional
+        .. versionadded:: 1.17
+
         Apply fftshift (``True``) or not (``False``) to data vector (after FFT).
         Consider using this option when you require frequencies to be arranged
         naturally, from negative to positive. When not applying fftshift after FFT,
@@ -450,6 +459,9 @@ def FFT(
     engine : :obj:`str`, optional
         Engine used for fft computation (``numpy``, ``fftw``, or ``scipy``). Choose
         ``numpy`` when working with cupy arrays.
+
+        .. note:: Since version 1.17, accepts "scipy".
+
     dtype : :obj:`str`, optional
         Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
@@ -480,6 +492,8 @@ def FFT(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
+        .. versionadded:: 1.17
+
         Operator is complex-linear. Is false when either ``real=True`` or when
         ``dtype`` is not a complex type.
     explicit : :obj:`bool`

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -417,7 +417,7 @@ def FFT(
     sampling : :obj:`float`, optional
         Sampling step ``dt``.
     norm : `{"ortho", "none", "1/n"}`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
           where :math:`N_F` is the number of samples in the Fourier domain given by ``nfft``.
@@ -435,11 +435,11 @@ def FFT(
         (``False``). Used to enforce that the output of adjoint of a real
         model is real.
     fftshift : :obj:`bool`, optional
-        .. deprecated:: 1.17
+        .. deprecated:: 1.17.0
 
             Use ``ifftshift_before``.
     ifftshift_before : :obj:`bool`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
@@ -449,7 +449,7 @@ def FFT(
         Transform.
         Defaults to not applying ifftshift.
     fftshift_after : :obj:`bool`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Apply fftshift (``True``) or not (``False``) to data vector (after FFT).
         Consider using this option when you require frequencies to be arranged
@@ -460,7 +460,7 @@ def FFT(
         Engine used for fft computation (``numpy``, ``fftw``, or ``scipy``). Choose
         ``numpy`` when working with cupy arrays.
 
-        .. note:: Since version 1.17, accepts "scipy".
+        .. note:: Since version 1.17.0, accepts "scipy".
 
     dtype : :obj:`str`, optional
         Type of elements in input array. Note that the ``dtype`` of the operator
@@ -492,7 +492,7 @@ def FFT(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Operator is complex-linear. Is false when either ``real=True`` or when
         ``dtype`` is not a complex type.

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -257,7 +257,7 @@ def FFT2D(
         for both directions. Unlike ``nffts``, any ``None`` will not be converted to the
         default value.
     norm : `{"ortho", "none", "1/n"}`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
           where :math:`N_F` is the number of samples in the Fourier domain given by
@@ -295,7 +295,7 @@ def FFT2D(
         When passing a single value, the shift will the same for every direction. Pass
         a tuple to specify which dimensions are shifted.
     engine : :obj:`str`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Engine used for fft computation (``numpy`` or ``scipy``).
     dtype : :obj:`str`, optional
@@ -327,7 +327,7 @@ def FFT2D(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Operator is complex-linear. Is false when either ``real=True`` or when
         ``dtype`` is not a complex type.

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -257,6 +257,8 @@ def FFT2D(
         for both directions. Unlike ``nffts``, any ``None`` will not be converted to the
         default value.
     norm : `{"ortho", "none", "1/n"}`, optional
+        .. versionadded:: 1.17
+
         - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
           where :math:`N_F` is the number of samples in the Fourier domain given by
           product of all elements of ``nffts``.
@@ -268,6 +270,7 @@ def FFT2D(
 
         .. note:: For "none" and "1/n", the operator is not unitary, that is, the
           adjoint is not the inverse. To invert the operator, simply use ``Op \ y``.
+
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -292,6 +295,8 @@ def FFT2D(
         When passing a single value, the shift will the same for every direction. Pass
         a tuple to specify which dimensions are shifted.
     engine : :obj:`str`, optional
+        .. versionadded:: 1.17
+
         Engine used for fft computation (``numpy`` or ``scipy``).
     dtype : :obj:`str`, optional
         Type of elements in input array. Note that the ``dtype`` of the operator
@@ -322,6 +327,8 @@ def FFT2D(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
+        .. versionadded:: 1.17
+
         Operator is complex-linear. Is false when either ``real=True`` or when
         ``dtype`` is not a complex type.
     explicit : :obj:`bool`

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -37,7 +37,7 @@ class _FFTND_numpy(_BaseFFTND):
         )
         if self.cdtype != np.complex128:
             warnings.warn(
-                f"numpy backend always returns complex128 dtype. To respect the passed dtype, data will be casted to {self.cdtype}."
+                f"numpy backend always returns complex128 dtype. To respect the passed dtype, data will be cast to {self.cdtype}."
             )
 
         self._norm_kwargs = {"norm": None}  # equivalent to "backward" in Numpy/Scipy
@@ -242,6 +242,8 @@ def FFTND(
         for all directions. Unlike ``nffts``, any ``None`` will not be converted to the
         default value.
     norm : `{"ortho", "none", "1/n"}`, optional
+        .. versionadded:: 1.17
+
         - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
           where :math:`N_F` is the number of samples in the Fourier domain given by
           product of all elements of ``nffts``.
@@ -253,6 +255,7 @@ def FFTND(
 
         .. note:: For "none" and "1/n", the operator is not unitary, that is, the
           adjoint is not the inverse. To invert the operator, simply use ``Op \ y``.
+
     real : :obj:`bool`, optional
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
@@ -260,6 +263,8 @@ def FFTND(
         dimension to which the FFTND operator is applied (last element of
         ``dirs``)
     ifftshift_before : :obj:`tuple` or :obj:`bool`, optional
+        .. versionadded:: 1.17
+
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
         with respect to the zero value sample. This will shift the zero value sample to
@@ -269,6 +274,8 @@ def FFTND(
         When passing a single value, the shift will the same for every direction. Pass
         a tuple to specify which dimensions are shifted.
     fftshift_after : :obj:`tuple` or :obj:`bool`, optional
+        .. versionadded:: 1.17
+
         Apply fftshift (``True``) or not (``False``) to data vector (after FFT).
         Consider using this option when you require frequencies to be arranged
         naturally, from negative to positive. When not applying fftshift after FFT,
@@ -277,13 +284,15 @@ def FFTND(
         When passing a single value, the shift will the same for every direction. Pass
         a tuple to specify which dimensions are shifted.
     engine : :obj:`str`, optional
+        .. versionadded:: 1.17
+
         Engine used for fft computation (``numpy`` or ``scipy``).
     dtype : :obj:`str`, optional
         Type of elements in input array. Note that the ``dtype`` of the operator
         is the corresponding complex type even when a real type is provided.
         In addition, note that the NumPy backend does not support returning ``dtype``
         different than ``complex128``. As such, when using the NumPy backend, arrays will
-        be force-casted to types corresponding to the supplied ``dtype``.
+        be force-cast to types corresponding to the supplied ``dtype``.
         The SciPy backend supports all precisions natively.
         Under both backends, when a real ``dtype`` is supplied, a real result will be
         enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
@@ -306,6 +315,8 @@ def FFTND(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
+        .. versionadded:: 1.17
+
         Operator is complex-linear. Is false when either ``real=True`` or when
         ``dtype`` is not a complex type.
     explicit : :obj:`bool`

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -242,7 +242,7 @@ def FFTND(
         for all directions. Unlike ``nffts``, any ``None`` will not be converted to the
         default value.
     norm : `{"ortho", "none", "1/n"}`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         - "ortho": Scales forward and adjoint FFT transforms with :math:`1/\sqrt{N_F}`,
           where :math:`N_F` is the number of samples in the Fourier domain given by
@@ -263,7 +263,7 @@ def FFTND(
         dimension to which the FFTND operator is applied (last element of
         ``dirs``)
     ifftshift_before : :obj:`tuple` or :obj:`bool`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Apply ifftshift (``True``) or not (``False``) to model vector (before FFT).
         Consider using this option when the model vector's respective axis is symmetric
@@ -274,7 +274,7 @@ def FFTND(
         When passing a single value, the shift will the same for every direction. Pass
         a tuple to specify which dimensions are shifted.
     fftshift_after : :obj:`tuple` or :obj:`bool`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Apply fftshift (``True``) or not (``False``) to data vector (after FFT).
         Consider using this option when you require frequencies to be arranged
@@ -284,7 +284,7 @@ def FFTND(
         When passing a single value, the shift will the same for every direction. Pass
         a tuple to specify which dimensions are shifted.
     engine : :obj:`str`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Engine used for fft computation (``numpy`` or ``scipy``).
     dtype : :obj:`str`, optional
@@ -315,7 +315,7 @@ def FFTND(
     shape : :obj:`tuple`
         Operator shape
     clinear : :obj:`bool`
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Operator is complex-linear. Is false when either ``real=True`` or when
         ``dtype`` is not a complex type.

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -224,6 +224,8 @@ def _describe(Op):
 def describe(Op):
     """Describe a PyLops operator
 
+    .. versionadded:: 1.17
+
     Convert a PyLops operator into a ``sympy`` mathematical formula.
     This routine is useful both for debugging and educational purposes.
 

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -224,7 +224,7 @@ def _describe(Op):
 def describe(Op):
     """Describe a PyLops operator
 
-    .. versionadded:: 1.17
+    .. versionadded:: 1.17.0
 
     Convert a PyLops operator into a ``sympy`` mathematical formula.
     This routine is useful both for debugging and educational purposes.

--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -94,13 +94,13 @@ def slope_estimate(d, dz=1.0, dx=1.0, smooth=5, eps=0):
         Sampling in :math:`z`-axis, :math:`\Delta z`
 
         .. warning::
-            Since version 1.17, defaults to 1.0.
+            Since version 1.17.0, defaults to 1.0.
 
     dx : :obj:`float`
         Sampling in :math:`x`-axis, :math:`\Delta x`
 
         .. warning::
-            Since version 1.17, defaults to 1.0.
+            Since version 1.17.0, defaults to 1.0.
 
     smooth : :obj:`float`, optional
         Standard deviation for Gaussian kernel. The standard deviations of the
@@ -108,10 +108,10 @@ def slope_estimate(d, dz=1.0, dx=1.0, smooth=5, eps=0):
         in which case it is equal for all axes.
 
         .. warning::
-            Default changed in version 1.17 to 5 from previous value of 20.
+            Default changed in version 1.17.0 to 5 from previous value of 20.
 
     eps : :obj:`float`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Regularization term. All slopes where :math:`|g_{zx}| < \epsilon \max |g_{zx}|`
         are set to zero. All anisotropies where :math:`\lambda_\text{max} < \epsilon`
@@ -125,14 +125,14 @@ def slope_estimate(d, dz=1.0, dx=1.0, smooth=5, eps=0):
         Estimated local slopes. Unit is that of :math:`\Delta z/\Delta x`.
 
         .. warning::
-            Prior to version 1.17, erroneously returned angles in radians instead of
+            Prior to version 1.17.0, erroneously returned angles in radians instead of
             slopes.
 
     anisotropies : :obj:`np.ndarray`
         Estimated local anisotropies: :math:`1-\lambda_\text{min}/\lambda_\text{max}`
 
         .. note::
-            Since 1.17, changed name from ``linearity`` to ``anisotropies``.
+            Since 1.17.0, changed name from ``linearity`` to ``anisotropies``.
             Definition remains the same.
 
 

--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -92,13 +92,27 @@ def slope_estimate(d, dz=1.0, dx=1.0, smooth=5, eps=0):
         Input dataset of size :math:`n_z \times n_x`
     dz : :obj:`float`
         Sampling in :math:`z`-axis, :math:`\Delta z`
+
+        .. warning::
+            Since version 1.17, defaults to 1.0.
+
     dx : :obj:`float`
         Sampling in :math:`x`-axis, :math:`\Delta x`
+
+        .. warning::
+            Since version 1.17, defaults to 1.0.
+
     smooth : :obj:`float`, optional
         Standard deviation for Gaussian kernel. The standard deviations of the
         Gaussian filter are given for each axis as a sequence, or as a single number,
         in which case it is equal for all axes.
+
+        .. warning::
+            Default changed in version 1.17 to 5 from previous value of 20.
+
     eps : :obj:`float`, optional
+        .. versionadded:: 1.17
+
         Regularization term. All slopes where :math:`|g_{zx}| < \epsilon \max |g_{zx}|`
         are set to zero. All anisotropies where :math:`\lambda_\text{max} < \epsilon`
         are also set to zero. See Notes. When using with small values of ``smooth``,
@@ -109,8 +123,18 @@ def slope_estimate(d, dz=1.0, dx=1.0, smooth=5, eps=0):
     -------
     slopes : :obj:`np.ndarray`
         Estimated local slopes. Unit is that of :math:`\Delta z/\Delta x`.
+
+        .. warning::
+            Prior to version 1.17, erroneously returned angles in radians instead of
+            slopes.
+
     anisotropies : :obj:`np.ndarray`
         Estimated local anisotropies: :math:`1-\lambda_\text{min}/\lambda_\text{max}`
+
+        .. note::
+            Since 1.17, changed name from ``linearity`` to ``anisotropies``.
+            Definition remains the same.
+
 
     Notes
     -----

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -139,6 +139,8 @@ class Marchenko:
         ``prescaled=True``, the ``R`` is assumed to have been pre-scaled by
         the user.
     fftengine : :obj:`str`, optional
+        .. versionadded:: 1.17
+
         Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
 
     Attributes

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -139,7 +139,7 @@ class Marchenko:
         ``prescaled=True``, the ``R`` is assumed to have been pre-scaled by
         the user.
     fftengine : :obj:`str`, optional
-        .. versionadded:: 1.17
+        .. versionadded:: 1.17.0
 
         Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
 

--- a/pylops/waveeqprocessing/oneway.py
+++ b/pylops/waveeqprocessing/oneway.py
@@ -166,10 +166,17 @@ def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64"):
         dims = (nt, kx.size, ky.size)
         dimsfft = (freq.size, kx.size, ky.size)
     Fop = FFT(dims, dir=0, nfft=nt, real=True, dtype=dtype)
-    Kxop = FFT(dimsfft, dir=1, nfft=kx.size, real=False, fftshift=True, dtype=dtypefft)
+    Kxop = FFT(
+        dimsfft, dir=1, nfft=kx.size, real=False, fftshift_after=True, dtype=dtypefft
+    )
     if ky is not None:
         Kyop = FFT(
-            dimsfft, dir=2, nfft=ky.size, real=False, fftshift=True, dtype=dtypefft
+            dimsfft,
+            dir=2,
+            nfft=ky.size,
+            real=False,
+            fftshift_after=True,
+            dtype=dtypefft,
         )
     Pop = _PhaseShift(vel, dz, freq, kx, ky, dtypefft)
     if ky is None:

--- a/pytests/test_oneway.py
+++ b/pytests/test_oneway.py
@@ -66,7 +66,7 @@ def test_PhaseShift_2dsignal(par):
     kx = np.fft.fftshift(np.fft.fftfreq(par["nx"], 1.0))
 
     Pop = PhaseShift(vel, zprop, par["nt"], freq, kx, dtype=par["dtype"])
-    assert dottest(Pop, par["nt"] * par["nx"], par["nt"] * par["nx"], tol=1e-5)
+    assert dottest(Pop, par["nt"] * par["nx"], par["nt"] * par["nx"])
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])

--- a/pytests/test_oneway.py
+++ b/pytests/test_oneway.py
@@ -66,7 +66,7 @@ def test_PhaseShift_2dsignal(par):
     kx = np.fft.fftshift(np.fft.fftfreq(par["nx"], 1.0))
 
     Pop = PhaseShift(vel, zprop, par["nt"], freq, kx, dtype=par["dtype"])
-    assert dottest(Pop, par["nt"] * par["nx"], par["nt"] * par["nx"])
+    assert dottest(Pop, par["nt"] * par["nx"], par["nt"] * par["nx"], tol=1e-5)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])


### PR DESCRIPTION
This PR contains several improvements to documentation, including math formatting and some language fixes. Most importantly, however, it documents with versionadded/note/warning tags all the changes introduced since the latest stable release v1.16.0.

Following the rationale in #306, I have used version v1.17 as the following major, but this can be amended if #306 is not accepted.