### PR TITLE
Minor: Extend Laplacian to Nd-arrays

### DIFF
--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -36,6 +36,11 @@ def Laplacian(
     l2op : :obj:`pylops.LinearOperator`
         Laplacian linear operator
 
+    Raises
+    ------
+    ValueError
+        If ``dirs``. ``weights``, and ``sampling`` do not have the same size
+
     Notes
     -----
     The Laplacian operator applies a second derivative along two directions of
@@ -48,6 +53,9 @@ def Laplacian(
                   / (\Delta x \Delta y)
 
     """
+    if not (len(dirs) == len(weights) == len(sampling)):
+        raise ValueError("dirs, weights, and sampling have different size")
+
     l2op = weights[0] * SecondDerivative(
         np.prod(dims),
         dims=dims,
@@ -56,12 +64,14 @@ def Laplacian(
         edge=edge,
         dtype=dtype,
     )
-    l2op += weights[1] * SecondDerivative(
-        np.prod(dims),
-        dims=dims,
-        dir=dirs[1],
-        sampling=sampling[1],
-        edge=edge,
-        dtype=dtype,
-    )
+
+    for dir, samp, weight in zip(dirs[1:], sampling[1:], weights[1:]):
+        l2op += weight * SecondDerivative(
+            np.prod(dims),
+            dims=dims,
+            dir=dir,
+            sampling=samp,
+            edge=edge,
+            dtype=dtype,
+        )
     return aslinearoperator(l2op)

--- a/pytests/test_derivative.py
+++ b/pytests/test_derivative.py
@@ -502,6 +502,22 @@ def test_Laplacian(par):
         tol=1e-3,
     )
 
+    # 3d - symmetrical on all directions
+    Dlapop = Laplacian(
+        (par["nz"], par["ny"], par["nx"]),
+        dirs=(0, 1, 2),
+        weights=(1, 1, 1),
+        sampling=(par["dz"], par["dx"], par["dx"]),
+        edge=par["edge"],
+        dtype="float32",
+    )
+    assert dottest(
+        Dlapop,
+        par["nz"] * par["ny"] * par["nx"],
+        par["nz"] * par["ny"] * par["nx"],
+        tol=1e-3,
+    )
+
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]


### PR DESCRIPTION
This PR extends the `Laplacian` operator to perform derivatives over N directions of a N-dimensional array.

Previously the operator could only apply derivatives over up to two directions of a N-dimensional array.