### PR TITLE
Bugfix: Modifications to handle scipy 1.8.0

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -11,8 +11,13 @@ from scipy.sparse.linalg import eigs as sp_eigs
 from scipy.sparse.linalg import eigsh as sp_eigsh
 from scipy.sparse.linalg import lobpcg as sp_lobpcg
 from scipy.sparse.linalg import lsqr, spsolve
-from scipy.sparse.linalg.interface import _ProductLinearOperator
 
+# need to check scipy version since the interface submodule changed into
+# _interface from scipy>=1.8.0
+if int(sp.__version__.split(".")[1]) < 8:
+    from scipy.sparse.linalg.interface import _ProductLinearOperator
+else:
+    from scipy.sparse.linalg._interface import _ProductLinearOperator
 from pylops.optimization.solver import cgls
 from pylops.utils.backend import get_array_module, get_module, get_sparse_eye
 from pylops.utils.estimators import trace_hutchinson, trace_hutchpp, trace_nahutchpp
@@ -298,7 +303,7 @@ class LinearOperator(spLinearOperator):
         else:
             if isinstance(y, np.ndarray):
                 # numpy backend
-                xest = lsqr(self, y, iter_lim=niter)[0]
+                xest = lsqr(self, y, iter_lim=niter, atol=1e-8, btol=1e-8)[0]
             else:
                 # cupy backend
                 ncp = get_array_module(y)

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -14,7 +14,8 @@ from scipy.sparse.linalg import lsqr, spsolve
 
 # need to check scipy version since the interface submodule changed into
 # _interface from scipy>=1.8.0
-if int(sp.__version__.split(".")[1]) < 8:
+sp_version = sp.__version__.split(".")
+if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import _ProductLinearOperator
 else:
     from scipy.sparse.linalg._interface import _ProductLinearOperator

--- a/pylops/basicoperators/BlockDiag.py
+++ b/pylops/basicoperators/BlockDiag.py
@@ -6,7 +6,8 @@ from scipy.sparse.linalg.interface import LinearOperator as spLinearOperator
 
 # need to check scipy version since the interface submodule changed into
 # _interface from scipy>=1.8.0
-if int(sp.__version__.split(".")[1]) < 8:
+sp_version = sp.__version__.split(".")
+if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import _get_dtype
 else:
     from scipy.sparse.linalg._interface import _get_dtype

--- a/pylops/basicoperators/BlockDiag.py
+++ b/pylops/basicoperators/BlockDiag.py
@@ -1,8 +1,15 @@
 import multiprocessing as mp
 
 import numpy as np
+import scipy as sp
 from scipy.sparse.linalg.interface import LinearOperator as spLinearOperator
-from scipy.sparse.linalg.interface import _get_dtype
+
+# need to check scipy version since the interface submodule changed into
+# _interface from scipy>=1.8.0
+if int(sp.__version__.split(".")[1]) < 8:
+    from scipy.sparse.linalg.interface import _get_dtype
+else:
+    from scipy.sparse.linalg._interface import _get_dtype
 
 from pylops import LinearOperator
 from pylops.basicoperators import MatrixMult

--- a/pylops/basicoperators/HStack.py
+++ b/pylops/basicoperators/HStack.py
@@ -6,7 +6,8 @@ from scipy.sparse.linalg.interface import LinearOperator as spLinearOperator
 
 # need to check scipy version since the interface submodule changed into
 # _interface from scipy>=1.8.0
-if int(sp.__version__.split(".")[1]) < 8:
+sp_version = sp.__version__.split(".")
+if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import _get_dtype
 else:
     from scipy.sparse.linalg._interface import _get_dtype

--- a/pylops/basicoperators/HStack.py
+++ b/pylops/basicoperators/HStack.py
@@ -1,8 +1,15 @@
 import multiprocessing as mp
 
 import numpy as np
+import scipy as sp
 from scipy.sparse.linalg.interface import LinearOperator as spLinearOperator
-from scipy.sparse.linalg.interface import _get_dtype
+
+# need to check scipy version since the interface submodule changed into
+# _interface from scipy>=1.8.0
+if int(sp.__version__.split(".")[1]) < 8:
+    from scipy.sparse.linalg.interface import _get_dtype
+else:
+    from scipy.sparse.linalg._interface import _get_dtype
 
 from pylops import LinearOperator
 from pylops.basicoperators import MatrixMult

--- a/pylops/basicoperators/VStack.py
+++ b/pylops/basicoperators/VStack.py
@@ -6,7 +6,8 @@ from scipy.sparse.linalg.interface import LinearOperator as spLinearOperator
 
 # need to check scipy version since the interface submodule changed into
 # _interface from scipy>=1.8.0
-if int(sp.__version__.split(".")[1]) < 8:
+sp_version = sp.__version__.split(".")
+if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import _get_dtype
 else:
     from scipy.sparse.linalg._interface import _get_dtype

--- a/pylops/basicoperators/VStack.py
+++ b/pylops/basicoperators/VStack.py
@@ -1,8 +1,15 @@
 import multiprocessing as mp
 
 import numpy as np
+import scipy as sp
 from scipy.sparse.linalg.interface import LinearOperator as spLinearOperator
-from scipy.sparse.linalg.interface import _get_dtype
+
+# need to check scipy version since the interface submodule changed into
+# _interface from scipy>=1.8.0
+if int(sp.__version__.split(".")[1]) < 8:
+    from scipy.sparse.linalg.interface import _get_dtype
+else:
+    from scipy.sparse.linalg._interface import _get_dtype
 
 from pylops import LinearOperator
 from pylops.basicoperators import MatrixMult

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -1,12 +1,24 @@
 import random
 import string
 
-from scipy.sparse.linalg.interface import (
-    _AdjointLinearOperator,
-    _ProductLinearOperator,
-    _SumLinearOperator,
-    _TransposedLinearOperator,
-)
+import scipy as sp
+
+# need to check scipy version since the interface submodule changed into
+# _interface from scipy>=1.8.0
+if int(sp.__version__.split(".")[1]) < 8:
+    from scipy.sparse.linalg.interface import (
+        _AdjointLinearOperator,
+        _ProductLinearOperator,
+        _SumLinearOperator,
+        _TransposedLinearOperator,
+    )
+else:
+    from scipy.sparse.linalg._interface import (
+        _AdjointLinearOperator,
+        _ProductLinearOperator,
+        _SumLinearOperator,
+        _TransposedLinearOperator,
+    )
 
 from pylops import LinearOperator
 from pylops.basicoperators import BlockDiag, HStack, VStack

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -5,7 +5,8 @@ import scipy as sp
 
 # need to check scipy version since the interface submodule changed into
 # _interface from scipy>=1.8.0
-if int(sp.__version__.split(".")[1]) < 8:
+sp_version = sp.__version__.split(".")
+if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import (
         _AdjointLinearOperator,
         _ProductLinearOperator,

--- a/pytests/test_avo.py
+++ b/pytests/test_avo.py
@@ -15,12 +15,14 @@ from pylops.avo.avo import (
 from pylops.avo.prestack import AVOLinearModelling
 from pylops.utils import dottest
 
+np.random.seed(0)
+
 # Create medium parameters for single contrast
 vp1, vs1, rho1 = 2200.0, 1300.0, 2000  # upper medium
 vp0, vs0, rho0 = 2300.0, 1400.0, 2100  # lower medium
 
 # Create medium parameters for multiple contrasts
-nt0 = 501
+nt0 = 201
 dt0 = 0.004
 t0 = np.arange(nt0) * dt0
 vp = 1200 + np.arange(nt0) + filtfilt(np.ones(5) / 5.0, 1, np.random.normal(0, 80, nt0))
@@ -126,5 +128,7 @@ def test_AVOLinearModelling(par):
     )
     assert dottest(AVOop, ntheta * nt0, 3 * nt0)
 
-    minv = lsqr(AVOop, AVOop * m, damp=1e-20, iter_lim=1000, show=0)[0]
+    minv = lsqr(
+        AVOop, AVOop * m, damp=1e-20, iter_lim=1000, atol=1e-8, btol=1e-8, show=0
+    )[0]
     assert_array_almost_equal(m, minv, decimal=3)

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -44,7 +44,9 @@ def test_Regression(par):
     assert dottest(LRop, par["ny"], order + 1)
 
     x = np.array([1.0, 2.0, 0.0, 3.0, -1.0], dtype=np.float32)
-    xlsqr = lsqr(LRop, LRop * x, damp=1e-10, iter_lim=300, show=0)[0]
+    xlsqr = lsqr(
+        LRop, LRop * x, damp=1e-10, iter_lim=300, atol=1e-8, btol=1e-8, show=0
+    )[0]
     assert_array_almost_equal(x, xlsqr, decimal=3)
 
     y = LRop * x

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -171,7 +171,9 @@ def test_BlockDiag(par):
         BDop, 2 * par["ny"], 2 * par["nx"], complexflag=0 if par["imag"] == 0 else 3
     )
 
-    xlsqr = lsqr(BDop, BDop * x, damp=1e-20, iter_lim=500, show=0)[0]
+    xlsqr = lsqr(
+        BDop, BDop * x, damp=1e-20, iter_lim=500, atol=1e-8, btol=1e-8, show=0
+    )[0]
     assert_array_almost_equal(x, xlsqr, decimal=3)
 
     # use numpy matrix directly in the definition of the operator

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -57,7 +57,9 @@ def test_VStack(par):
         Vop, 2 * par["ny"], par["nx"], complexflag=0 if par["imag"] == 0 else 3
     )
 
-    xlsqr = lsqr(Vop, Vop * x, damp=1e-20, iter_lim=300, show=0)[0]
+    xlsqr = lsqr(Vop, Vop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[
+        0
+    ]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
     # use numpy matrix directly in the definition of the operator
@@ -87,7 +89,9 @@ def test_HStack(par):
         Hop, par["ny"], 2 * par["nx"], complexflag=0 if par["imag"] == 0 else 3
     )
 
-    xlsqr = lsqr(Hop, Hop * x, damp=1e-20, iter_lim=300, show=0)[0]
+    xlsqr = lsqr(Hop, Hop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[
+        0
+    ]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
     # use numpy matrix directly in the definition of the operator
@@ -126,7 +130,9 @@ def test_Block(par):
         Bop, 2 * par["ny"], 2 * par["nx"], complexflag=0 if par["imag"] == 0 else 3
     )
 
-    xlsqr = lsqr(Bop, Bop * x, damp=1e-20, iter_lim=500, show=0)[0]
+    xlsqr = lsqr(Bop, Bop * x, damp=1e-20, iter_lim=500, atol=1e-8, btol=1e-8, show=0)[
+        0
+    ]
     assert_array_almost_equal(x, xlsqr, decimal=3)
 
     # use numpy matrix directly in the definition of the operator

--- a/pytests/test_wavedecomposition.py
+++ b/pytests/test_wavedecomposition.py
@@ -123,7 +123,7 @@ def test_WavefieldDecomposition2D(par, create_data2D):
         ntaper=ntaper,
         dottest=True,
         dtype="complex128",
-        **dict(damp=1e-10, iter_lim=10)
+        **dict(damp=1e-10, atol=1e-8, btol=1e-8, iter_lim=10)
     )
     assert np.linalg.norm(p2d_minus_est - p2d_minus) / np.linalg.norm(p2d_minus) < 2e-1
     assert np.linalg.norm(p2d_plus_est - p2d_plus) / np.linalg.norm(p2d_plus) < 2e-1
@@ -169,7 +169,7 @@ def test_WavefieldDecomposition3D(par, create_data3D):
         ntaper=ntaper,
         dottest=True,
         dtype="complex128",
-        **dict(damp=1e-10, iter_lim=10, show=2)
+        **dict(damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=2)
     )
     assert np.linalg.norm(p3d_minus_est - p3d_minus) / np.linalg.norm(p3d_minus) < 3e-1
     assert np.linalg.norm(p3d_plus_est - p3d_plus) / np.linalg.norm(p3d_plus) < 3e-1


### PR DESCRIPTION
Some of the private routines in scipy.sparse.linalg.interface have
been moved to scipy.sparse.linalg._interface. Moreover, scipy lsqr
atol and btol have changed in this version to more conservative values,
the old values are forced in PyLops to ensure tests to pass without
loosening up on tolerance.