### PR TITLE
Refactor dottest

### DIFF
--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -112,7 +112,7 @@ def dottest(
 
     def passes(xx, yy, tol=tol):
         """True if xx and yy are  the same within tolerance."""
-        return np.abs((yy - xx) / ((yy + xx + 1e-15) / 2)) < tol
+        return abs((yy - xx) / ((yy + xx + 1e-15) / 2)) < tol
 
     # evaluate if dot test is passed (both real and imag parts)
     passed = passes(np.real(xx), np.real(yy)) and passes(np.imag(xx), np.imag(yy))

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -114,12 +114,8 @@ def dottest(
         """True if xx and yy are  the same within tolerance."""
         return np.abs((yy - xx) / ((yy + xx + 1e-15) / 2)) < tol
 
-    # evaluate if dot test is passed
-    if complexflag == 0:
-        passed = passes(xx, yy)
-    else:
-        # Check both real and imag parts
-        passed = passes(np.real(xx), np.real(yy)) and passes(np.imag(xx), np.imag(yy))
+    # evaluate if dot test is passed (both real and imag parts)
+    passed = passes(np.real(xx), np.real(yy)) and passes(np.imag(xx), np.imag(yy))
 
     if not passed and raiseerror:
         raise ValueError(f"Dot test failed, v^H(Opu)={yy} - u^H(Op^Hv)={xx}")

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -120,7 +120,7 @@ def dottest(
     if not passed and raiseerror:
         raise ValueError(f"Dot test failed, v^H(Opu)={yy} - u^H(Op^Hv)={xx}")
     elif verb:
-        passed_str = ['failed', 'passed'][passed]
-        print(f"Dot test {passed_str}, v^H(Opu)={yy} - u^H(Op^Hv)={xx}")
+        passed_status = "passed" if passed else "failed"
+        print(f"Dot test {passed_status}, v^H(Opu)={yy} - u^H(Op^Hv)={xx}")
 
     return passed


### PR DESCRIPTION
Just refactoring, removing a lot of duplicate code. No functional change.

The only change is that the message always says `^H`, also for real values. I feel that is OK and not wrong, but if preferred I can add that it prints `^T` for real values.

Warning: I have _not_ tested it! I assume the tests that run when I create the PR will do that...

(I am using f-strings, f"{var}", which were introduced in Python 3.6; should be fine I think, or does PyLops still support Python 3.5?)