### PR TITLE
Check passed with np.isclose

### DIFF
--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -8,3 +8,5 @@ should be used as a checklist when converting a piece of code using PyLops from 
 - XX
 - XX
 - XX
+
+- `utils.dottest`: The relative tolerance is new set via `rtol` (before `tol`), and absolute tolerance is new supported via the keyword `atol`. When calling it with purely positional arguments, note that after `rtol` comes now first `atol` before `complexflag`. When using `raiseerror=True` it now emits an `AttributeError` instead of a `ValueError`.

--- a/examples/plot_nmo.py
+++ b/examples/plot_nmo.py
@@ -296,7 +296,7 @@ class NMO(LinearOperator):
 # and adjoint transforms truly are adjoints of each other.
 
 NMOOp = NMO(t, x, vel_t)
-dottest(NMOOp, *NMOOp.shape, tol=1e-4)
+dottest(NMOOp, *NMOOp.shape, rtol=1e-4)
 
 ###############################################################################
 # NMO using :py:class:`pylops.Spread`
@@ -370,7 +370,7 @@ SpreadNMO = Spread(
     dtable=nmo_dtable,  # Table of weights for linear interpolation
     engine="numba",  # numba or numpy
 ).H  # To perform NMO *correction*, we need the adjoint
-dottest(SpreadNMO, *SpreadNMO.shape, tol=1e-4)
+dottest(SpreadNMO, *SpreadNMO.shape, rtol=1e-4)
 
 ###############################################################################
 # We see it passes the dot test, but are the results right? Let's find out.

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -90,22 +90,15 @@ def dottest(
         raise AssertionError("Provided nr and nc do not match operator shape")
 
     # make u and v vectors
-    if complexflag != 0:
-        rdtype = np.real(np.ones(1, Op.dtype)).dtype
+    rdtype = np.ones(1, Op.dtype).real.dtype
 
-    if complexflag in (0, 2):
-        u = ncp.random.randn(nc).astype(Op.dtype)
-    else:
-        u = ncp.random.randn(nc).astype(rdtype) + 1j * ncp.random.randn(nc).astype(
-            rdtype
-        )
+    u = ncp.random.randn(nc).astype(rdtype)
+    if complexflag not in (0, 2):
+        u = u + 1j * ncp.random.randn(nc).astype(rdtype)
 
-    if complexflag in (0, 1):
-        v = ncp.random.randn(nr).astype(Op.dtype)
-    else:
-        v = ncp.random.randn(nr).astype(rdtype) + 1j * ncp.random.randn(nr).astype(
-            rdtype
-        )
+    v = ncp.random.randn(nr).astype(rdtype)
+    if complexflag not in (0, 1):
+        v = v + 1j * ncp.random.randn(nr).astype(rdtype)
 
     y = Op.matvec(u)  # Op * u
     x = Op.rmatvec(v)  # Op'* v

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 from pylops.utils.backend import get_module, to_numpy
@@ -8,11 +9,11 @@ def dottest(
     nr=None,
     nc=None,
     rtol=1e-6,
+    atol=1e-21,
     complexflag=0,
     raiseerror=True,
     verb=False,
     backend="numpy",
-    atol=1e-21,
     tol=None,  # deprecated, use rtol
 ):
     r"""Dot test.
@@ -32,6 +33,9 @@ def dottest(
         Number of columns of operator (i.e., elements in model)
     rtol : :obj:`float`, optional
         Relative dottest tolerance
+    atol : :obj:`float`, optional
+        Absolute dottest tolerance
+        .. versionadded:: 2.0.0
     complexflag : :obj:`bool`, optional
         Generate random vectors with
 
@@ -49,8 +53,10 @@ def dottest(
     backend : :obj:`str`, optional
         Backend used for dot test computations (``numpy`` or ``cupy``). This
         parameter will be used to choose how to create the random vectors.
-    atol : :obj:`float`, optional
-        Absolute dottest tolerance
+    tol : :obj:`float`, optional
+        Dottest tolerance
+        .. deprecated:: 2.0.0
+            Use ``rtol`` instead.
 
     Raises
     ------

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -86,7 +86,8 @@ def dottest(
     if nc is None:
         nc = Op.shape[1]
 
-    assert (nr, nc) == Op.shape, "Provided nr and nc do not match operator shape"
+    if (nr, nc) != Op.shape:
+        raise AssertionError("Provided nr and nc do not match operator shape")
 
     # make u and v vectors
     if complexflag != 0:

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -8,12 +8,12 @@ def dottest(
     nr=None,
     nc=None,
     rtol=1e-6,
-    atol=1e-21,
     complexflag=0,
     raiseerror=True,
     verb=False,
     backend="numpy",
-    tol=None,
+    atol=1e-21,
+    tol=None,  # deprecated, use rtol
 ):
     r"""Dot test.
 
@@ -32,8 +32,6 @@ def dottest(
         Number of columns of operator (i.e., elements in model)
     rtol : :obj:`float`, optional
         Relative dottest tolerance
-    atol : :obj:`float`, optional
-        Absolute dottest tolerance
     complexflag : :obj:`bool`, optional
         Generate random vectors with
 
@@ -51,6 +49,8 @@ def dottest(
     backend : :obj:`str`, optional
         Backend used for dot test computations (``numpy`` or ``cupy``). This
         parameter will be used to choose how to create the random vectors.
+    atol : :obj:`float`, optional
+        Absolute dottest tolerance
 
     Raises
     ------

--- a/pylops/utils/dottest.py
+++ b/pylops/utils/dottest.py
@@ -13,7 +13,7 @@ def dottest(
     raiseerror=True,
     verb=False,
     backend="numpy",
-    **kwargs,
+    tol=None,
 ):
     r"""Dot test.
 
@@ -71,8 +71,13 @@ def dottest(
         \mathbf{u}^H(\mathbf{Op}^H\mathbf{v})
 
     """
-    # Backwards compatibility for ``tol`` keyword:
-    rtol = kwargs.pop("tol", rtol)
+    if tol is not None:
+        warnings.warn(
+            "tol will be deprecated in version 2.0.0, use rtol instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        rtol = tol
 
     ncp = get_module(backend)
 

--- a/pytests/test_derivative.py
+++ b/pytests/test_derivative.py
@@ -97,7 +97,7 @@ def test_FirstDerivative_centered(par):
     D1op = FirstDerivative(
         par["nx"], sampling=par["dx"], edge=par["edge"], dtype="float32"
     )
-    assert dottest(D1op, par["nx"], par["nx"], tol=1e-3)
+    assert dottest(D1op, par["nx"], par["nx"], rtol=1e-3)
 
     x = (par["dx"] * np.arange(par["nx"])) ** 2
     yana = 2 * par["dx"] * np.arange(par["nx"])
@@ -113,7 +113,7 @@ def test_FirstDerivative_centered(par):
         edge=par["edge"],
         dtype="float32",
     )
-    assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     x = np.outer((par["dy"] * np.arange(par["ny"])) ** 2, np.ones(par["nx"]))
     yana = np.outer(2 * par["dy"] * np.arange(par["ny"]), np.ones(par["nx"]))
@@ -130,7 +130,7 @@ def test_FirstDerivative_centered(par):
         edge=par["edge"],
         dtype="float32",
     )
-    assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     x = np.outer((par["dy"] * np.arange(par["ny"])) ** 2, np.ones(par["nx"]))
     yana = np.zeros((par["ny"], par["nx"]))
@@ -151,7 +151,7 @@ def test_FirstDerivative_centered(par):
         D1op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     x = np.outer(
@@ -177,7 +177,7 @@ def test_FirstDerivative_centered(par):
         D1op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     x = np.outer(
@@ -201,7 +201,7 @@ def test_FirstDerivative_centered(par):
         D1op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     yana = np.zeros((par["nz"], par["ny"], par["nx"]))
@@ -223,7 +223,7 @@ def test_FirstDerivative_forwaback(par):
         D1op = FirstDerivative(
             par["nx"], sampling=par["dx"], edge=par["edge"], kind=kind, dtype="float32"
         )
-        assert dottest(D1op, par["nx"], par["nx"], tol=1e-3)
+        assert dottest(D1op, par["nx"], par["nx"], rtol=1e-3)
 
         # 2d - derivative on 1st direction
         D1op = FirstDerivative(
@@ -235,7 +235,7 @@ def test_FirstDerivative_forwaback(par):
             kind=kind,
             dtype="float32",
         )
-        assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+        assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
         # 2d - derivative on 2nd direction
         D1op = FirstDerivative(
@@ -247,7 +247,7 @@ def test_FirstDerivative_forwaback(par):
             kind=kind,
             dtype="float32",
         )
-        assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+        assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
         # 3d - derivative on 1st direction
         D1op = FirstDerivative(
@@ -263,7 +263,7 @@ def test_FirstDerivative_forwaback(par):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            tol=1e-3,
+            rtol=1e-3,
         )
 
         # 3d - derivative on 2nd direction
@@ -280,7 +280,7 @@ def test_FirstDerivative_forwaback(par):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            tol=1e-3,
+            rtol=1e-3,
         )
 
         # 3d - derivative on 3rd direction
@@ -297,7 +297,7 @@ def test_FirstDerivative_forwaback(par):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            tol=1e-3,
+            rtol=1e-3,
         )
 
 
@@ -321,7 +321,7 @@ def test_SecondDerivative_centered(par):
     D2op = SecondDerivative(
         par["nx"], sampling=par["dx"], edge=par["edge"], dtype="float32"
     )
-    assert dottest(D2op, par["nx"], par["nx"], tol=1e-3)
+    assert dottest(D2op, par["nx"], par["nx"], rtol=1e-3)
 
     # polynomial f(x) = x^3, f''(x) = 6x
     f = x ** 3
@@ -339,7 +339,7 @@ def test_SecondDerivative_centered(par):
         dtype="float32",
     )
 
-    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # polynomial f(x,y) = y^3, f_{yy}(x,y) = 6y
     f = yy ** 3
@@ -358,7 +358,7 @@ def test_SecondDerivative_centered(par):
         dtype="float32",
     )
 
-    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # polynomial f(x,y) = x^3, f_{xx}(x,y) = 6x
     f = xx ** 3
@@ -381,7 +381,7 @@ def test_SecondDerivative_centered(par):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # polynomial f(x,y,z) = y^3, f_{yy}(x,y,z) = 6y
@@ -406,7 +406,7 @@ def test_SecondDerivative_centered(par):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # polynomial f(x,y,z) = x^3, f_{xx}(x,y,z) = 6x
@@ -431,7 +431,7 @@ def test_SecondDerivative_centered(par):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["ny"] * par["nx"] * par["nz"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # polynomial f(x,y,z) = z^3, f_{zz}(x,y,z) = 6z
@@ -461,7 +461,7 @@ def test_SecondDerivative_forward(par):
     D2op = SecondDerivative(
         par["nx"], sampling=par["dx"], edge=par["edge"], kind="forward", dtype="float32"
     )
-    assert dottest(D2op, par["nx"], par["nx"], tol=1e-3)
+    assert dottest(D2op, par["nx"], par["nx"], rtol=1e-3)
 
     # 2d - derivative on 1st direction
     D2op = SecondDerivative(
@@ -474,7 +474,7 @@ def test_SecondDerivative_forward(par):
         dtype="float32",
     )
 
-    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # 2d - derivative on 2nd direction
     D2op = SecondDerivative(
@@ -487,7 +487,7 @@ def test_SecondDerivative_forward(par):
         dtype="float32",
     )
 
-    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # 3d - derivative on 1st direction
     D2op = SecondDerivative(
@@ -504,7 +504,7 @@ def test_SecondDerivative_forward(par):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # 3d - derivative on 2nd direction
@@ -522,7 +522,7 @@ def test_SecondDerivative_forward(par):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # 3d - derivative on 3rd direction
@@ -540,7 +540,7 @@ def test_SecondDerivative_forward(par):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["ny"] * par["nx"] * par["nz"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
 
@@ -558,7 +558,7 @@ def test_Laplacian(par):
         edge=par["edge"],
         dtype="float32",
     )
-    assert dottest(Dlapop, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(Dlapop, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # 2d - asymmetrical
     Dlapop = Laplacian(
@@ -569,7 +569,7 @@ def test_Laplacian(par):
         edge=par["edge"],
         dtype="float32",
     )
-    assert dottest(Dlapop, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(Dlapop, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # 3d - symmetrical on 1st and 2nd direction
     Dlapop = Laplacian(
@@ -584,7 +584,7 @@ def test_Laplacian(par):
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # 3d - symmetrical on 1st and 2nd direction
@@ -600,7 +600,7 @@ def test_Laplacian(par):
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     # 3d - symmetrical on all directions
@@ -616,7 +616,7 @@ def test_Laplacian(par):
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
 
@@ -634,7 +634,7 @@ def test_Gradient(par):
             kind=kind,
             dtype="float32",
         )
-        assert dottest(Gop, 2 * par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+        assert dottest(Gop, 2 * par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
         # 3d
         Gop = Gradient(
@@ -648,7 +648,7 @@ def test_Gradient(par):
             Gop,
             3 * par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            tol=1e-3,
+            rtol=1e-3,
         )
 
 
@@ -667,7 +667,7 @@ def test_FirstDirectionalDerivative(par):
             kind=kind,
             dtype="float32",
         )
-        assert dottest(Fdop, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+        assert dottest(Fdop, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
         # 3d
         Fdop = FirstDirectionalDerivative(
@@ -682,7 +682,7 @@ def test_FirstDirectionalDerivative(par):
             Fdop,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            tol=1e-3,
+            rtol=1e-3,
         )
 
 
@@ -699,7 +699,7 @@ def test_SecondDirectionalDerivative(par):
         edge=par["edge"],
         dtype="float32",
     )
-    assert dottest(Fdop, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+    assert dottest(Fdop, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
     # 3d
     Fdop = SecondDirectionalDerivative(
@@ -713,7 +713,7 @@ def test_SecondDirectionalDerivative(par):
         Fdop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
 

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -216,8 +216,8 @@ def test_FFT_small_real(par):
         y_true *= np.exp(2 * np.pi * 1j * FFTop.f * x0)
 
     assert_array_almost_equal(y, y_true, decimal=decimal)
-    assert dottest(FFTop, len(y), len(x), complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, len(y), len(x), complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, len(y), len(x), complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, len(y), len(x), complexflag=2, rtol=10 ** (-decimal))
 
     x_inv = FFTop / y
     x_inv = x_inv.reshape(x.shape)
@@ -275,8 +275,8 @@ def test_FFT_random_real(par):
 
     # Dot tests
     nr, nc = FFTop.shape
-    assert dottest(FFTop, nr, nc, complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, nr, nc, complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=2, rtol=10 ** (-decimal))
 
 
 par_lists_fft_small_cpx = dict(
@@ -327,7 +327,7 @@ def test_FFT_small_complex(par):
     # Compute FFT with FFTop and compare with y_true
     y = FFTop * x.ravel()
     assert_array_almost_equal(y, y_true, decimal=decimal)
-    assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+    assert dottest(FFTop, *FFTop.shape, complexflag=3, rtol=10 ** (-decimal))
 
     x_inv = FFTop / y
     x_inv = x_inv.reshape(x.shape)
@@ -409,11 +409,11 @@ def test_FFT_random_complex(par):
 
     # Dot tests
     nr, nc = FFTop.shape
-    assert dottest(FFTop, nr, nc, complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, nr, nc, complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=2, rtol=10 ** (-decimal))
     if np.issubdtype(dtype, np.complexfloating):
-        assert dottest(FFTop, nr, nc, complexflag=1, tol=10 ** (-decimal))
-        assert dottest(FFTop, nr, nc, complexflag=3, tol=10 ** (-decimal))
+        assert dottest(FFTop, nr, nc, complexflag=1, rtol=10 ** (-decimal))
+        assert dottest(FFTop, nr, nc, complexflag=3, rtol=10 ** (-decimal))
 
 
 par_lists_fft2d_random_real = dict(
@@ -470,8 +470,8 @@ def test_FFT2D_random_real(par):
 
     # Dot tests
     nr, nc = FFTop.shape
-    assert dottest(FFTop, nr, nc, complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, nr, nc, complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=2, rtol=10 ** (-decimal))
 
 
 par_lists_fft2d_random_cpx = dict(
@@ -550,11 +550,11 @@ def test_FFT2D_random_complex(par):
 
     # Dot tests
     nr, nc = FFTop.shape
-    assert dottest(FFTop, nr, nc, complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, nr, nc, complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=2, rtol=10 ** (-decimal))
     if np.issubdtype(dtype, np.complexfloating):
-        assert dottest(FFTop, nr, nc, complexflag=1, tol=10 ** (-decimal))
-        assert dottest(FFTop, nr, nc, complexflag=3, tol=10 ** (-decimal))
+        assert dottest(FFTop, nr, nc, complexflag=1, rtol=10 ** (-decimal))
+        assert dottest(FFTop, nr, nc, complexflag=3, rtol=10 ** (-decimal))
 
 
 par_lists_fftnd_random_real = dict(
@@ -612,8 +612,8 @@ def test_FFTND_random_real(par):
 
     # Dot tests
     nr, nc = FFTop.shape
-    assert dottest(FFTop, nr, nc, complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, nr, nc, complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=2, rtol=10 ** (-decimal))
 
 
 par_lists_fftnd_random_cpx = dict(
@@ -692,11 +692,11 @@ def test_FFTND_random_complex(par):
 
     # Dot tests
     nr, nc = FFTop.shape
-    assert dottest(FFTop, nr, nc, complexflag=0, tol=10 ** (-decimal))
-    assert dottest(FFTop, nr, nc, complexflag=2, tol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=0, rtol=10 ** (-decimal))
+    assert dottest(FFTop, nr, nc, complexflag=2, rtol=10 ** (-decimal))
     if np.issubdtype(dtype, np.complexfloating):
-        assert dottest(FFTop, nr, nc, complexflag=1, tol=10 ** (-decimal))
-        assert dottest(FFTop, nr, nc, complexflag=3, tol=10 ** (-decimal))
+        assert dottest(FFTop, nr, nc, complexflag=1, rtol=10 ** (-decimal))
+        assert dottest(FFTop, nr, nc, complexflag=3, rtol=10 ** (-decimal))
 
 
 par_lists_fft2dnd_small_cpx = dict(
@@ -750,7 +750,7 @@ def test_FFT2D_small_complex(par):
     y = FFTop * x.ravel()
     y = y.reshape(FFTop.dims_fft)
     assert_array_almost_equal(y, y_true, decimal=decimal)
-    assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+    assert dottest(FFTop, *FFTop.shape, complexflag=3, rtol=10 ** (-decimal))
 
     x_inv = FFTop / y.ravel()
     x_inv = x_inv.reshape(x.shape)
@@ -797,7 +797,7 @@ def test_FFTND_small_complex(par):
     y = FFTop * x.ravel()
     y = y.reshape(FFTop.dims_fft)
     assert_array_almost_equal(y, y_true, decimal=decimal)
-    assert dottest(FFTop, *FFTop.shape, complexflag=3, tol=10 ** (-decimal))
+    assert dottest(FFTop, *FFTop.shape, complexflag=3, rtol=10 ** (-decimal))
 
     x_inv = FFTop / y.ravel()
     x_inv = x_inv.reshape(x.shape)
@@ -842,11 +842,11 @@ def test_FFT_1dsignal(par):
 
     if par["real"]:
         assert dottest(
-            FFTop, nfft // 2 + 1, par["nt"], complexflag=2, tol=10 ** (-decimal)
+            FFTop, nfft // 2 + 1, par["nt"], complexflag=2, rtol=10 ** (-decimal)
         )
     else:
-        assert dottest(FFTop, nfft, par["nt"], complexflag=2, tol=10 ** (-decimal))
-        assert dottest(FFTop, nfft, par["nt"], complexflag=3, tol=10 ** (-decimal))
+        assert dottest(FFTop, nfft, par["nt"], complexflag=2, rtol=10 ** (-decimal))
+        assert dottest(FFTop, nfft, par["nt"], complexflag=3, rtol=10 ** (-decimal))
 
     y = FFTop * x
     xadj = FFTop.H * y  # adjoint is same as inverse for fft
@@ -922,11 +922,11 @@ def test_FFT_2dsignal(par):
 
     if par["real"]:
         assert dottest(
-            FFTop, (nfft // 2 + 1) * nx, nt * nx, complexflag=2, tol=10 ** (-decimal)
+            FFTop, (nfft // 2 + 1) * nx, nt * nx, complexflag=2, rtol=10 ** (-decimal)
         )
     else:
-        assert dottest(FFTop, nfft * nx, nt * nx, complexflag=2, tol=10 ** (-decimal))
-        assert dottest(FFTop, nfft * nx, nt * nx, complexflag=3, tol=10 ** (-decimal))
+        assert dottest(FFTop, nfft * nx, nt * nx, complexflag=2, rtol=10 ** (-decimal))
+        assert dottest(FFTop, nfft * nx, nt * nx, complexflag=3, rtol=10 ** (-decimal))
 
     D = FFTop * d.ravel()
     dadj = FFTop.H * D  # adjoint is same as inverse for fft
@@ -980,11 +980,11 @@ def test_FFT_2dsignal(par):
 
     if par["real"]:
         assert dottest(
-            FFTop, nt * (nfft // 2 + 1), nt * nx, complexflag=2, tol=10 ** (-decimal)
+            FFTop, nt * (nfft // 2 + 1), nt * nx, complexflag=2, rtol=10 ** (-decimal)
         )
     else:
-        assert dottest(FFTop, nt * nfft, nt * nx, complexflag=2, tol=10 ** (-decimal))
-        assert dottest(FFTop, nt * nfft, nt * nx, complexflag=3, tol=10 ** (-decimal))
+        assert dottest(FFTop, nt * nfft, nt * nx, complexflag=2, rtol=10 ** (-decimal))
+        assert dottest(FFTop, nt * nfft, nt * nx, complexflag=3, rtol=10 ** (-decimal))
 
     D = FFTop * d.ravel()
     dadj = FFTop.H * D  # adjoint is inverse for fft
@@ -1073,14 +1073,14 @@ def test_FFT_3dsignal(par):
             (nfft // 2 + 1) * nx * ny,
             nt * nx * ny,
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
-            FFTop, nfft * nx * ny, nt * nx * ny, complexflag=2, tol=10 ** (-decimal)
+            FFTop, nfft * nx * ny, nt * nx * ny, complexflag=2, rtol=10 ** (-decimal)
         )
         assert dottest(
-            FFTop, nfft * nx * ny, nt * nx * ny, complexflag=3, tol=10 ** (-decimal)
+            FFTop, nfft * nx * ny, nt * nx * ny, complexflag=3, rtol=10 ** (-decimal)
         )
 
     D = FFTop * d.ravel()
@@ -1113,14 +1113,14 @@ def test_FFT_3dsignal(par):
             nt * (nfft // 2 + 1) * ny,
             nt * nx * ny,
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
-            FFTop, nt * nfft * ny, nt * nx * ny, complexflag=2, tol=10 ** (-decimal)
+            FFTop, nt * nfft * ny, nt * nx * ny, complexflag=2, rtol=10 ** (-decimal)
         )
         assert dottest(
-            FFTop, nt * nfft * ny, nt * nx * ny, complexflag=3, tol=10 ** (-decimal)
+            FFTop, nt * nfft * ny, nt * nx * ny, complexflag=3, rtol=10 ** (-decimal)
         )
 
     D = FFTop * d.ravel()
@@ -1154,14 +1154,14 @@ def test_FFT_3dsignal(par):
             nt * nx * (nfft // 2 + 1),
             nt * nx * ny,
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
-            FFTop, nt * nx * nfft, nt * nx * ny, complexflag=2, tol=10 ** (-decimal)
+            FFTop, nt * nx * nfft, nt * nx * ny, complexflag=2, rtol=10 ** (-decimal)
         )
         assert dottest(
-            FFTop, nt * nx * nfft, nt * nx * ny, complexflag=3, tol=10 ** (-decimal)
+            FFTop, nt * nx * nfft, nt * nx * ny, complexflag=3, rtol=10 ** (-decimal)
         )
 
     D = FFTop * d.ravel()
@@ -1231,7 +1231,7 @@ def test_FFT2D(par):
             nfft1 * (nfft2 // 2 + 1),
             par["nt"] * par["nx"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
@@ -1239,14 +1239,14 @@ def test_FFT2D(par):
             nfft1 * nfft2,
             par["nt"] * par["nx"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
         assert dottest(
             FFTop,
             nfft1 * nfft2,
             par["nt"] * par["nx"],
             complexflag=3,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
 
     D = FFTop * d.ravel()
@@ -1277,7 +1277,7 @@ def test_FFT2D(par):
             nfft2 * (nfft1 // 2 + 1),
             par["nt"] * par["nx"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
@@ -1285,14 +1285,14 @@ def test_FFT2D(par):
             nfft1 * nfft2,
             par["nt"] * par["nx"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
         assert dottest(
             FFTop,
             nfft1 * nfft2,
             par["nt"] * par["nx"],
             complexflag=3,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
 
     D = FFTop * d.ravel()
@@ -1337,7 +1337,7 @@ def test_FFT3D(par):
             nfft1 * nfft2 * (nfft3 // 2 + 1),
             par["nt"] * par["nx"] * par["ny"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
@@ -1345,14 +1345,14 @@ def test_FFT3D(par):
             nfft1 * nfft2 * nfft3,
             par["nt"] * par["nx"] * par["ny"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
         assert dottest(
             FFTop,
             nfft1 * nfft2 * nfft3,
             par["nt"] * par["nx"] * par["ny"],
             complexflag=3,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
 
     D = FFTop * d.ravel()
@@ -1388,7 +1388,7 @@ def test_FFT3D(par):
             nfft1 * nfft3 * (nfft2 // 2 + 1),
             par["nt"] * par["nx"] * par["ny"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
@@ -1396,14 +1396,14 @@ def test_FFT3D(par):
             nfft1 * nfft2 * nfft3,
             par["nt"] * par["nx"] * par["ny"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
         assert dottest(
             FFTop,
             nfft1 * nfft2 * nfft3,
             par["nt"] * par["nx"] * par["ny"],
             complexflag=3,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
 
     D = FFTop * d.ravel()
@@ -1435,7 +1435,7 @@ def test_FFT3D(par):
             nfft2 * nfft3 * (nfft1 // 2 + 1),
             par["nt"] * par["nx"] * par["ny"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
     else:
         assert dottest(
@@ -1443,14 +1443,14 @@ def test_FFT3D(par):
             nfft1 * nfft2 * nfft3,
             par["nt"] * par["nx"] * par["ny"],
             complexflag=2,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
         assert dottest(
             FFTop,
             nfft1 * nfft2 * nfft3,
             par["nt"] * par["nx"] * par["ny"],
             complexflag=3,
-            tol=10 ** (-decimal),
+            rtol=10 ** (-decimal),
         )
 
     D = FFTop * d.ravel()

--- a/pytests/test_functionoperator.py
+++ b/pytests/test_functionoperator.py
@@ -28,7 +28,7 @@ for nr, nc, dtype in itertools.product(*PARS_LISTS):
             "nc": nc,
             "imag": 0 if dtype.startswith("float") else 1j,
             "dtype": dtype,
-            "tol": 1e-3 if dtype in ["float32", "complex64"] else 1e-6,
+            "rtol": 1e-3 if dtype in ["float32", "complex64"] else 1e-6,
         }
     ]
 
@@ -61,7 +61,7 @@ def test_FunctionOperator(par):
         par["nr"],
         par["nc"],
         complexflag=0 if par["imag"] == 0 else 3,
-        tol=par["tol"],
+        rtol=par["rtol"],
     )
 
     x = (np.ones(par["nc"]) + np.ones(par["nc"]) * par["imag"]).astype(par["dtype"])

--- a/pytests/test_oneway.py
+++ b/pytests/test_oneway.py
@@ -66,7 +66,7 @@ def test_PhaseShift_2dsignal(par):
     kx = np.fft.fftshift(np.fft.fftfreq(par["nx"], 1.0))
 
     Pop = PhaseShift(vel, zprop, par["nt"], freq, kx, dtype=par["dtype"])
-    assert dottest(Pop, par["nt"] * par["nx"], par["nt"] * par["nx"], tol=1e-5)
+    assert dottest(Pop, par["nt"] * par["nx"], par["nt"] * par["nx"], rtol=1e-5)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
@@ -83,7 +83,7 @@ def test_PhaseShift_3dsignal(par):
         Pop,
         par["nt"] * par["nx"] * par["ny"],
         par["nt"] * par["nx"] * par["ny"],
-        tol=1e-5,
+        rtol=1e-5,
     )
 
 

--- a/pytests/test_poststack.py
+++ b/pytests/test_poststack.py
@@ -96,11 +96,11 @@ def test_PoststackLinearModelling1d(par):
     """
     # Dense
     PPop_dense = PoststackLinearModelling(wav, nt0=nt0, explicit=True)
-    assert dottest(PPop_dense, nt0, nt0, tol=1e-4)
+    assert dottest(PPop_dense, nt0, nt0, rtol=1e-4)
 
     # Linear operator
     PPop = PoststackLinearModelling(wav, nt0=nt0, explicit=False)
-    assert dottest(PPop, nt0, nt0, tol=1e-4)
+    assert dottest(PPop, nt0, nt0, rtol=1e-4)
 
     # Compare data
     d = PPop * m.ravel()
@@ -133,11 +133,11 @@ def test_PoststackLinearModelling1d_nonstationary(par):
     """
     # Dense
     PPop_dense = PoststackLinearModelling(wavs, nt0=nt0, explicit=True)
-    assert dottest(PPop_dense, nt0, nt0, tol=1e-4)
+    assert dottest(PPop_dense, nt0, nt0, rtol=1e-4)
 
     # Linear operator
     PPop = PoststackLinearModelling(wavs, nt0=nt0, explicit=False)
-    assert dottest(PPop, nt0, nt0, tol=1e-4)
+    assert dottest(PPop, nt0, nt0, rtol=1e-4)
 
     # Compare data
     d = PPop * m.ravel()
@@ -171,11 +171,11 @@ def test_PoststackLinearModelling2d(par):
 
     # Dense
     PPop_dense = PoststackLinearModelling(wav, nt0=nz, spatdims=nx, explicit=True)
-    assert dottest(PPop_dense, nz * nx, nz * nx, tol=1e-4)
+    assert dottest(PPop_dense, nz * nx, nz * nx, rtol=1e-4)
 
     # Linear operator
     PPop = PoststackLinearModelling(wav, nt0=nz, spatdims=nx, explicit=False)
-    assert dottest(PPop, nz * nx, nz * nx, tol=1e-4)
+    assert dottest(PPop, nz * nx, nz * nx, rtol=1e-4)
 
     # Compare data
     d = (PPop * m2d.ravel()).reshape(nz, nx)

--- a/pytests/test_radon.py
+++ b/pytests/test_radon.py
@@ -158,7 +158,7 @@ def test_Radon2D(par):
         engine=par["engine"],
         dtype="float64",
     )
-    assert dottest(Rop, par["nhx"] * par["nt"], par["npx"] * par["nt"], tol=1e-3)
+    assert dottest(Rop, par["nhx"] * par["nt"], par["npx"] * par["nt"], rtol=1e-3)
 
     y = Rop * x.ravel()
     y1 = R1op * x.ravel()
@@ -223,7 +223,7 @@ def test_Radon3D(par):
             Rop,
             par["nhy"] * par["nhx"] * par["nt"],
             par["npy"] * par["npx"] * par["nt"],
-            tol=1e-3,
+            rtol=1e-3,
         )
         y = Rop * x.ravel()
         y1 = R1op * x.ravel()

--- a/pytests/test_smoothing.py
+++ b/pytests/test_smoothing.py
@@ -50,7 +50,7 @@ def test_Smoothing1D(par):
         D1op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        tol=1e-3,
+        rtol=1e-3,
     )
 
     x = np.random.normal(0, 1, (par["nz"], par["ny"], par["nx"])).ravel()
@@ -65,7 +65,7 @@ def test_Smoothing2D(par):
     # 2d kernel on 2d signal
     if par["dir"] < 2:
         D2op = Smoothing2D(nsmooth=(5, 5), dims=(par["ny"], par["nx"]), dtype="float64")
-        assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], tol=1e-3)
+        assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
 
         # forward
         x = np.zeros((par["ny"], par["nx"]))

--- a/tutorials/dottest.py
+++ b/tutorials/dottest.py
@@ -125,7 +125,7 @@ N = 10
 d = np.arange(N)
 Dop = pylops.Diagonal(d)
 
-dottest(Dop, N, N, tol=1e-6, complexflag=0, verb=True)
+dottest(Dop, N, N, rtol=1e-6, complexflag=0, verb=True)
 
 ###############################################################################
 # We move now to a more complicated operator, the :py:func:`pylops.signalprocessing.FFT`


### PR DESCRIPTION
As a follow-up to #335.

We can have the discussion here.

The defaults I set (`rtol=1e-6, atol=1e-21`) corresponds more or less to the status quo I think. Backwards compatibility is given through the kwargs option. So both, keyword and positional arguments will keep working the same way:
```
dottest(Op, nr, nc, tol)
dottest(Op, nr, nc, tol=tol)
```