### PR TITLE
Revamped __init__ files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,12 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        args: ["--profile", "black", "--filter-files", "--line-length=88"]
+        args:
+          [
+            "--profile",
+            "black",
+            "--skip",
+            "__init__.py",
+            "--filter-files",
+            "--line-length=88",
+          ]

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -1,61 +1,67 @@
-# isort: skip_file
+"""
+PyLops
+======
+
+Linear operators and inverse problems are at the core of many of the most used
+algorithms in signal processing, image processing, and remote sensing.
+When dealing with small-scale problems, the Python numerical scientific
+libraries `numpy <http://www.numpy.org>`_
+and `scipy <http://www.scipy.org/scipylib/index.html>`_  allow to perform most
+of the underlying matrix operations (e.g., computation of matrix-vector
+products and manipulation of matrices) in a simple and expressive way.
+
+Many useful operators, however, do not lend themselves to an explicit matrix
+representation when used to solve large-scale problems. PyLops operators,
+on the other hand, still represent a matrix and can be treated in a similar
+way, but do not rely on the explicit creation of a dense (or sparse) matrix
+itself. Conversely, the forward and adjoint operators are represented by small
+pieces of codes that mimic the effect of the matrix on a vector or
+another matrix.
+
+Luckily, many iterative methods (e.g. cg, lsqr) do not need to know the
+individual entries of a matrix to solve a linear system. Such solvers only
+require the computation of forward and adjoint matrix-vector products as
+done for any of the PyLops operators.
+
+PyLops provides
+  1. A general construct for creating Linear Operators
+  2. An extensive set of commonly used linear operators
+  3. A set of least-squares and sparse solvers for linear operators.
+
+Available subpackages
+---------------------
+basicoperators
+    Basic Linear Operators
+signalprocessing
+    Linear Operators for Signal Processing operations
+avo
+    Linear Operators for Seismic Reservoir Characterization
+waveeqprocessing
+    Linear Operators for Wave Equation oriented processing
+optimization
+    Solvers
+utils
+    Utility routines
+
+"""
+from . import (
+    avo,
+    basicoperators,
+    optimization,
+    signalprocessing,
+    utils,
+    waveeqprocessing,
+)
+from .avo.poststack import *
+from .avo.prestack import *
+from .basicoperators import *
 from .LinearOperator import LinearOperator
-from .basicoperators import Regression
-from .basicoperators import LinearRegression
-from .basicoperators import MatrixMult
-from .basicoperators import Identity
-from .basicoperators import Zero
-from .basicoperators import Diagonal
-from .basicoperators import Flip
-from .basicoperators import Symmetrize
-from .basicoperators import Spread
-from .basicoperators import Transpose
-from .basicoperators import Roll
-from .basicoperators import Pad
-from .basicoperators import Sum
-from .basicoperators import FunctionOperator
-from .basicoperators import MemoizeOperator
-
-from .basicoperators import VStack
-from .basicoperators import HStack
-from .basicoperators import Block
-from .basicoperators import BlockDiag
-from .basicoperators import Kronecker
-from .basicoperators import Real
-from .basicoperators import Imag
-from .basicoperators import Conj
-
-from .basicoperators import CausalIntegration
-from .basicoperators import FirstDerivative
-from .basicoperators import SecondDerivative
-from .basicoperators import Laplacian
-from .basicoperators import Gradient
-from .basicoperators import FirstDirectionalDerivative
-from .basicoperators import SecondDirectionalDerivative
-from .basicoperators import Restriction
-from .basicoperators import Smoothing1D
-from .basicoperators import Smoothing2D
-
-from .avo.poststack import PoststackLinearModelling
-from .avo.prestack import PrestackWaveletModelling, PrestackLinearModelling
-
-from .optimization.solver import cg, cgls
-from .optimization.leastsquares import NormalEquationsInversion, RegularizedInversion
-from .optimization.leastsquares import PreconditionedInversion
-from .optimization.sparsity import IRLS, OMP, ISTA, FISTA, SPGL1, SplitBregman
-
-from .utils.seismicevents import makeaxis, linear2d, parabolic2d
-from .utils.tapers import hanningtaper, cosinetaper, taper2d, taper3d
-from .utils.wavelets import ricker, gaussian
+from .optimization.leastsquares import *
+from .optimization.sparsity import *
+from .utils.seismicevents import *
+from .utils.tapers import *
 from .utils.utils import Report
-from .utils.deps import *
-
-from . import avo
-from . import basicoperators
-from . import optimization
-from . import signalprocessing
-from . import utils
-from . import waveeqprocessing
+from .utils.wavelets import *
 
 try:
     from .version import version as __version__

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -44,6 +44,9 @@ utils
     Utility routines
 
 """
+from .LinearOperator import LinearOperator
+from .basicoperators import *
+
 from . import (
     avo,
     basicoperators,
@@ -54,8 +57,7 @@ from . import (
 )
 from .avo.poststack import *
 from .avo.prestack import *
-from .basicoperators import *
-from .LinearOperator import LinearOperator
+from .optimization.solver import *
 from .optimization.leastsquares import *
 from .optimization.sparsity import *
 from .utils.seismicevents import *

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -44,6 +44,9 @@ utils
     Utility routines
 
 """
+
+# isort: skip_file
+
 from .LinearOperator import LinearOperator
 from .basicoperators import *
 

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -45,8 +45,6 @@ utils
 
 """
 
-# isort: skip_file
-
 from .LinearOperator import LinearOperator
 from .basicoperators import *
 

--- a/pylops/avo/__init__.py
+++ b/pylops/avo/__init__.py
@@ -8,7 +8,7 @@ Characterization.
 
 A list of available operators present in pylops.avo:
 
-    AVOLinearModelling	                    AVO modelling.
+    AVOLinearModelling                      AVO modelling.
     PoststackLinearModelling                Post-stack seismic modelling.
     PrestackLinearModelling                 Pre-stack seismic modelling.
     PrestackWaveletModelling                Pre-stack modelling operator for wavelet.
@@ -19,8 +19,6 @@ and a list of applications:
     PrestackInversion                       Pre-stack seismic inversion.
 
 """
-
-# isort: skip_file
 
 from .poststack import *
 from .prestack import *

--- a/pylops/avo/__init__.py
+++ b/pylops/avo/__init__.py
@@ -20,10 +20,17 @@ and a list of applications:
 
 """
 
-# from .poststack import *
-# from .prestack import *
+# isort: skip_file
+
+from .poststack import *
+from .prestack import *
 
 
-# __all__ = ['AVOLinearModelling', 'PoststackLinearModelling',
-#           'PrestackWaveletModelling', 'PrestackLinearModelling',
-#           'PoststackInversion', 'PrestackInversion']
+__all__ = [
+    "AVOLinearModelling",
+    "PoststackLinearModelling",
+    "PrestackWaveletModelling",
+    "PrestackLinearModelling",
+    "PoststackInversion",
+    "PrestackInversion",
+]

--- a/pylops/avo/__init__.py
+++ b/pylops/avo/__init__.py
@@ -1,1 +1,29 @@
-# isort: skip_file
+"""
+AVO Operators
+=============
+
+The subpackage avo provides linear operators and applications aimed at
+solving various inverse problems in the area of Seismic Reservoir
+Characterization.
+
+A list of available operators present in pylops.avo:
+
+    AVOLinearModelling	                    AVO modelling.
+    PoststackLinearModelling                Post-stack seismic modelling.
+    PrestackLinearModelling                 Pre-stack seismic modelling.
+    PrestackWaveletModelling                Pre-stack modelling operator for wavelet.
+
+and a list of applications:
+
+    PoststackInversion                      Post-stack seismic inversion.
+    PrestackInversion                       Pre-stack seismic inversion.
+
+"""
+
+# from .poststack import *
+# from .prestack import *
+
+
+# __all__ = ['AVOLinearModelling', 'PoststackLinearModelling',
+#           'PrestackWaveletModelling', 'PrestackLinearModelling',
+#           'PoststackInversion', 'PrestackInversion']

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -1,37 +1,111 @@
-# isort: skip_file
-from .FunctionOperator import FunctionOperator
-from .MemoizeOperator import MemoizeOperator
-from .Regression import Regression
-from .LinearRegression import LinearRegression
-from .MatrixMult import MatrixMult
-from .Diagonal import Diagonal
-from .Zero import Zero
-from .Identity import Identity
-from .Restriction import Restriction
-from .Flip import Flip
-from .Symmetrize import Symmetrize
-from .Spread import Spread
-from .Transpose import Transpose
-from .Roll import Roll
-from .Pad import Pad
-from .Sum import Sum
-from .Real import Real
-from .Imag import Imag
-from .Conj import Conj
+"""
+Basic Linear Operators
+======================
 
-from .VStack import VStack
-from .HStack import HStack
-from .Block import Block
-from .BlockDiag import BlockDiag
-from .Kronecker import Kronecker
+The subpackage basicoperators extends some of the basic linear algebra
+operations provided by numpy providing forward and adjoint functionalities.
 
-from .Smoothing1D import Smoothing1D
-from .Smoothing2D import Smoothing2D
+A list of operators present in pylops.basicoperators :
 
-from .CausalIntegration import CausalIntegration
-from .FirstDerivative import FirstDerivative
-from .SecondDerivative import SecondDerivative
-from .Laplacian import Laplacian
-from .Gradient import Gradient
-from .DirectionalDerivative import FirstDirectionalDerivative
-from .DirectionalDerivative import SecondDirectionalDerivative
+    MatrixMult	                    Matrix multiplication.
+    Identity                        Identity operator.
+    Zero         	                Zero operator.
+    Diagonal     	                Diagonal operator.
+    Transpose   	                Transpose operator.
+    Flip        	                Flip along an axis.
+    Roll                            Roll along an axis.
+    Pad                             Pad operator.
+    Sum                             Sum operator.
+    Symmetrize                      Symmetrize along an axis.
+    Restriction                     Restriction (or sampling) operator.
+    Regression                      Polynomial regression.
+    LinearRegression                Linear regression.
+    CausalIntegration               Causal integration.
+    Spread                          Spread operator.
+    VStack                          Vertical stacking.
+    HStack                          Horizontal stacking.
+    Block                           Block operator.
+    BlockDiag                       Block-diagonal operator.
+    Kronecker                       Kronecker operator.
+    Real   	                        Real operator.
+    Imag   	                        Imag operator.
+    Conj   	                        Conj operator.
+    Smoothing1D     	            1D Smoothing.
+    Smoothing2D	                    2D Smoothing.
+    FirstDerivative 	            First derivative.
+    SecondDerivative 	            Second derivative.
+    Laplacian 	                    Laplacian.
+    Gradient 	                    Gradient.
+    FirstDirectionalDerivative      First Directional derivative.
+    SecondDirectionalDerivative     Second Directional derivative.
+
+"""
+
+from .Block import *
+from .BlockDiag import *
+from .CausalIntegration import *
+from .Conj import *
+from .Diagonal import *
+from .DirectionalDerivative import *
+from .FirstDerivative import *
+from .Flip import *
+from .FunctionOperator import *
+from .Gradient import *
+from .HStack import *
+from .Identity import *
+from .Imag import *
+from .Kronecker import *
+from .Laplacian import *
+from .LinearRegression import *
+from .MatrixMult import *
+from .MemoizeOperator import *
+from .Pad import *
+from .Real import *
+from .Regression import *
+from .Restriction import *
+from .Roll import *
+from .SecondDerivative import *
+from .Smoothing1D import *
+from .Smoothing2D import *
+from .Spread import *
+from .Sum import *
+from .Symmetrize import *
+from .Transpose import *
+from .VStack import *
+from .Zero import *
+
+__all__ = [
+    "FunctionOperator",
+    "MemoizeOperator",
+    "Regression",
+    "LinearRegression",
+    "MatrixMult",
+    "Diagonal",
+    "Zero",
+    "Identity",
+    "Restriction",
+    "Flip",
+    "Symmetrize",
+    "Spread",
+    "Transpose",
+    "Roll",
+    "Pad",
+    "Sum",
+    "VStack",
+    "HStack",
+    "Block",
+    "BlockDiag",
+    "Kronecker",
+    "Real",
+    "Imag",
+    "Conj",
+    "Smoothing1D",
+    "Smoothing2D",
+    "CausalIntegration",
+    "FirstDerivative",
+    "SecondDerivative",
+    "Laplacian",
+    "Gradient",
+    "FirstDirectionalDerivative",
+    "SecondDirectionalDerivative",
+]

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -41,6 +41,8 @@ A list of operators present in pylops.basicoperators :
 
 """
 
+# isort: skip_file
+
 from .FunctionOperator import *
 from .MemoizeOperator import *
 from .Regression import *

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -27,9 +27,9 @@ A list of operators present in pylops.basicoperators :
     Block                           Block operator.
     BlockDiag                       Block-diagonal operator.
     Kronecker                       Kronecker operator.
-    Real   	                        Real operator.
-    Imag   	                        Imag operator.
-    Conj   	                        Conj operator.
+    Real                            Real operator.
+    Imag                            Imag operator.
+    Conj                            Conj operator.
     Smoothing1D     	            1D Smoothing.
     Smoothing2D	                    2D Smoothing.
     FirstDerivative 	            First derivative.
@@ -41,38 +41,41 @@ A list of operators present in pylops.basicoperators :
 
 """
 
-from .Block import *
-from .BlockDiag import *
-from .CausalIntegration import *
-from .Conj import *
-from .Diagonal import *
-from .DirectionalDerivative import *
-from .FirstDerivative import *
-from .Flip import *
 from .FunctionOperator import *
-from .Gradient import *
-from .HStack import *
-from .Identity import *
-from .Imag import *
-from .Kronecker import *
-from .Laplacian import *
+from .MemoizeOperator import *
+from .Regression import *
 from .LinearRegression import *
 from .MatrixMult import *
-from .MemoizeOperator import *
-from .Pad import *
-from .Real import *
-from .Regression import *
+from .Diagonal import *
+from .Zero import *
+from .Identity import *
 from .Restriction import *
+from .Flip import *
+from .Symmetrize import *
+from .Spread import *
+from .Transpose import *
 from .Roll import *
-from .SecondDerivative import *
+from .Pad import *
+from .Sum import *
+
+from .VStack import *
+from .HStack import *
+from .Block import *
+from .BlockDiag import *
+from .Kronecker import *
+from .Real import *
+from .Imag import *
+from .Conj import *
+
 from .Smoothing1D import *
 from .Smoothing2D import *
-from .Spread import *
-from .Sum import *
-from .Symmetrize import *
-from .Transpose import *
-from .VStack import *
-from .Zero import *
+
+from .CausalIntegration import *
+from .FirstDerivative import *
+from .SecondDerivative import *
+from .Laplacian import *
+from .Gradient import *
+from .DirectionalDerivative import *
 
 __all__ = [
     "FunctionOperator",

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -7,12 +7,12 @@ operations provided by numpy providing forward and adjoint functionalities.
 
 A list of operators present in pylops.basicoperators :
 
-    MatrixMult	                    Matrix multiplication.
+    MatrixMult                      Matrix multiplication.
     Identity                        Identity operator.
-    Zero         	                Zero operator.
-    Diagonal     	                Diagonal operator.
-    Transpose   	                Transpose operator.
-    Flip        	                Flip along an axis.
+    Zero                            Zero operator.
+    Diagonal                        Diagonal operator.
+    Transpose                       Transpose operator.
+    Flip                            Flip along an axis.
     Roll                            Roll along an axis.
     Pad                             Pad operator.
     Sum                             Sum operator.
@@ -30,18 +30,15 @@ A list of operators present in pylops.basicoperators :
     Real                            Real operator.
     Imag                            Imag operator.
     Conj                            Conj operator.
-    Smoothing1D     	            1D Smoothing.
+    Smoothing1D                     1D Smoothing.
     Smoothing2D	                    2D Smoothing.
-    FirstDerivative 	            First derivative.
-    SecondDerivative 	            Second derivative.
-    Laplacian 	                    Laplacian.
-    Gradient 	                    Gradient.
+    FirstDerivative                 First derivative.
+    SecondDerivative                Second derivative.
+    Laplacian                       Laplacian.
+    Gradient                        Gradient.
     FirstDirectionalDerivative      First Directional derivative.
     SecondDirectionalDerivative     Second Directional derivative.
-
 """
-
-# isort: skip_file
 
 from .FunctionOperator import *
 from .MemoizeOperator import *

--- a/pylops/optimization/__init__.py
+++ b/pylops/optimization/__init__.py
@@ -5,7 +5,13 @@ Optimization
 The subpackage optimization provides an extensive set of solvers to be
 used with PyLops linear operators.
 
-A list of least-squares solvers in pylops.optimization.leastsquares:
+A list of least-squares solvers in pylops.optimization.solver:
+
+    cg                              Conjugate gradient.
+    cgls                            Conjugate gradient least-squares.
+    lsqr                            LSQR.
+
+and wrappers for regularized or preconditioned inversion in pylops.optimization.leastsquares:
 
     NormalEquationsInversion        Inversion of normal equations.
     RegularizedInversion            Regularized inversion.
@@ -21,11 +27,3 @@ and sparsity-promoting solvers in pylops.optimization.sparsity:
     SplitBregman	                Split Bregman for mixed L2-L1 norms.
 
 """
-
-# from .leastsquares import *
-# from .sparsity import *
-
-
-# __all__ = ['NormalEquationsInversion', 'RegularizedInversion',
-#           'PreconditionedInversion', 'IRLS', 'OMP', 'ISTA', 'FISTA',
-#           'SPGL1', 'SplitBregman']

--- a/pylops/optimization/__init__.py
+++ b/pylops/optimization/__init__.py
@@ -1,1 +1,31 @@
-# isort: skip_file
+"""
+Optimization
+============
+
+The subpackage optimization provides an extensive set of solvers to be
+used with PyLops linear operators.
+
+A list of least-squares solvers in pylops.optimization.leastsquares:
+
+    NormalEquationsInversion        Inversion of normal equations.
+    RegularizedInversion            Regularized inversion.
+    PreconditionedInversion         Preconditioned inversion.
+
+and sparsity-promoting solvers in pylops.optimization.sparsity:
+
+    IRLS	                        Iteratively reweighted least squares.
+    OMP	                            Orthogonal Matching Pursuit (OMP).
+    ISTA                            Iterative Soft Thresholding Algorithm.
+    FISTA                           Fast Iterative Soft Thresholding Algorithm.
+    SPGL1                           Spectral Projected-Gradient for L1 norm.
+    SplitBregman	                Split Bregman for mixed L2-L1 norms.
+
+"""
+
+# from .leastsquares import *
+# from .sparsity import *
+
+
+# __all__ = ['NormalEquationsInversion', 'RegularizedInversion',
+#           'PreconditionedInversion', 'IRLS', 'OMP', 'ISTA', 'FISTA',
+#           'SPGL1', 'SplitBregman']

--- a/pylops/optimization/__init__.py
+++ b/pylops/optimization/__init__.py
@@ -19,11 +19,11 @@ and wrappers for regularized or preconditioned inversion in pylops.optimization.
 
 and sparsity-promoting solvers in pylops.optimization.sparsity:
 
-    IRLS	                        Iteratively reweighted least squares.
+    IRLS                            Iteratively reweighted least squares.
     OMP	                            Orthogonal Matching Pursuit (OMP).
     ISTA                            Iterative Soft Thresholding Algorithm.
     FISTA                           Fast Iterative Soft Thresholding Algorithm.
     SPGL1                           Spectral Projected-Gradient for L1 norm.
-    SplitBregman	                Split Bregman for mixed L2-L1 norms.
+    SplitBregman                    Split Bregman for mixed L2-L1 norms.
 
 """

--- a/pylops/signalprocessing/__init__.py
+++ b/pylops/signalprocessing/__init__.py
@@ -27,27 +27,29 @@ A list of operators present in pylops.signalprocessing:
 
 """
 
-from .FFT import FFT
-from .FFT2D import FFT2D
-from .FFTND import FFTND
-from .Convolve1D import Convolve1D
-from .ConvolveND import ConvolveND
-from .Convolve2D import Convolve2D
-from .Shift import Shift
-from .Interp import Interp
-from .Bilinear import Bilinear
-from .Radon2D import Radon2D
-from .Radon3D import Radon3D
-from .ChirpRadon2D import ChirpRadon2D
-from .ChirpRadon3D import ChirpRadon3D
-from .Sliding1D import Sliding1D
-from .Sliding2D import Sliding2D
-from .Sliding3D import Sliding3D
-from .Patch2D import Patch2D
-from .Fredholm1 import Fredholm1
-from .DWT import DWT
-from .DWT2D import DWT2D
-from .Seislet import Seislet
+# isort: skip_file
+
+from .FFT import *
+from .FFT2D import *
+from .FFTND import *
+from .Convolve1D import *
+from .ConvolveND import *
+from .Convolve2D import *
+from .Shift import *
+from .Interp import *
+from .Bilinear import *
+from .Radon2D import *
+from .Radon3D import *
+from .ChirpRadon2D import *
+from .ChirpRadon3D import *
+from .Sliding1D import *
+from .Sliding2D import *
+from .Sliding3D import *
+from .Patch2D import *
+from .Fredholm1 import *
+from .DWT import *
+from .DWT2D import *
+from .Seislet import *
 
 __all__ = [
     "FFT",

--- a/pylops/signalprocessing/__init__.py
+++ b/pylops/signalprocessing/__init__.py
@@ -7,13 +7,13 @@ processing algorithms with forward and adjoint functionalities.
 
 A list of operators present in pylops.signalprocessing:
 
-    Convolve1D	                    1D convolution operator.
-    Convolve2D	                    2D convolution operator.
-    ConvolveND	                    ND convolution operator.
-    Interp          	            Interpolation operator.
-    Bilinear                    	Bilinear interpolation operator.
+    Convolve1D                      1D convolution operator.
+    Convolve2D                      2D convolution operator.
+    ConvolveND                      ND convolution operator.
+    Interp                          Interpolation operator.
+    Bilinear                        Bilinear interpolation operator.
     FFT                             One dimensional Fast-Fourier Transform.
-    FFT2D                       	Two dimensional Fast-Fourier Transform.
+    FFT2D                           Two dimensional Fast-Fourier Transform.
     FFTND                           N-dimensional Fast-Fourier Transform.
     Shift                           Fractional Shift operator.
     DWT                             One dimensional Wavelet operator.
@@ -21,13 +21,11 @@ A list of operators present in pylops.signalprocessing:
     Seislet                         Two dimensional Seislet operator.
     Radon2D	                        Two dimensional Radon transform.
     Radon3D	                        Three dimensional Radon transform.
-    Sliding2D	                    2D Sliding transform operator.
-    Sliding3D	                    3D Sliding transform operator.
-    Fredholm1	                    Fredholm integral of first kind.
+    Sliding2D                       2D Sliding transform operator.
+    Sliding3D                       3D Sliding transform operator.
+    Fredholm1                       Fredholm integral of first kind.
 
 """
-
-# isort: skip_file
 
 from .FFT import *
 from .FFT2D import *

--- a/pylops/signalprocessing/__init__.py
+++ b/pylops/signalprocessing/__init__.py
@@ -1,22 +1,78 @@
-# isort: skip_file
+"""
+Signal processing
+=================
+
+The subpackage signalprocessing provides linear operators for several signal
+processing algorithms with forward and adjoint functionalities.
+
+A list of operators present in pylops.signalprocessing:
+
+    Convolve1D	                    1D convolution operator.
+    Convolve2D	                    2D convolution operator.
+    ConvolveND	                    ND convolution operator.
+    Interp          	            Interpolation operator.
+    Bilinear                    	Bilinear interpolation operator.
+    FFT                             One dimensional Fast-Fourier Transform.
+    FFT2D                       	Two dimensional Fast-Fourier Transform.
+    FFTND                           N-dimensional Fast-Fourier Transform.
+    Shift                           Fractional Shift operator.
+    DWT                             One dimensional Wavelet operator.
+    DWT2D                           Two dimensional Wavelet operator.
+    Seislet                         Two dimensional Seislet operator.
+    Radon2D	                        Two dimensional Radon transform.
+    Radon3D	                        Three dimensional Radon transform.
+    ChirpRadon2D	                Two dimensional Chirp Radon transform.
+    ChirpRadon3D	                Three dimensional Chirp Radon transform.
+    Sliding1D	                    1D Sliding transform operator.
+    Sliding2D	                    2D Sliding transform operator.
+    Sliding3D	                    3D Sliding transform operator.
+    Patch2D	                        2D Patching transform operator.
+    Fredholm1	                    Fredholm integral of first kind.
+
+"""
+
+from .Bilinear import Bilinear
+from .ChirpRadon2D import ChirpRadon2D
+from .ChirpRadon3D import ChirpRadon3D
+from .Convolve1D import Convolve1D
+from .Convolve2D import Convolve2D
+from .ConvolveND import ConvolveND
+from .DWT import DWT
+from .DWT2D import DWT2D
 from .FFT import FFT
 from .FFT2D import FFT2D
 from .FFTND import FFTND
-from .Convolve1D import Convolve1D
-from .ConvolveND import ConvolveND
-from .Convolve2D import Convolve2D
+from .Fredholm1 import Fredholm1
 from .Interp import Interp
-from .Bilinear import Bilinear
+from .Patch2D import Patch2D
 from .Radon2D import Radon2D
 from .Radon3D import Radon3D
+from .Seislet import Seislet
+from .Shift import Shift
 from .Sliding1D import Sliding1D
 from .Sliding2D import Sliding2D
 from .Sliding3D import Sliding3D
-from .Patch2D import Patch2D
-from .Fredholm1 import Fredholm1
-from .DWT import DWT
-from .DWT2D import DWT2D
-from .Seislet import Seislet
-from .ChirpRadon2D import ChirpRadon2D
-from .ChirpRadon3D import ChirpRadon3D
-from .Shift import Shift
+
+__all__ = [
+    "FFT",
+    "FFT2D",
+    "FFTND",
+    "Shift",
+    "Convolve1D",
+    "ConvolveND",
+    "Convolve2D",
+    "Interp",
+    "Bilinear",
+    "Radon2D",
+    "Radon3D",
+    "ChirpRadon2D",
+    "ChirpRadon3D",
+    "Sliding1D",
+    "Sliding2D",
+    "Sliding3D",
+    "Patch2D",
+    "Fredholm1",
+    "DWT",
+    "DWT2D",
+    "Seislet",
+]

--- a/pylops/signalprocessing/__init__.py
+++ b/pylops/signalprocessing/__init__.py
@@ -21,37 +21,33 @@ A list of operators present in pylops.signalprocessing:
     Seislet                         Two dimensional Seislet operator.
     Radon2D	                        Two dimensional Radon transform.
     Radon3D	                        Three dimensional Radon transform.
-    ChirpRadon2D	                Two dimensional Chirp Radon transform.
-    ChirpRadon3D	                Three dimensional Chirp Radon transform.
-    Sliding1D	                    1D Sliding transform operator.
     Sliding2D	                    2D Sliding transform operator.
     Sliding3D	                    3D Sliding transform operator.
-    Patch2D	                        2D Patching transform operator.
     Fredholm1	                    Fredholm integral of first kind.
 
 """
 
-from .Bilinear import Bilinear
-from .ChirpRadon2D import ChirpRadon2D
-from .ChirpRadon3D import ChirpRadon3D
-from .Convolve1D import Convolve1D
-from .Convolve2D import Convolve2D
-from .ConvolveND import ConvolveND
-from .DWT import DWT
-from .DWT2D import DWT2D
 from .FFT import FFT
 from .FFT2D import FFT2D
 from .FFTND import FFTND
-from .Fredholm1 import Fredholm1
+from .Convolve1D import Convolve1D
+from .ConvolveND import ConvolveND
+from .Convolve2D import Convolve2D
+from .Shift import Shift
 from .Interp import Interp
-from .Patch2D import Patch2D
+from .Bilinear import Bilinear
 from .Radon2D import Radon2D
 from .Radon3D import Radon3D
-from .Seislet import Seislet
-from .Shift import Shift
+from .ChirpRadon2D import ChirpRadon2D
+from .ChirpRadon3D import ChirpRadon3D
 from .Sliding1D import Sliding1D
 from .Sliding2D import Sliding2D
 from .Sliding3D import Sliding3D
+from .Patch2D import Patch2D
+from .Fredholm1 import Fredholm1
+from .DWT import DWT
+from .DWT2D import DWT2D
+from .Seislet import Seislet
 
 __all__ = [
     "FFT",

--- a/pylops/waveeqprocessing/__init__.py
+++ b/pylops/waveeqprocessing/__init__.py
@@ -26,8 +26,6 @@ and a list of applications:
 
 """
 
-# isort: skip_file
-
 from .lsm import *
 from .marchenko import *
 from .mdd import *

--- a/pylops/waveeqprocessing/__init__.py
+++ b/pylops/waveeqprocessing/__init__.py
@@ -26,6 +26,8 @@ and a list of applications:
 
 """
 
+# isort: skip_file
+
 from .lsm import *
 from .marchenko import *
 from .mdd import *

--- a/pylops/waveeqprocessing/__init__.py
+++ b/pylops/waveeqprocessing/__init__.py
@@ -1,12 +1,49 @@
-# isort: skip_file
-from .lsm import LSM, Demigration
-from .marchenko import Marchenko
-from .mdd import MDC, MDD
-from .oneway import Deghosting, PhaseShift
-from .seismicinterpolation import SeismicInterpolation
-from .wavedecomposition import (
-    PressureToVelocity,
-    UpDownComposition2D,
-    UpDownComposition3D,
-    WavefieldDecomposition,
-)
+"""
+Wave Equation processing
+========================
+
+The subpackage waveeqprocessing provides linear operators and applications
+aimed at solving various inverse problems in the area of Seismic Wave
+Equation Processing.
+
+A list of operators present in pylops.waveeqprocessing:
+
+    PressureToVelocity              Pressure to Vertical velocity conversion.
+    UpDownComposition2D             2D Up-down wavefield composition.
+    UpDownComposition3D             3D Up-down wavefield composition.
+    MDC                             Multi-dimensional convolution.
+    PhaseShift                      Phase shift operator.
+    Demigration                     Kirchoff Demigration operator.
+
+and a list of applications:
+
+    SeismicInterpolation            Seismic interpolation (or regularization).
+    Deghosting                      Single-component wavefield decomposition.
+    WavefieldDecomposition          Multi-component wavefield decomposition.
+    MDD                             Multi-dimensional deconvolution.
+    Marchenko                       Marchenko redatuming.
+    LSM                             Least-squares Migration (LSM).
+
+"""
+
+from .lsm import *
+from .marchenko import *
+from .mdd import *
+from .oneway import *
+from .seismicinterpolation import *
+from .wavedecomposition import *
+
+__all__ = [
+    "MDC",
+    "MDD",
+    "Marchenko",
+    "SeismicInterpolation",
+    "PressureToVelocity",
+    "UpDownComposition2D",
+    "UpDownComposition3D",
+    "WavefieldDecomposition",
+    "PhaseShift",
+    "Deghosting",
+    "Demigration",
+    "LSM",
+]


### PR DESCRIPTION
This PR revamps the __init__ files with 2 major changes:

- Docstrings are added such that `help(module)` will print some description
- `__all__` lists are used to define what methods in a module will be imported when `from <module> import *`