### PR TITLE
Implement `dimsd` for all operators with `dims`

### DIFF
--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -13,3 +13,4 @@ should be used as a checklist when converting a piece of code using PyLops from 
   When calling it with purely positional arguments, note that after `rtol` comes now first `atol` before `complexflag`.
   When using `raiseerror=True` it now emits an `AttributeError` instead of a `ValueError`.
 - `dims_fft` in the FFT operators is deprecated in favor of `dimsd`.
+- `dims_d` in `Sum` is deprecated in favor or `dimsd`

--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -12,3 +12,4 @@ should be used as a checklist when converting a piece of code using PyLops from 
 - `utils.dottest`: Change `tol` into `rtol`. Absolute tolerance is now also supported via the keyword `atol`.
   When calling it with purely positional arguments, note that after `rtol` comes now first `atol` before `complexflag`.
   When using `raiseerror=True` it now emits an `AttributeError` instead of a `ValueError`.
+- `dims_fft` in the FFT operators is deprecated in favor of `dimsd`.

--- a/examples/plot_matrixmult.py
+++ b/examples/plot_matrixmult.py
@@ -196,11 +196,11 @@ print("lsqr solution xest= %s" % xest)
 #
 # and apply it using the same implementation of the
 # :py:class:`pylops.MatrixMult` operator by simply telling the operator how we
-# want the model to be organized through the ``dims`` input parameter.
+# want the model to be organized through the ``otherdims`` input parameter.
 A = np.array([[1.0, 2.0], [4.0, 5.0]])
 x = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
 
-Aop = pylops.MatrixMult(A, dims=(3,), dtype="float64")
+Aop = pylops.MatrixMult(A, otherdims=(3,), dtype="float64")
 y = Aop * x.ravel()
 
 xest, istop, itn, r1norm, r2norm = lsqr(Aop, y, damp=1e-10, iter_lim=10, show=0)[0:5]

--- a/pylops/avo/poststack.py
+++ b/pylops/avo/poststack.py
@@ -87,7 +87,7 @@ def _PoststackLinearModelling(
         M = ncp.dot(C, D)
         if sparse:
             M = get_csc_matrix(wav)(M)
-        Pop = _MatrixMult(M, dims=spatdims, dtype=dtype, **args_MatrixMult)
+        Pop = _MatrixMult(M, otherdims=spatdims, dtype=dtype, **args_MatrixMult)
     else:
         # Create wavelet operator
         if len(wav.shape) == 1:
@@ -102,7 +102,7 @@ def _PoststackLinearModelling(
         else:
             Cop = _MatrixMult(
                 nonstationary_convmtx(wav, nt0, hc=wav.shape[1] // 2, pad=(nt0, nt0)),
-                dims=spatdims,
+                otherdims=spatdims,
                 dtype=dtype,
                 **args_MatrixMult
             )
@@ -350,7 +350,7 @@ def PoststackInversion(
                     minv = get_lstsq(data)(PP, datarn, **kwargs_solver)[0]
                 else:
                     # solve regularized normal equations simultaneously
-                    PPop_reg = MatrixMult(PP, dims=nspatprod)
+                    PPop_reg = MatrixMult(PP, otherdims=nspatprod)
                     if ncp == np:
                         minv = lsqr(PPop_reg, datar.ravel(), **kwargs_solver)[0]
                     else:
@@ -364,7 +364,7 @@ def PoststackInversion(
                 # create regularized normal eqs. and solve them simultaneously
                 PP = ncp.dot(PPop.A.T, PPop.A) + epsI * ncp.eye(nt0, dtype=PPop.A.dtype)
                 datarn = PPop.A.T * datar.reshape(nt0, nspatprod)
-                PPop_reg = MatrixMult(PP, dims=nspatprod)
+                PPop_reg = MatrixMult(PP, otherdims=nspatprod)
                 minv = get_lstsq(data)(PPop_reg.A, datarn.ravel(), **kwargs_solver)[0]
         else:
             # solve unregularized normal equations simultaneously with lop

--- a/pylops/avo/prestack.py
+++ b/pylops/avo/prestack.py
@@ -182,7 +182,7 @@ def PrestackLinearModelling(
 
         # Combine operators
         M = ncp.dot(C, ncp.dot(G, D))
-        Preop = MatrixMult(M, dims=spatdims, dtype=dtype)
+        Preop = MatrixMult(M, otherdims=spatdims, dtype=dtype)
 
     else:
         # Create wavelet operator
@@ -504,7 +504,7 @@ def PrestackInversion(
         ]
         if explicit:
             PPop = MatrixMult(
-                np.vstack([Op.A for Op in PPop]), dims=nspat, dtype=PPop[0].A.dtype
+                np.vstack([Op.A for Op in PPop]), otherdims=nspat, dtype=PPop[0].A.dtype
             )
         else:
             PPop = VStack(PPop)
@@ -560,7 +560,7 @@ def PrestackInversion(
                     minv = get_lstsq(data)(PP, datarn, **kwargs_solver)[0]
                 else:
                     # solve regularized normal equations simultaneously
-                    PPop_reg = MatrixMult(PP, dims=nspatprod)
+                    PPop_reg = MatrixMult(PP, otherdims=nspatprod)
                     if ncp == np:
                         minv = lsqr(PPop_reg, datarn.ravel(), **kwargs_solver)[0]
                     else:
@@ -574,7 +574,7 @@ def PrestackInversion(
             #    # create regularized normal eqs. and solve them simultaneously
             #    PP = np.dot(PPop.A.T, PPop.A) + epsI * np.eye(nt0*nm)
             #    datarn = PPop.A.T * datar.reshape(nt0*ntheta, nspatprod)
-            #    PPop_reg = MatrixMult(PP, dims=ntheta*nspatprod)
+            #    PPop_reg = MatrixMult(PP, otherdims=ntheta*nspatprod)
             #    minv = lstsq(PPop_reg, datarn.ravel(), **kwargs_solver)[0]
         else:
             # solve unregularized normal equations simultaneously with lop

--- a/pylops/basicoperators/CausalIntegration.py
+++ b/pylops/basicoperators/CausalIntegration.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 
 
 class CausalIntegration(LinearOperator):
@@ -97,16 +97,18 @@ class CausalIntegration(LinearOperator):
         kind="full",
         removefirst=False,
     ):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = _value_or_list_like_to_tuple(dims)
         self.axis = axis
         self.sampling = sampling
         self.kind = kind
         if kind == "full" and halfcurrent:  # ensure backcompatibility
             self.kind = "half"
         self.removefirst = removefirst
-        self.dimsd = self.dims.copy()
+        dimsd = list(self.dims)
         if self.removefirst:
-            self.dimsd[self.axis] -= 1
+            dimsd[self.axis] -= 1
+        self.dimsd = tuple(dimsd)
+
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pylops import LinearOperator
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 
@@ -41,7 +42,9 @@ class Conj(LinearOperator):
     """
 
     def __init__(self, dims, dtype="complex128"):
-        self.shape = (np.prod(np.array(dims)), np.prod(np.array(dims)))
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
         self.clinear = False

--- a/pylops/basicoperators/DirectionalDerivative.py
+++ b/pylops/basicoperators/DirectionalDerivative.py
@@ -14,7 +14,6 @@ def FirstDirectionalDerivative(
     .. note:: At least 2 dimensions are required, consider using
       :py:func:`pylops.FirstDerivative` for 1d arrays.
 
-
     Parameters
     ----------
     dims : :obj:`tuple`

--- a/pylops/basicoperators/DirectionalDerivative.py
+++ b/pylops/basicoperators/DirectionalDerivative.py
@@ -67,8 +67,10 @@ def FirstDirectionalDerivative(
     else:
         Dop = Diagonal(v.ravel(), dtype=dtype)
     Sop = Sum(dims=[len(dims)] + list(dims), axis=0, dtype=dtype)
-    ddop = Sop * Dop * Gop
-    return LinearOperator(ddop)
+    ddop = LinearOperator(Sop * Dop * Gop)
+    ddop.dims = ddop.dimsd = dims
+    ddop.sampling = sampling
+    return ddop
 
 
 def SecondDirectionalDerivative(dims, v, sampling=1, edge=False, dtype="float64"):
@@ -118,5 +120,7 @@ def SecondDirectionalDerivative(dims, v, sampling=1, edge=False, dtype="float64"
     in the literature.
     """
     Dop = FirstDirectionalDerivative(dims, v, sampling=sampling, edge=edge, dtype=dtype)
-    ddop = -Dop.H * Dop
-    return LinearOperator(ddop)
+    ddop = LinearOperator(-Dop.H * Dop)
+    ddop.dims = ddop.dimsd = dims
+    ddop.sampling = sampling
+    return ddop

--- a/pylops/basicoperators/FirstDerivative.py
+++ b/pylops/basicoperators/FirstDerivative.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 
@@ -73,13 +73,13 @@ class FirstDerivative(LinearOperator):
         dtype="float64",
         kind="centered",
     ):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = normalize_axis_index(axis, len(self.dims))
         self.sampling = sampling
         self.edge = edge
         self.kind = kind
-        N = np.prod(self.dims)
-        self.shape = (N, N)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/basicoperators/Flip.py
+++ b/pylops/basicoperators/Flip.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 
 
 class Flip(LinearOperator):
@@ -46,10 +46,10 @@ class Flip(LinearOperator):
     """
 
     def __init__(self, dims, axis=-1, dtype="float64"):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = axis
-        N = np.prod(self.dims)
-        self.shape = (N, N)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/basicoperators/Gradient.py
+++ b/pylops/basicoperators/Gradient.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pylops.basicoperators import FirstDerivative, VStack
+from pylops.utils._internal import _value_or_list_like_to_tuple
 
 
 def Gradient(dims, sampling=1, edge=False, dtype="float64", kind="centered"):
@@ -58,9 +59,9 @@ def Gradient(dims, sampling=1, edge=False, dtype="float64", kind="centered"):
     axes are instead summed together.
 
     """
+    dims = _value_or_list_like_to_tuple(dims)
     ndims = len(dims)
-    if isinstance(sampling, (int, float)):
-        sampling = [sampling] * ndims
+    sampling = _value_or_list_like_to_tuple(sampling, repeat=ndims)
 
     gop = VStack(
         [
@@ -75,4 +76,9 @@ def Gradient(dims, sampling=1, edge=False, dtype="float64", kind="centered"):
             for iax in range(ndims)
         ]
     )
+    gop.dims = dims
+    gop.dimsd = (ndims, *gop.dims)
+    gop.sampling = sampling
+    gop.edge = edge
+    gop.kind = kind
     return gop

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pylops import LinearOperator
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 
@@ -43,7 +44,9 @@ class Imag(LinearOperator):
     """
 
     def __init__(self, dims, dtype="complex128"):
-        self.shape = (np.prod(np.array(dims)), np.prod(np.array(dims)))
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.rdtype = np.real(np.ones(1, self.dtype)).dtype
         self.explicit = False

--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -84,4 +84,9 @@ def Laplacian(
     l2op = aslinearoperator(l2op)
     l2op.dims = dims
     l2op.dimsd = dimsd
+    l2op.axes = axes
+    l2op.weights = weights
+    l2op.sampling = sampling
+    l2op.edge = edge
+    l2op.kind = kind
     return l2op

--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -70,13 +70,18 @@ def Laplacian(
     if not (len(axes) == len(weights) == len(sampling)):
         raise ValueError("axes, weights, and sampling have different size")
 
-    l2op = weights[0] * SecondDerivative(
+    l2op = SecondDerivative(
         dims, axis=axes[0], sampling=sampling[0], edge=edge, kind=kind, dtype=dtype
     )
+    dims, dimsd = l2op.dims, l2op.dimsd
 
+    l2op *= weights[0]
     for ax, samp, weight in zip(axes[1:], sampling[1:], weights[1:]):
         l2op += weight * SecondDerivative(
             dims, axis=ax, sampling=samp, edge=edge, dtype=dtype
         )
 
-    return aslinearoperator(l2op)
+    l2op = aslinearoperator(l2op)
+    l2op.dims = dims
+    l2op.dimsd = dimsd
+    return l2op

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pylops import LinearOperator
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 
@@ -43,7 +44,9 @@ class Real(LinearOperator):
     """
 
     def __init__(self, dims, dtype="complex128"):
-        self.shape = (np.prod(np.array(dims)), np.prod(np.array(dims)))
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.rdtype = np.real(np.ones(1, self.dtype)).dtype
         self.explicit = False

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -5,7 +5,7 @@ import numpy.ma as np_ma
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module, to_cupy_conditional
 
 
@@ -86,11 +86,12 @@ class Restriction(LinearOperator):
 
     def __init__(self, dims, iava, axis=-1, dtype="float64", inplace=True):
         ncp = get_array_module(iava)
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = _value_or_list_like_to_tuple(dims)
         self.axis = normalize_axis_index(axis, len(self.dims))
         self.iava = iava
-        self.dimsd = self.dims.copy()  # data dimensions
-        self.dimsd[self.axis] = len(iava)
+        dimsd = list(self.dims)  # data dimensions
+        dimsd[self.axis] = len(iava)
+        self.dimsd = tuple(dimsd)
         self.iavareshape = np.ones(len(self.dims), dtype=int)
         self.iavareshape[self.axis] = len(self.iava)
 
@@ -100,6 +101,7 @@ class Restriction(LinearOperator):
         if ncp != np:
             self.iavamask = _compute_iavamask(self.dims, self.axis, self.iava, ncp)
         self.inplace = inplace
+
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False

--- a/pylops/basicoperators/Roll.py
+++ b/pylops/basicoperators/Roll.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 
 
 class Roll(LinearOperator):
@@ -42,11 +42,11 @@ class Roll(LinearOperator):
     """
 
     def __init__(self, dims, axis=-1, shift=1, dtype="float64"):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = axis
-        N = np.prod(self.dims)
         self.shift = shift
-        self.shape = (N, N)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 
@@ -73,13 +73,13 @@ class SecondDerivative(LinearOperator):
         dtype="float64",
         kind="centered",
     ):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = normalize_axis_index(axis, len(self.dims))
         self.sampling = sampling
         self.edge = edge
         self.kind = kind
-        N = np.prod(self.dims)
-        self.shape = (N, N)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/basicoperators/Spread.py
+++ b/pylops/basicoperators/Spread.py
@@ -179,7 +179,7 @@ class Spread(LinearOperator):
             self.engine = "numpy"
 
         # axes
-        self.dims, self.dimsd = dims, dimsd
+        self.dims, self.dimsd = tuple(dims), tuple(dimsd)
         self.nx0, self.nt0 = self.dims[0], self.dims[1]
         self.nx, self.nt = self.dimsd[0], self.dimsd[1]
         self.table = table

--- a/pylops/basicoperators/Symmetrize.py
+++ b/pylops/basicoperators/Symmetrize.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 
@@ -61,11 +61,13 @@ class Symmetrize(LinearOperator):
     """
 
     def __init__(self, dims, axis=-1, dtype="float64"):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = _value_or_list_like_to_tuple(dims)
         self.axis = axis
-        self.dimsd = self.dims.copy()
-        self.dimsd[self.axis] = self.dims[self.axis] * 2 - 1
+        dimsd = list(self.dims)
+        dimsd[self.axis] = self.dims[self.axis] * 2 - 1
+        self.dimsd = tuple(dimsd)
         self.nsym = self.dims[self.axis]
+
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False

--- a/pylops/basicoperators/Transpose.py
+++ b/pylops/basicoperators/Transpose.py
@@ -1,6 +1,8 @@
 import numpy as np
+from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
+from pylops.utils._internal import _value_or_list_like_to_tuple
 
 
 class Transpose(LinearOperator):
@@ -46,22 +48,24 @@ class Transpose(LinearOperator):
     """
 
     def __init__(self, dims, axes, dtype="float64"):
-        self.dims = list(dims)
-        self.axes = list(axes)
+        self.dims = _value_or_list_like_to_tuple(dims)
+        ndims = len(self.dims)
+        self.axes = [normalize_axis_index(ax, ndims) for ax in axes]
 
         # find out if all axes are present only once in axes
-        ndims = len(self.dims)
         if len(np.unique(self.axes)) != ndims:
             raise ValueError("axes must contain each direction once")
 
         # find out how axes should be transposed in adjoint mode
         self.axesd = np.zeros(ndims, dtype=int)
-        self.dimsd = np.zeros(ndims, dtype=int)
         self.axesd[self.axes] = np.arange(ndims, dtype=int)
-        self.dimsd[self.axesd] = self.dims
+
+        dimsd = np.zeros(ndims, dtype=int)
+        dimsd[self.axesd] = self.dims
+        self.dimsd = tuple(dimsd)
         self.axesd = list(self.axesd)
 
-        self.shape = (np.prod(self.dims), np.prod(self.dims))
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/signalprocessing/Bilinear.py
+++ b/pylops/signalprocessing/Bilinear.py
@@ -84,8 +84,8 @@ class Bilinear(LinearOperator):
 
         # define dimension of data
         ndims = len(dims)
-        self.dims = dims
-        self.dimsd = [len(iava[1])] + list(dims[2:])
+        self.dims = tuple(dims)
+        self.dimsd = tuple([len(iava[1])] + list(dims[2:]))
 
         # find indices and weights
         self.iava_t = ncp.floor(iava[0]).astype(int)

--- a/pylops/signalprocessing/Convolve1D.py
+++ b/pylops/signalprocessing/Convolve1D.py
@@ -1,10 +1,9 @@
 import warnings
 
 import numpy as np
-from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import (
     get_convolve,
     get_fftconvolve,
@@ -118,7 +117,7 @@ class Convolve1D(LinearOperator):
     """
 
     def __init__(self, dims, h, offset=0, axis=-1, dtype="float64", method=None):
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = axis
 
         if offset > len(h) - 1:
@@ -149,7 +148,7 @@ class Convolve1D(LinearOperator):
 
         # choose method and function handle
         self.convfunc, self.method = _choose_convfunc(h, method, self.dimsorig)
-        self.shape = (np.prod(self.dims), np.prod(self.dims))
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/signalprocessing/ConvolveND.py
+++ b/pylops/signalprocessing/ConvolveND.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import (
     get_array_module,
     get_convolve,
@@ -64,7 +64,7 @@ class ConvolveND(LinearOperator):
         dtype="float64",
     ):
         ncp = get_array_module(h)
-        self.dims = _value_or_list_like_to_array(dims)
+        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axes = (
             np.arange(len(self.dims))
             if axes is None
@@ -106,7 +106,7 @@ class ConvolveND(LinearOperator):
         self.correlate = get_correlate(h)
         self.method = method
 
-        self.shape = (np.prod(self.dims), np.prod(self.dims))
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/signalprocessing/DWT.py
+++ b/pylops/signalprocessing/DWT.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.basicoperators import Pad
+from pylops.utils._internal import _value_or_list_like_to_tuple
 
 try:
     import pywt
@@ -104,15 +105,16 @@ class DWT(LinearOperator):
         if isinstance(dims, int):
             dims = (dims,)
 
+        self.dims = _value_or_list_like_to_tuple(dims)
         # define padding for length to be power of 2
-        ndimpow2 = max(2 ** ceil(log(dims[axis], 2)), 2 ** level)
-        pad = [(0, 0)] * len(dims)
-        pad[axis] = (0, ndimpow2 - dims[axis])
-        self.pad = Pad(dims, pad)
-        self.dims = dims
+        ndimpow2 = max(2 ** ceil(log(self.dims[axis], 2)), 2 ** level)
+        pad = [(0, 0)] * len(self.dims)
+        pad[axis] = (0, ndimpow2 - self.dims[axis])
+        self.pad = Pad(self.dims, pad)
         self.axis = axis
-        self.dimsd = list(dims)
-        self.dimsd[self.axis] = ndimpow2
+        dimsd = list(self.dims)
+        dimsd[self.axis] = ndimpow2
+        self.dimsd = tuple(dimsd)
 
         # apply transform to find out slices
         _, self.sl = pywt.coeffs_to_array(
@@ -130,7 +132,8 @@ class DWT(LinearOperator):
         self.waveletadj = _adjointwavelet(wavelet)
         self.level = level
         self.reshape = True if len(self.dims) > 1 else False
-        self.shape = (int(np.prod(self.dimsd)), int(np.prod(self.dims)))
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/signalprocessing/DWT.py
+++ b/pylops/signalprocessing/DWT.py
@@ -102,9 +102,6 @@ class DWT(LinearOperator):
             raise ModuleNotFoundError(pywt_message)
         _checkwavelet(wavelet)
 
-        if isinstance(dims, int):
-            dims = (dims,)
-
         self.dims = _value_or_list_like_to_tuple(dims)
         # define padding for length to be power of 2
         ndimpow2 = max(2 ** ceil(log(self.dims[axis], 2)), 2 ** level)

--- a/pylops/signalprocessing/DWT2D.py
+++ b/pylops/signalprocessing/DWT2D.py
@@ -80,17 +80,18 @@ class DWT2D(LinearOperator):
             raise ModuleNotFoundError(pywt_message)
         _checkwavelet(wavelet)
 
+        self.dims = tuple(dims)
         # define padding for length to be power of 2
-        ndimpow2 = [max(2 ** ceil(log(dims[ax], 2)), 2 ** level) for ax in axes]
-        pad = [(0, 0)] * len(dims)
+        ndimpow2 = [max(2 ** ceil(log(self.dims[ax], 2)), 2 ** level) for ax in axes]
+        pad = [(0, 0)] * len(self.dims)
         for i, ax in enumerate(axes):
-            pad[ax] = (0, ndimpow2[i] - dims[ax])
-        self.pad = Pad(dims, pad)
-        self.dims = dims
+            pad[ax] = (0, ndimpow2[i] - self.dims[ax])
+        self.pad = Pad(self.dims, pad)
         self.axes = axes
-        self.dimsd = list(dims)
+        dimsd = list(self.dims)
         for i, ax in enumerate(axes):
-            self.dimsd[ax] = ndimpow2[i]
+            dimsd[ax] = ndimpow2[i]
+        self.dimsd = tuple(dimsd)
 
         # apply transform once again to find out slices
         _, self.sl = pywt.coeffs_to_array(
@@ -106,7 +107,8 @@ class DWT2D(LinearOperator):
         self.wavelet = wavelet
         self.waveletadj = _adjointwavelet(wavelet)
         self.level = level
-        self.shape = (int(np.prod(self.dimsd)), int(np.prod(self.dims)))
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
 

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -484,10 +484,6 @@ def FFT(
         Shape of the array after the forward, but before linearization.
 
         For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
-    dims_fft : :obj:`tuple`
-
-        .. deprecated:: 2.0.0
-            Use ``dimsd`` instead.
     f : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies
     real : :obj:`bool`

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -84,7 +84,7 @@ class _FFT_numpy(_BaseFFT):
         return y
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after:
             x = np.fft.ifftshift(x, axes=self.axis)
         if self.real:
@@ -175,7 +175,7 @@ class _FFT_scipy(_BaseFFT):
         return y
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after:
             x = scipy.fft.ifftshift(x, axes=self.axis)
         if self.real:
@@ -255,29 +255,30 @@ class _FFT_fftw(_BaseFFT):
                 f"fftw backend returns complex128 dtype. To respect the passed dtype, data will be cast to {self.cdtype}."
             )
 
-        self.dims_t = self.dims.copy()
-        self.dims_t[self.axis] = self.nfft
+        dims_t = list(self.dims)
+        dims_t[self.axis] = self.nfft
+        self.dims_t = dims_t
 
         # define padding(fftw requires the user to provide padded input signal)
         self.pad = np.zeros((self.ndim, 2), dtype=int)
         if self.real:
             if self.nfft % 2:
                 self.pad[self.axis, 1] = (
-                    2 * (self.dims_fft[self.axis] - 1) + 1 - self.dims[self.axis]
+                    2 * (self.dimsd[self.axis] - 1) + 1 - self.dims[self.axis]
                 )
             else:
                 self.pad[self.axis, 1] = (
-                    2 * (self.dims_fft[self.axis] - 1) - self.dims[self.axis]
+                    2 * (self.dimsd[self.axis] - 1) - self.dims[self.axis]
                 )
         else:
-            self.pad[self.axis, 1] = self.dims_fft[self.axis] - self.dims[self.axis]
+            self.pad[self.axis, 1] = self.dimsd[self.axis] - self.dims[self.axis]
         self.dopad = True if np.sum(self.pad) > 0 else False
 
         # create empty arrays and plans for fft/ifft
         self.x = pyfftw.empty_aligned(
             self.dims_t, dtype=self.rdtype if real else self.cdtype
         )
-        self.y = pyfftw.empty_aligned(self.dims_fft, dtype=self.cdtype)
+        self.y = pyfftw.empty_aligned(self.dimsd, dtype=self.cdtype)
 
         # Use FFTW without norm-related keywords above. In this case, FFTW standard
         # behavior is to scale with 1/N on the inverse transform. The _scale below
@@ -327,7 +328,7 @@ class _FFT_fftw(_BaseFFT):
         return y.ravel()
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after:
             x = np.fft.ifftshift(x, axes=self.axis)
 
@@ -479,10 +480,14 @@ def FFT(
 
     Attributes
     ----------
-    dims_fft : :obj:`tuple`
+    dimsd : :obj:`tuple`
         Shape of the array after the forward, but before linearization.
 
-        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
+    dims_fft : :obj:`tuple`
+
+        .. deprecated:: 2.0.0
+            Use ``dimsd`` instead.
     f : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies
     real : :obj:`bool`

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -316,10 +316,6 @@ def FFT2D(
         Shape of the array after the forward, but before linearization.
 
         For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
-    dims_fft : :obj:`tuple`
-
-        .. deprecated:: 2.0.0
-            Use ``dimsd`` instead.
     f1 : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies along ``axes[0]``
     f2 : :obj:`numpy.ndarray`

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -79,7 +79,7 @@ class _FFT2D_numpy(_BaseFFTND):
         return y.ravel()
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = np.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -177,7 +177,7 @@ class _FFT2D_scipy(_BaseFFTND):
         return y.ravel()
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = scipy.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -312,10 +312,14 @@ def FFT2D(
 
     Attributes
     ----------
-    dims_fft : :obj:`tuple`
+    dimsd : :obj:`tuple`
         Shape of the array after the forward, but before linearization.
 
-        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
+    dims_fft : :obj:`tuple`
+
+        .. deprecated:: 2.0.0
+            Use ``dimsd`` instead.
     f1 : :obj:`numpy.ndarray`
         Discrete Fourier Transform sample frequencies along ``axes[0]``
     f2 : :obj:`numpy.ndarray`

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -70,7 +70,7 @@ class _FFTND_numpy(_BaseFFTND):
         return y.ravel()
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = np.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -158,7 +158,7 @@ class _FFTND_scipy(_BaseFFTND):
         return y.ravel()
 
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims_fft)
+        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = scipy.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -301,10 +301,14 @@ def FFTND(
 
     Attributes
     ----------
-    dims_fft : :obj:`tuple`
+    dimsd : :obj:`tuple`
         Shape of the array after the forward, but before linearization.
 
-        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dims_fft)``.
+        For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
+    dims_fft : :obj:`tuple`
+
+        .. deprecated:: 2.0.0
+            Use ``dimsd`` instead.
     fs : :obj:`tuple`
         Each element of the tuple corresponds to the Discrete Fourier Transform
         sample frequencies along the respective direction given by ``axes``.

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -305,10 +305,6 @@ def FFTND(
         Shape of the array after the forward, but before linearization.
 
         For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
-    dims_fft : :obj:`tuple`
-
-        .. deprecated:: 2.0.0
-            Use ``dimsd`` instead.
     fs : :obj:`tuple`
         Each element of the tuple corresponds to the Discrete Fourier Transform
         sample frequencies along the respective direction given by ``axes``.

--- a/pylops/signalprocessing/Interp.py
+++ b/pylops/signalprocessing/Interp.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.basicoperators import Diagonal, MatrixMult, Restriction, Transpose
-from pylops.utils._internal import _value_or_list_like_to_array
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
@@ -188,7 +188,7 @@ def Interp(dims, iava, axis=-1, kind="linear", dtype="float64"):
     :math:`i,j` possible combinations.
 
     """
-    dims = _value_or_list_like_to_array(dims)
+    dims = _value_or_list_like_to_tuple(dims)
 
     if kind == "nearest":
         interpop, iava = _nearestinterp(dims, iava, axis=axis, dtype=dtype)
@@ -198,4 +198,4 @@ def Interp(dims, iava, axis=-1, kind="linear", dtype="float64"):
         interpop = _sincinterp(dims, iava, axis=axis, dtype=dtype)
     else:
         raise NotImplementedError("kind is not correct...")
-    return LinearOperator(interpop), iava
+    return interpop, iava

--- a/pylops/signalprocessing/Patch2D.py
+++ b/pylops/signalprocessing/Patch2D.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from pylops.basicoperators import BlockDiag, Diagonal, HStack, Restriction
+from pylops.LinearOperator import aslinearoperator
 from pylops.signalprocessing.Sliding2D import _slidingsteps
 from pylops.utils.tapers import taper2d
 
@@ -180,5 +181,11 @@ def Patch2D(Op, dims, dimsd, nwin, nover, nop, tapertype="hanning", design=False
             for win_in, win_end in zip(dwin0_ins, dwin0_ends)
         ]
     )
-    Pop = combining0 * combining1 * OOp
+    Pop = aslinearoperator(combining0 * combining1 * OOp)
+    Pop.dims, Pop.dimsd = (
+        nwins0,
+        nwins1,
+        int(dims[0] // nwins0),
+        int(dims[1] // nwins1),
+    ), dimsd
     return Pop

--- a/pylops/signalprocessing/Shift.py
+++ b/pylops/signalprocessing/Shift.py
@@ -95,6 +95,7 @@ def Shift(
     shift = np.exp(-1j * 2 * np.pi * Fop.f * shift)
     Sop = Diagonal(shift, dims=dimsdiag, axis=axis, dtype=Fop.cdtype)
     Op = Fop.H * Sop * Fop
+    Op.dims = Op.dimsd = Fop.dims
     # force dtype to that of input (FFT always upcasts it to complex)
     Op.dtype = dtype
     return Op

--- a/pylops/signalprocessing/Sliding1D.py
+++ b/pylops/signalprocessing/Sliding1D.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from pylops.basicoperators import BlockDiag, Diagonal, HStack, Restriction
+from pylops.LinearOperator import aslinearoperator
 from pylops.signalprocessing.Sliding2D import _slidingsteps
 from pylops.utils.tapers import taper
 
@@ -107,5 +108,6 @@ def Sliding1D(Op, dim, dimd, nwin, nover, tapertype="hanning", design=False):
             for win_in, win_end in zip(dwin_ins, dwin_ends)
         ]
     )
-    Sop = combining * OOp
+    Sop = aslinearoperator(combining * OOp)
+    Sop.dims, Sop.dimsd = (nwins, int(dim // nwins)), dimd
     return Sop

--- a/pylops/signalprocessing/Sliding2D.py
+++ b/pylops/signalprocessing/Sliding2D.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from pylops.basicoperators import BlockDiag, Diagonal, HStack, Restriction
+from pylops.LinearOperator import aslinearoperator
 from pylops.utils.tapers import taper2d
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
@@ -139,5 +140,6 @@ def Sliding2D(Op, dims, dimsd, nwin, nover, tapertype="hanning", design=False):
             for win_in, win_end in zip(dwin_ins, dwin_ends)
         ]
     )
-    Sop = combining * OOp
+    Sop = aslinearoperator(combining * OOp)
+    Sop.dims, Sop.dimsd = (nwins, int(dims[0] // nwins), dims[1]), dimsd
     return Sop

--- a/pylops/signalprocessing/Sliding3D.py
+++ b/pylops/signalprocessing/Sliding3D.py
@@ -1,8 +1,7 @@
 import logging
 
-import numpy as np
-
 from pylops.basicoperators import BlockDiag, Diagonal, HStack, Restriction
+from pylops.LinearOperator import aslinearoperator
 from pylops.signalprocessing.Sliding2D import _slidingsteps
 from pylops.utils.tapers import taper3d
 
@@ -152,5 +151,12 @@ def Sliding3D(
             for win_in, win_end in zip(dwin0_ins, dwin0_ends)
         ]
     )
-    Sop = combining0 * combining1 * OOp
+    Sop = aslinearoperator(combining0 * combining1 * OOp)
+    Sop.dims, Sop.dimsd = (
+        nwins0,
+        nwins1,
+        int(dims[0] // nwins0),
+        int(dims[1] // nwins1),
+        dims[2],
+    ), dimsd
     return Sop

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -6,7 +6,11 @@ import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import _raise_on_wrong_dtype, _value_or_list_like_to_array
+from pylops.utils._internal import (
+    _raise_on_wrong_dtype,
+    _value_or_list_like_to_array,
+    _value_or_list_like_to_tuple,
+)
 from pylops.utils.backend import get_complex_dtype, get_real_dtype
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
@@ -33,8 +37,8 @@ class _BaseFFT(LinearOperator):
         fftshift_after=False,
         dtype="complex128",
     ):
-        self.dims = _value_or_list_like_to_array(dims)
-        _raise_on_wrong_dtype(self.dims, np.integer, "dims")
+        self.dims = _value_or_list_like_to_tuple(dims)
+        _raise_on_wrong_dtype(np.array(self.dims), np.integer, "dims")
 
         self.ndim = len(self.dims)
 
@@ -99,10 +103,11 @@ class _BaseFFT(LinearOperator):
                 )
             self.f = np.fft.fftshift(self.f)
 
-        self.dims_fft = self.dims.copy()
-        self.dims_fft[self.axis] = self.nfft // 2 + 1 if self.real else self.nfft
-        self.shape = (int(np.prod(self.dims_fft)), int(np.prod(self.dims)))
+        dimsd = list(self.dims)
+        dimsd[self.axis] = self.nfft // 2 + 1 if self.real else self.nfft
+        self.dimsd = tuple(dimsd)
 
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         # Find types to enforce to forward and adjoint outputs. This is
         # required as np.fft.fft always returns complex128 even if input is
         # float32 or less. Moreover, when choosing real=True, the type of the
@@ -113,6 +118,24 @@ class _BaseFFT(LinearOperator):
         self.dtype = self.cdtype
         self.clinear = False if self.real or np.issubdtype(dtype, np.floating) else True
         self.explicit = False
+
+    @property
+    def dims_fft(self):
+        warnings.warn(
+            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.dimsd
+
+    @dims_fft.setter
+    def dims_fft(self, value):
+        warnings.warn(
+            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.dimsd = value
 
     def _matvec(self, x):
         raise NotImplementedError(
@@ -140,8 +163,8 @@ class _BaseFFTND(LinearOperator):
         fftshift_after=False,
         dtype="complex128",
     ):
-        self.dims = _value_or_list_like_to_array(dims)
-        _raise_on_wrong_dtype(self.dims, np.integer, "dims")
+        self.dims = _value_or_list_like_to_tuple(dims)
+        _raise_on_wrong_dtype(np.array(self.dims), np.integer, "dims")
 
         self.ndim = len(self.dims)
 
@@ -159,7 +182,7 @@ class _BaseFFTND(LinearOperator):
             nffts[np.equal(nffts, None)] = np.array(
                 [self.dims[d] for d, n in zip(axes, nffts) if n is None]
             )
-            nffts = nffts.astype(self.dims.dtype)
+            nffts = nffts.astype(np.array(self.dims).dtype)
         self.nffts = nffts
         _raise_on_wrong_dtype(self.nffts, np.integer, "nffts")
 
@@ -256,16 +279,36 @@ class _BaseFFTND(LinearOperator):
                 )
                 fs[-1] = np.fft.fftshift(fs[-1])
         self.fs = tuple(fs)
-        self.dims_fft = self.dims.copy()
-        self.dims_fft[self.axes] = self.nffts
+        dimsd = np.array(self.dims)
+        dimsd[self.axes] = self.nffts
         if self.real:
-            self.dims_fft[self.axes[-1]] = self.nffts[-1] // 2 + 1
-        self.shape = (int(np.prod(self.dims_fft)), int(np.prod(self.dims)))
+            dimsd[self.axes[-1]] = self.nffts[-1] // 2 + 1
+        self.dimsd = tuple(dimsd)
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.rdtype = get_real_dtype(dtype) if self.real else np.dtype(dtype)
         self.cdtype = get_complex_dtype(dtype)
         self.dtype = self.cdtype
         self.clinear = False if self.real or np.issubdtype(dtype, np.floating) else True
         self.explicit = False
+
+    @property
+    def dims_fft(self):
+        warnings.warn(
+            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.dimsd
+
+    @dims_fft.setter
+    def dims_fft(self, value):
+        warnings.warn(
+            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.dimsd = value
 
     def _matvec(self, x):
         raise NotImplementedError(

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -119,24 +119,6 @@ class _BaseFFT(LinearOperator):
         self.clinear = False if self.real or np.issubdtype(dtype, np.floating) else True
         self.explicit = False
 
-    @property
-    def dims_fft(self):
-        warnings.warn(
-            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.dimsd
-
-    @dims_fft.setter
-    def dims_fft(self, value):
-        warnings.warn(
-            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.dimsd = value
-
     def _matvec(self, x):
         raise NotImplementedError(
             "_BaseFFT does not provide _matvec. It must be implemented separately."
@@ -291,24 +273,6 @@ class _BaseFFTND(LinearOperator):
         self.dtype = self.cdtype
         self.clinear = False if self.real or np.issubdtype(dtype, np.floating) else True
         self.explicit = False
-
-    @property
-    def dims_fft(self):
-        warnings.warn(
-            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.dimsd
-
-    @dims_fft.setter
-    def dims_fft(self, value):
-        warnings.warn(
-            "dims_fft is deprecated in version 2.0.0, use dimsd instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.dimsd = value
 
     def _matvec(self, x):
         raise NotImplementedError(

--- a/pylops/utils/_internal.py
+++ b/pylops/utils/_internal.py
@@ -27,6 +27,27 @@ def _value_or_list_like_to_array(value_or_list_like, repeat=1):
     return out
 
 
+def _value_or_list_like_to_tuple(value_or_list_like, repeat=1):
+    """Convert an object which is either single value or a list-like to a tuple.
+
+    Parameters
+    ----------
+    value_or_list_like
+        Single value or list-like.
+    repeat : `obj`:`int`
+        Size of resulting array if value is passed. If list is passed, it is ignored.
+
+    Returns
+    -------
+    out : `obj`:`tuple`
+        When the input is a single value, returned an array with `repeat` samples
+        containing that value. When the input is a list-like object, converts it to a
+        tuple.
+
+    """
+    return tuple(_value_or_list_like_to_array(value_or_list_like, repeat=repeat))
+
+
 def _raise_on_wrong_dtype(arr, dtype, name):
     """Raises an error if dtype of `arr` is not a subdtype of `dtype`.
 

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -127,7 +127,7 @@ def test_MatrixMult_repeated(par):
     G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32") + par[
         "imag"
     ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
-    Gop = MatrixMult(G, dims=5, dtype=par["dtype"])
+    Gop = MatrixMult(G, otherdims=5, dtype=par["dtype"])
     assert dottest(
         Gop, par["ny"] * 5, par["nx"] * 5, complexflag=0 if par["imag"] == 1 else 3
     )

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -748,7 +748,7 @@ def test_FFT2D_small_complex(par):
 
     # Compute FFT with FFTop and compare with y_true
     y = FFTop * x.ravel()
-    y = y.reshape(FFTop.dims_fft)
+    y = y.reshape(FFTop.dimsd)
     assert_array_almost_equal(y, y_true, decimal=decimal)
     assert dottest(FFTop, *FFTop.shape, complexflag=3, rtol=10 ** (-decimal))
 
@@ -795,7 +795,7 @@ def test_FFTND_small_complex(par):
 
     # Compute FFT with FFTop and compare with y_true
     y = FFTop * x.ravel()
-    y = y.reshape(FFTop.dims_fft)
+    y = y.reshape(FFTop.dimsd)
     assert_array_almost_equal(y, y_true, decimal=decimal)
     assert dottest(FFTop, *FFTop.shape, complexflag=3, rtol=10 ** (-decimal))
 


### PR DESCRIPTION
## Motivation
The are many operators whose output is of a different shape as that of input. In these cases, it can be confusing to the user that does not know exactly how this output is shaped.

## Changes
* This PR introduces a standardized `dimsd` for all operators which take `dims` except `MatrixMul`, `Patch2D`, `Sliding2D` and `Interp`
* `dims_fft` in FFT operators and `dims_d` in `Sum` are replaced by `dimsd`
* `dims` and `dimsd` are now tuples always