### PR TITLE
feature: add name to all operators

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -45,16 +45,21 @@ class LinearOperator(spLinearOperator):
     ----------
     Op : :obj:`scipy.sparse.linalg.LinearOperator` or :obj:`scipy.sparse.linalg._ProductLinearOperator` or :obj:`scipy.sparse.linalg._SumLinearOperator`
         Operator
-    explicit : :obj:`bool`
+    explicit : :obj:`bool`, optional
         Operator contains a matrix that can be solved explicitly
         (``True``) or not (``False``)
-    clinear : :obj:`bool`
+    clinear : :obj:`bool`, optional
         .. versionadded:: 1.17.0
 
         Operator is complex-linear.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
+
     """
 
-    def __init__(self, Op=None, explicit=False, clinear=None):
+    def __init__(self, Op=None, explicit=False, clinear=None, name=None):
         self.explicit = explicit
         if Op is not None:
             self.Op = Op
@@ -63,6 +68,7 @@ class LinearOperator(spLinearOperator):
             self.clinear = getattr(self.Op, "clinear", True)
         if clinear is not None:
             self.clinear = clinear
+        self.name = name
 
     def _matvec(self, x):
         if callable(self.Op._matvec):

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -539,6 +539,10 @@ class AVOLinearModelling(LinearOperator):
 
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -578,6 +582,7 @@ class AVOLinearModelling(LinearOperator):
         spatdims=None,
         linearization="akirich",
         dtype="float64",
+        name="A",
     ):
         self.ncp = get_array_module(theta)
 
@@ -613,7 +618,7 @@ class AVOLinearModelling(LinearOperator):
             self.nt0 * self.npars * nspatdims,
         )
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         if self.spatdims is None:

--- a/pylops/avo/poststack.py
+++ b/pylops/avo/poststack.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.sparse.linalg import lsqr
 
 from pylops import FirstDerivative, Laplacian, MatrixMult, SecondDerivative
+from pylops.LinearOperator import aslinearoperator
 from pylops.optimization.leastsquares import RegularizedInversion
 from pylops.optimization.solver import cgls
 from pylops.optimization.sparsity import SplitBregman
@@ -115,7 +116,7 @@ def _PoststackLinearModelling(
 
 
 def PoststackLinearModelling(
-    wav, nt0, spatdims=None, explicit=False, sparse=False, kind="centered"
+    wav, nt0, spatdims=None, explicit=False, sparse=False, kind="centered", name=None
 ):
     r"""Post-stack linearized seismic modelling operator.
 
@@ -145,6 +146,10 @@ def PoststackLinearModelling(
     sparse : :obj:`bool`, optional
         Create a sparse matrix (``True``) or dense  (``False``) when
         ``explicit=True``
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -182,9 +187,11 @@ def PoststackLinearModelling(
     the wavelet.
 
     """
-    return _PoststackLinearModelling(
+    Pop = _PoststackLinearModelling(
         wav, nt0, spatdims=spatdims, explicit=explicit, sparse=sparse, kind=kind
     )
+    Pop.name = name
+    return Pop
 
 
 def PoststackInversion(

--- a/pylops/avo/prestack.py
+++ b/pylops/avo/prestack.py
@@ -40,6 +40,7 @@ def PrestackLinearModelling(
     linearization="akirich",
     explicit=False,
     kind="centered",
+    name=None,
 ):
     r"""Pre-stack linearized seismic modelling operator.
 
@@ -83,6 +84,10 @@ def PrestackLinearModelling(
         (``True``, preferred for small data)
     kind : :obj:`str`, optional
         Derivative kind (``forward`` or ``centered``).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -204,11 +209,19 @@ def PrestackLinearModelling(
         dimsm[1] = AVOop.npars
         Dop = FirstDerivative(dimsm, axis=0, sampling=1.0, kind=kind, dtype=dtype)
         Preop = Cop * AVOop * Dop
+
+    Preop.name = name
     return Preop
 
 
 def PrestackWaveletModelling(
-    m, theta, nwav, wavc=None, vsvp=0.5, linearization="akirich"
+    m,
+    theta,
+    nwav,
+    wavc=None,
+    vsvp=0.5,
+    linearization="akirich",
+    name=None,
 ):
     r"""Pre-stack linearized seismic modelling operator for wavelet.
 
@@ -239,6 +252,10 @@ def PrestackWaveletModelling(
         * "PS": PS. See :py:func:`pylops.avo.avo.ps`.
 
         * Function with the same signature as :py:func:`pylops.avo.avo.akirichards`
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -323,6 +340,7 @@ def PrestackWaveletModelling(
             for itheta in range(ntheta)
         ]
     )
+    Mconv.name = name
     return Mconv
 
 

--- a/pylops/basicoperators/CausalIntegration.py
+++ b/pylops/basicoperators/CausalIntegration.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator
@@ -31,6 +29,10 @@ class CausalIntegration(LinearOperator):
         Integration kind (``full``, ``half``, or ``trapezoidal``).
     removefirst : :obj:`bool`, optional
         Remove first sample (``True``) or not (``False``).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -96,6 +98,7 @@ class CausalIntegration(LinearOperator):
         dtype="float64",
         kind="full",
         removefirst=False,
+        name="C",
     ):
         self.dims = _value_or_list_like_to_tuple(dims)
         self.axis = axis
@@ -111,7 +114,7 @@ class CausalIntegration(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -16,6 +16,10 @@ class Conj(LinearOperator):
         Number of samples for each dimension
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -41,13 +45,12 @@ class Conj(LinearOperator):
 
     """
 
-    def __init__(self, dims, dtype="complex128"):
+    def __init__(self, dims, dtype="complex128", name="C"):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
-        self.clinear = False
+        super().__init__(explicit=False, clinear=False, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Diagonal.py
+++ b/pylops/basicoperators/Diagonal.py
@@ -31,6 +31,10 @@ class Diagonal(LinearOperator):
         Axis along which multiplication is applied.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -60,7 +64,7 @@ class Diagonal(LinearOperator):
 
     """
 
-    def __init__(self, diag, dims=None, axis=-1, dtype="float64"):
+    def __init__(self, diag, dims=None, axis=-1, dtype="float64", name="D"):
         ncp = get_array_module(diag)
         self.diag = diag.ravel()
         self.complex = True if ncp.iscomplexobj(self.diag) else False
@@ -78,7 +82,7 @@ class Diagonal(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         if type(self.diag) != type(x):

--- a/pylops/basicoperators/FirstDerivative.py
+++ b/pylops/basicoperators/FirstDerivative.py
@@ -31,6 +31,10 @@ class FirstDerivative(LinearOperator):
         Type of elements in input array.
     kind : :obj:`str`, optional
         Derivative kind (``forward``, ``centered``, or ``backward``).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -72,16 +76,13 @@ class FirstDerivative(LinearOperator):
         edge=False,
         dtype="float64",
         kind="centered",
+        name="F",
     ):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = normalize_axis_index(axis, len(self.dims))
         self.sampling = sampling
         self.edge = edge
         self.kind = kind
-
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        self.explicit = False
 
         # choose _matvec and _rmatvec kind
         if self.kind == "forward":
@@ -95,6 +96,10 @@ class FirstDerivative(LinearOperator):
             self._rmatvec = self._rmatvec_backward
         else:
             raise NotImplementedError("kind must be forward, centered, " "or backward")
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
+        self.dtype = np.dtype(dtype)
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec_forward(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Flip.py
+++ b/pylops/basicoperators/Flip.py
@@ -21,6 +21,10 @@ class Flip(LinearOperator):
         Axis along which model is flipped.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -45,13 +49,13 @@ class Flip(LinearOperator):
 
     """
 
-    def __init__(self, dims, axis=-1, dtype="float64"):
+    def __init__(self, dims, axis=-1, dtype="float64", name="F"):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = axis
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -69,7 +69,7 @@ class FunctionOperator(LinearOperator):
             self.dtype = kwargs["dtype"]
         except KeyError:
             self.dtype = "float64"
-        super().__init__(explicit=False, clinear=True, name=kwargs.get("name", None))
+        super().__init__(explicit=False, clinear=True, name=kwargs.get("name", "F"))
         super().__init__()
 
         self.f = f

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -36,6 +36,10 @@ class FunctionOperator(LinearOperator):
         Number of columns (length of model vector).
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -65,8 +69,7 @@ class FunctionOperator(LinearOperator):
             self.dtype = kwargs["dtype"]
         except KeyError:
             self.dtype = "float64"
-        self.explicit = False
-
+        super().__init__(explicit=False, clinear=True, name=kwargs.get("name", None))
         super().__init__()
 
         self.f = f

--- a/pylops/basicoperators/Identity.py
+++ b/pylops/basicoperators/Identity.py
@@ -25,6 +25,10 @@ class Identity(LinearOperator):
         Work inplace (``True``) or make a new copy (``False``). By default,
         data is a reference to the model (in forward) and model is a reference
         to the data (in adjoint).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -75,12 +79,12 @@ class Identity(LinearOperator):
 
     """
 
-    def __init__(self, N, M=None, dtype="float64", inplace=True):
+    def __init__(self, N, M=None, dtype="float64", inplace=True, name="I"):
         M = N if M is None else M
         self.inplace = inplace
         self.shape = (N, M)
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -18,6 +18,10 @@ class Imag(LinearOperator):
         Number of samples for each dimension
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -43,14 +47,13 @@ class Imag(LinearOperator):
 
     """
 
-    def __init__(self, dims, dtype="complex128"):
+    def __init__(self, dims, dtype="complex128", name="I"):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.rdtype = np.real(np.ones(1, self.dtype)).dtype
-        self.explicit = False
-        self.clinear = False
+        super().__init__(explicit=False, clinear=False, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Kronecker.py
+++ b/pylops/basicoperators/Kronecker.py
@@ -19,6 +19,10 @@ class Kronecker(LinearOperator):
         Second operator
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -55,7 +59,7 @@ class Kronecker(LinearOperator):
 
     """
 
-    def __init__(self, Op1, Op2, dtype="float64"):
+    def __init__(self, Op1, Op2, dtype="float64", name="K"):
         self.Op1 = Op1
         self.Op2 = Op2
         self.Op1H = self.Op1.H
@@ -65,7 +69,7 @@ class Kronecker(LinearOperator):
             self.Op1.shape[1] * self.Op2.shape[1],
         )
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = x.reshape(self.Op1.shape[1], self.Op2.shape[1])

--- a/pylops/basicoperators/MatrixMult.py
+++ b/pylops/basicoperators/MatrixMult.py
@@ -27,6 +27,10 @@ class MatrixMult(LinearOperator):
         to each column of the model/data).
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -44,7 +48,7 @@ class MatrixMult(LinearOperator):
 
     """
 
-    def __init__(self, A, otherdims=None, dtype="float64"):
+    def __init__(self, A, otherdims=None, dtype="float64", name="M"):
         ncp = get_array_module(A)
         self.A = A
         if isinstance(A, ncp.ndarray):
@@ -55,7 +59,7 @@ class MatrixMult(LinearOperator):
             self.dims, self.dimsd = A.shape[1], A.shape[0]
             self.reshape = False
             self.shape = A.shape
-            self.explicit = True
+            explicit = True
         else:
             otherdims = _value_or_list_like_to_array(otherdims)
             self.otherdims = np.array(otherdims, dtype=int)
@@ -67,7 +71,7 @@ class MatrixMult(LinearOperator):
             ), np.insert([np.prod(self.otherdims)], 0, self.A.shape[0])
             self.reshape = True
             self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-            self.explicit = False
+            explicit = False
         self.dtype = np.dtype(dtype)
         # Check dtype for correctness (upcast to complex when A is complex)
         if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=self.dtype)):
@@ -75,6 +79,7 @@ class MatrixMult(LinearOperator):
             logging.warning(
                 "Matrix A is a complex object, dtype cast to %s" % self.dtype
             )
+        super().__init__(explicit=explicit, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/MemoizeOperator.py
+++ b/pylops/basicoperators/MemoizeOperator.py
@@ -18,6 +18,10 @@ class MemoizeOperator(LinearOperator):
     max_neval : :obj:`int`, optional
         Maximum number of previous evaluations stored,
         use ``np.inf`` for infinite memory
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -29,11 +33,8 @@ class MemoizeOperator(LinearOperator):
 
     """
 
-    def __init__(self, Op, max_neval=10):
-        self.Op = Op
-        self.shape = Op.shape
-        self.dtype = np.dtype(Op.dtype)
-        self.explicit = False
+    def __init__(self, Op, max_neval=10, name="M"):
+        super().__init__(Op=Op, explicit=False, clinear=None, name=name)
 
         self.max_neval = max_neval
         self.store = []  # Store a list of Tuples (x, y)

--- a/pylops/basicoperators/MemoizeOperator.py
+++ b/pylops/basicoperators/MemoizeOperator.py
@@ -18,10 +18,6 @@ class MemoizeOperator(LinearOperator):
     max_neval : :obj:`int`, optional
         Maximum number of previous evaluations stored,
         use ``np.inf`` for infinite memory
-    name : :obj:`str`, optional
-        .. versionadded:: 2.0.0
-
-        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -33,8 +29,10 @@ class MemoizeOperator(LinearOperator):
 
     """
 
-    def __init__(self, Op, max_neval=10, name="M"):
-        super().__init__(Op=Op, explicit=False, clinear=None, name=name)
+    def __init__(self, Op, max_neval=10):
+        super().__init__(
+            Op=Op, explicit=False, clinear=None, name=getattr(Op, "name", None)
+        )
 
         self.max_neval = max_neval
         self.store = []  # Store a list of Tuples (x, y)

--- a/pylops/basicoperators/Pad.py
+++ b/pylops/basicoperators/Pad.py
@@ -22,6 +22,10 @@ class Pad(LinearOperator):
         the number of samples to pad in each dimension
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -58,7 +62,7 @@ class Pad(LinearOperator):
 
     """
 
-    def __init__(self, dims, pad, dtype="float64"):
+    def __init__(self, dims, pad, dtype="float64", name="P"):
         if np.any(np.array(pad) < 0):
             raise ValueError("Padding must be positive or zero")
         self.reshape = False if isinstance(dims, int) else True
@@ -75,7 +79,7 @@ class Pad(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         if self.reshape:

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -18,6 +18,10 @@ class Real(LinearOperator):
         Number of samples for each dimension
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -43,14 +47,13 @@ class Real(LinearOperator):
 
     """
 
-    def __init__(self, dims, dtype="complex128"):
+    def __init__(self, dims, dtype="complex128", name="R"):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.rdtype = np.real(np.ones(1, self.dtype)).dtype
-        self.explicit = False
-        self.clinear = False
+        super().__init__(explicit=False, clinear=False, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Regression.py
+++ b/pylops/basicoperators/Regression.py
@@ -25,6 +25,10 @@ class Regression(LinearOperator):
         Order of the regressed polynomial.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -75,7 +79,7 @@ class Regression(LinearOperator):
 
     """
 
-    def __init__(self, taxis, order, dtype="float64"):
+    def __init__(self, taxis, order, dtype="float64", name="R"):
         ncp = get_array_module(taxis)
         if not isinstance(taxis, ncp.ndarray):
             logging.error("t must be numpy.ndarray...")
@@ -85,7 +89,7 @@ class Regression(LinearOperator):
         self.order = order
         self.shape = (len(self.taxis), self.order + 1)
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -45,6 +45,10 @@ class Restriction(LinearOperator):
         Work inplace (``True``) or make a new copy (``False``). By default,
         data is a reference to the model (in forward) and model is a reference
         to the data (in adjoint).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -84,7 +88,7 @@ class Restriction(LinearOperator):
 
     """
 
-    def __init__(self, dims, iava, axis=-1, dtype="float64", inplace=True):
+    def __init__(self, dims, iava, axis=-1, dtype="float64", inplace=True, name="R"):
         ncp = get_array_module(iava)
         self.dims = _value_or_list_like_to_tuple(dims)
         self.axis = normalize_axis_index(axis, len(self.dims))
@@ -96,7 +100,7 @@ class Restriction(LinearOperator):
         self.iavareshape[self.axis] = len(self.iava)
 
         # currently cupy does not support put_along_axis, so we need to
-        # explicitely create a list of indices in the n-dimensional
+        # explicitly create a list of indices in the n-dimensional
         # model space which will be used in _rmatvec to place the input
         if ncp != np:
             self.iavamask = _compute_iavamask(self.dims, self.axis, self.iava, ncp)
@@ -105,6 +109,7 @@ class Restriction(LinearOperator):
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
         self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Roll.py
+++ b/pylops/basicoperators/Roll.py
@@ -24,6 +24,10 @@ class Roll(LinearOperator):
         Number of samples by which elements are shifted
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -41,14 +45,14 @@ class Roll(LinearOperator):
 
     """
 
-    def __init__(self, dims, axis=-1, shift=1, dtype="float64"):
+    def __init__(self, dims, axis=-1, shift=1, dtype="float64", name="R"):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = axis
         self.shift = shift
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = np.reshape(x, self.dims)

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -32,6 +32,10 @@ class SecondDerivative(LinearOperator):
         Type of elements in input array.
     kind : :obj:`str`, optional
         Derivative kind (``forward``, ``centered``, or ``backward``).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -72,16 +76,13 @@ class SecondDerivative(LinearOperator):
         edge=False,
         dtype="float64",
         kind="centered",
+        name="S",
     ):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = normalize_axis_index(axis, len(self.dims))
         self.sampling = sampling
         self.edge = edge
         self.kind = kind
-
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        self.explicit = False
 
         # choose _matvec and _rmatvec kind
         if self.kind == "forward":
@@ -96,6 +97,10 @@ class SecondDerivative(LinearOperator):
             )
         else:
             raise NotImplementedError("kind must be forward, centered, or backward")
+
+        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
+        self.dtype = np.dtype(dtype)
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec_forward(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Spread.py
+++ b/pylops/basicoperators/Spread.py
@@ -110,6 +110,10 @@ class Spread(LinearOperator):
         ``numba`` can only be used when providing a look-up table
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -168,6 +172,7 @@ class Spread(LinearOperator):
         interp=None,
         engine="numpy",
         dtype="float64",
+        name="S",
     ):
         if engine not in ["numpy", "numba"]:
             raise KeyError("engine must be numpy or numba")
@@ -217,7 +222,7 @@ class Spread(LinearOperator):
             logging.warning("interp has been overridden to %r.", self.interp)
         self.shape = (int(np.prod(self.dimsd)), int(np.prod(self.dims)))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec_numpy(self, x):
         x = x.reshape(self.dims)

--- a/pylops/basicoperators/Sum.py
+++ b/pylops/basicoperators/Sum.py
@@ -24,6 +24,10 @@ class Sum(LinearOperator):
         Axis along which model is summed.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -51,7 +55,7 @@ class Sum(LinearOperator):
 
     """
 
-    def __init__(self, dims, axis=-1, dtype="float64"):
+    def __init__(self, dims, axis=-1, dtype="float64", name="S"):
         dims = _value_or_list_like_to_tuple(dims)
         # to avoid reducing matvec to a scalar
         self.dims = (dims[0], 1) if len(dims) == 1 else dims
@@ -66,7 +70,7 @@ class Sum(LinearOperator):
 
         self.dtype = np.dtype(dtype)
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Symmetrize.py
+++ b/pylops/basicoperators/Symmetrize.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator
@@ -23,6 +21,10 @@ class Symmetrize(LinearOperator):
         Axis along which model is symmetrized.
     dtype : :obj:`str`, optional
         Type of elements in input array
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -60,7 +62,7 @@ class Symmetrize(LinearOperator):
     apart from the central sample where :math:`x[0] = y[N-1]`.
     """
 
-    def __init__(self, dims, axis=-1, dtype="float64"):
+    def __init__(self, dims, axis=-1, dtype="float64", name="S"):
         self.dims = _value_or_list_like_to_tuple(dims)
         self.axis = axis
         dimsd = list(self.dims)
@@ -70,7 +72,7 @@ class Symmetrize(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Transpose.py
+++ b/pylops/basicoperators/Transpose.py
@@ -21,6 +21,10 @@ class Transpose(LinearOperator):
         Direction along which transposition is applied
     dtype : :obj:`str`, optional
         Type of elements in input array
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -47,7 +51,7 @@ class Transpose(LinearOperator):
 
     """
 
-    def __init__(self, dims, axes, dtype="float64"):
+    def __init__(self, dims, axes, dtype="float64", name="T"):
         self.dims = _value_or_list_like_to_tuple(dims)
         ndims = len(self.dims)
         self.axes = [normalize_axis_index(ax, ndims) for ax in axes]
@@ -67,7 +71,7 @@ class Transpose(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         y = x.reshape(self.dims)

--- a/pylops/basicoperators/Zero.py
+++ b/pylops/basicoperators/Zero.py
@@ -18,6 +18,10 @@ class Zero(LinearOperator):
        Number of samples in model.
     dtype : :obj:`str`, optional
        Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -44,11 +48,11 @@ class Zero(LinearOperator):
 
     """
 
-    def __init__(self, N, M=None, dtype="float64"):
+    def __init__(self, N, M=None, dtype="float64", name="Z"):
         M = N if M is None else M
         self.shape = (N, M)
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/signalprocessing/Bilinear.py
+++ b/pylops/signalprocessing/Bilinear.py
@@ -33,6 +33,10 @@ class Bilinear(LinearOperator):
         Number of samples for each dimension
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -76,7 +80,7 @@ class Bilinear(LinearOperator):
 
     """
 
-    def __init__(self, iava, dims, dtype="float64"):
+    def __init__(self, iava, dims, dtype="float64", name="B"):
         ncp = get_array_module(iava)
 
         # check non-unique pairs (works only with numpy arrays)
@@ -103,7 +107,7 @@ class Bilinear(LinearOperator):
 
         self.shape = (np.prod(np.array(self.dimsd)), np.prod(np.array(self.dims)))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/signalprocessing/ChirpRadon2D.py
+++ b/pylops/signalprocessing/ChirpRadon2D.py
@@ -33,6 +33,10 @@ class ChirpRadon2D(LinearOperator):
         :math:`p_{x, \text{max}}=c_0 \,\mathrm{d}y/\mathrm{d}t`.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -51,7 +55,7 @@ class ChirpRadon2D(LinearOperator):
 
     """
 
-    def __init__(self, taxis, haxis, pmax, dtype="float64"):
+    def __init__(self, taxis, haxis, pmax, dtype="float64", name="C"):
         self.dt = taxis[1] - taxis[0]
         self.dh = haxis[1] - haxis[0]
         self.nt, self.nh = taxis.size, haxis.size
@@ -59,7 +63,7 @@ class ChirpRadon2D(LinearOperator):
 
         self.shape = (self.nt * self.nh, self.nt * self.nh)
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = x.reshape(self.nh, self.nt)

--- a/pylops/signalprocessing/ChirpRadon3D.py
+++ b/pylops/signalprocessing/ChirpRadon3D.py
@@ -54,6 +54,10 @@ class ChirpRadon3D(LinearOperator):
         Engine used for fft computation (``numpy`` or ``fftw``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
     **kwargs_fftw
             Arbitrary keyword arguments for :py:class:`pyfftw.FTTW`
             (reccomended: ``flags=('FFTW_ESTIMATE', ), threads=NTHREADS``)
@@ -83,6 +87,7 @@ class ChirpRadon3D(LinearOperator):
         pmax,
         engine="numpy",
         dtype="float64",
+        name="C",
         **kwargs_fftw
     ):
         self.dt = taxis[1] - taxis[0]
@@ -96,7 +101,7 @@ class ChirpRadon3D(LinearOperator):
         self.kwargs_fftw = kwargs_fftw
         self.shape = (self.nt * self.nx * self.ny, self.nt * self.nx * self.ny)
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = x.reshape(self.ny, self.nx, self.nt)

--- a/pylops/signalprocessing/Convolve1D.py
+++ b/pylops/signalprocessing/Convolve1D.py
@@ -60,6 +60,10 @@ class Convolve1D(LinearOperator):
         when ``dims`` is provided.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -116,7 +120,9 @@ class Convolve1D(LinearOperator):
 
     """
 
-    def __init__(self, dims, h, offset=0, axis=-1, dtype="float64", method=None):
+    def __init__(
+        self, dims, h, offset=0, axis=-1, dtype="float64", method=None, name="C"
+    ):
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
         self.axis = axis
 
@@ -150,7 +156,7 @@ class Convolve1D(LinearOperator):
         self.convfunc, self.method = _choose_convfunc(h, method, self.dimsorig)
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         if type(self.h) != type(x):

--- a/pylops/signalprocessing/Convolve2D.py
+++ b/pylops/signalprocessing/Convolve2D.py
@@ -5,7 +5,9 @@ from numpy.core.multiarray import normalize_axis_index
 from pylops.signalprocessing import ConvolveND
 
 
-def Convolve2D(dims, h, offset=(0, 0), axes=(-2, -1), dtype="float64", method="fft"):
+def Convolve2D(
+    dims, h, offset=(0, 0), axes=(-2, -1), dtype="float64", method="fft", name="C"
+):
     r"""2D convolution operator.
 
     Apply two-dimensional convolution with a compact filter to model
@@ -28,6 +30,10 @@ def Convolve2D(dims, h, offset=(0, 0), axes=(-2, -1), dtype="float64", method="f
         Type of elements in input array.
     method : :obj:`str`, optional
         Method used to calculate the convolution (``direct`` or ``fft``).
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -77,4 +83,5 @@ def Convolve2D(dims, h, offset=(0, 0), axes=(-2, -1), dtype="float64", method="f
     if h.ndim != 2:
         raise ValueError("h must be 2-dimensional")
     cop = ConvolveND(dims, h, offset=offset, axes=axes, method=method, dtype=dtype)
+    cop.name = name
     return cop

--- a/pylops/signalprocessing/ConvolveND.py
+++ b/pylops/signalprocessing/ConvolveND.py
@@ -35,6 +35,10 @@ class ConvolveND(LinearOperator):
         Method used to calculate the convolution (``direct`` or ``fft``).
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -62,6 +66,7 @@ class ConvolveND(LinearOperator):
         axes=(-2, -1),
         method="fft",
         dtype="float64",
+        name="C",
     ):
         ncp = get_array_module(h)
         self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
@@ -108,7 +113,7 @@ class ConvolveND(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         # correct type of h if different from x and choose methods accordingly

--- a/pylops/signalprocessing/DWT.py
+++ b/pylops/signalprocessing/DWT.py
@@ -68,6 +68,10 @@ class DWT(LinearOperator):
         Number of scaling levels (must be >=0).
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -97,7 +101,9 @@ class DWT(LinearOperator):
 
     """
 
-    def __init__(self, dims, axis=-1, wavelet="haar", level=1, dtype="float64"):
+    def __init__(
+        self, dims, axis=-1, wavelet="haar", level=1, dtype="float64", name="D"
+    ):
         if pywt is None:
             raise ModuleNotFoundError(pywt_message)
         _checkwavelet(wavelet)
@@ -132,7 +138,7 @@ class DWT(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = self.pad.matvec(x)

--- a/pylops/signalprocessing/DWT2D.py
+++ b/pylops/signalprocessing/DWT2D.py
@@ -51,6 +51,10 @@ class DWT2D(LinearOperator):
         Number of scaling levels (must be >=0).
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -75,7 +79,9 @@ class DWT2D(LinearOperator):
 
     """
 
-    def __init__(self, dims, axes=(-2, -1), wavelet="haar", level=1, dtype="float64"):
+    def __init__(
+        self, dims, axes=(-2, -1), wavelet="haar", level=1, dtype="float64", name="D"
+    ):
         if pywt is None:
             raise ModuleNotFoundError(pywt_message)
         _checkwavelet(wavelet)
@@ -110,7 +116,7 @@ class DWT2D(LinearOperator):
 
         self.shape = (np.prod(self.dimsd), np.prod(self.dims))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = self.pad.matvec(x)

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -381,6 +381,7 @@ def FFT(
     fftshift_after=False,
     engine="numpy",
     dtype="complex128",
+    name="F",
     **kwargs_fftw,
 ):
     r"""One dimensional Fast-Fourier Transform.
@@ -474,6 +475,10 @@ def FFT(
         The SciPy backend supports all precisions natively.
         Under all backends, when a real ``dtype`` is supplied, a real result will be
         enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
     **kwargs_fftw
             Arbitrary keyword arguments
             for :py:class:`pyfftw.FTTW`
@@ -600,4 +605,5 @@ def FFT(
         )
     else:
         raise NotImplementedError("engine must be numpy, fftw or scipy")
+    f.name = name
     return f

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -216,6 +216,7 @@ def FFT2D(
     fftshift_after=False,
     dtype="complex128",
     engine="numpy",
+    name="F",
 ):
     r"""Two dimensional Fast-Fourier Transform.
 
@@ -309,6 +310,10 @@ def FFT2D(
         The SciPy backend supports all precisions natively.
         Under both backends, when a real ``dtype`` is supplied, a real result will be
         enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -405,4 +410,5 @@ def FFT2D(
         )
     else:
         raise NotImplementedError("engine must be numpy or scipy")
+    f.name = name
     return f

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -200,6 +200,7 @@ def FFTND(
     fftshift_after=False,
     dtype="complex128",
     engine="scipy",
+    name="F",
 ):
     r"""N-dimensional Fast-Fourier Transform.
 
@@ -298,6 +299,10 @@ def FFTND(
         The SciPy backend supports all precisions natively.
         Under both backends, when a real ``dtype`` is supplied, a real result will be
         enforced on the result of the ``rmatvec`` and the input of the ``matvec``.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -398,4 +403,5 @@ def FFTND(
         )
     else:
         raise NotImplementedError("engine must be numpy or scipy")
+    f.name = name
     return f

--- a/pylops/signalprocessing/Fredholm1.py
+++ b/pylops/signalprocessing/Fredholm1.py
@@ -35,6 +35,10 @@ class Fredholm1(LinearOperator):
         choice.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -79,7 +83,7 @@ class Fredholm1(LinearOperator):
 
     """
 
-    def __init__(self, G, nz=1, saveGt=True, usematmul=True, dtype="float64"):
+    def __init__(self, G, nz=1, saveGt=True, usematmul=True, dtype="float64", name="F"):
         self.nz = nz
         self.nsl, self.nx, self.ny = G.shape
         self.G = G
@@ -88,7 +92,7 @@ class Fredholm1(LinearOperator):
         self.usematmul = usematmul
         self.shape = (self.nsl * self.nx * self.nz, self.nsl * self.ny * self.nz)
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/signalprocessing/Interp.py
+++ b/pylops/signalprocessing/Interp.py
@@ -201,11 +201,11 @@ def Interp(dims, iava, axis=-1, kind="linear", dtype="float64", name="I"):
         interpop, dims, dimsd = _sincinterp(dims, iava, axis=axis, dtype=dtype)
     else:
         raise NotImplementedError("kind is not correct...")
-    interpop.name = name
     # add dims and dimsd to composite operators (not needed for neareast as
     # interpop is a Restriction operator already
     if kind != "nearest":
         interpop = aslinearoperator(interpop)
         interpop.dims = dims
         interpop.dimsd = dimsd
+        interpop.name = name
     return interpop, iava

--- a/pylops/signalprocessing/Interp.py
+++ b/pylops/signalprocessing/Interp.py
@@ -89,7 +89,7 @@ def _sincinterp(dims, iava, axis=0, dtype="float64"):
     return Op, dims, dimsd
 
 
-def Interp(dims, iava, axis=-1, kind="linear", dtype="float64"):
+def Interp(dims, iava, axis=-1, kind="linear", dtype="float64", name="I"):
     r"""Interpolation operator.
 
     Apply interpolation along ``axis``
@@ -132,6 +132,10 @@ def Interp(dims, iava, axis=-1, kind="linear", dtype="float64"):
         currently supported)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -197,6 +201,7 @@ def Interp(dims, iava, axis=-1, kind="linear", dtype="float64"):
         interpop, dims, dimsd = _sincinterp(dims, iava, axis=axis, dtype=dtype)
     else:
         raise NotImplementedError("kind is not correct...")
+    interpop.name = name
     # add dims and dimsd to composite operators (not needed for neareast as
     # interpop is a Restriction operator already
     if kind != "nearest":

--- a/pylops/signalprocessing/Patch2D.py
+++ b/pylops/signalprocessing/Patch2D.py
@@ -10,7 +10,9 @@ from pylops.utils.tapers import taper2d
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
-def Patch2D(Op, dims, dimsd, nwin, nover, nop, tapertype="hanning", design=False):
+def Patch2D(
+    Op, dims, dimsd, nwin, nover, nop, tapertype="hanning", design=False, name="P"
+):
     """2D Patch transform operator.
 
     Apply a transform operator ``Op`` repeatedly to patches of the model
@@ -57,6 +59,10 @@ def Patch2D(Op, dims, dimsd, nwin, nover, nop, tapertype="hanning", design=False
         Type of taper (``hanning``, ``cosine``, ``cosinesquare`` or ``None``)
     design : :obj:`bool`, optional
         Print number of sliding window (``True``) or not (``False``)
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -188,4 +194,5 @@ def Patch2D(Op, dims, dimsd, nwin, nover, nop, tapertype="hanning", design=False
         int(dims[0] // nwins0),
         int(dims[1] // nwins1),
     ), dimsd
+    Pop.name = name
     return Pop

--- a/pylops/signalprocessing/Radon2D.py
+++ b/pylops/signalprocessing/Radon2D.py
@@ -116,6 +116,7 @@ def Radon2D(
     onthefly=False,
     engine="numpy",
     dtype="float64",
+    name="R",
 ):
     r"""Two dimensional Radon transform.
 
@@ -155,6 +156,10 @@ def Radon2D(
         Engine used for computation (``numpy`` or ``numba``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -276,4 +281,5 @@ def Radon2D(
             engine=engine,
             dtype=dtype,
         )
+    r2op.name = name
     return r2op

--- a/pylops/signalprocessing/Radon3D.py
+++ b/pylops/signalprocessing/Radon3D.py
@@ -122,6 +122,7 @@ def Radon3D(
     onthefly=False,
     engine="numpy",
     dtype="float64",
+    name="R",
 ):
     r"""Three dimensional Radon transform.
 
@@ -164,6 +165,10 @@ def Radon3D(
         Engine used for computation (``numpy`` or ``numba``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -334,4 +339,5 @@ def Radon3D(
             engine=engine,
             dtype=dtype,
         )
+    r3op.name = name
     return r3op

--- a/pylops/signalprocessing/Seislet.py
+++ b/pylops/signalprocessing/Seislet.py
@@ -239,6 +239,10 @@ class Seislet(LinearOperator):
         can access the inverse directly as method of this class.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -373,6 +377,7 @@ class Seislet(LinearOperator):
         kind="haar",
         inv=False,
         dtype="float64",
+        name="S",
     ):
         if len(sampling) != 2:
             raise ValueError("provide two sampling steps")
@@ -413,7 +418,7 @@ class Seislet(LinearOperator):
         self.inv = inv
         self.shape = (int(np.prod(self.dimsd)), int(np.prod(self.dims)))
         self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = self.pad.matvec(x)

--- a/pylops/signalprocessing/Shift.py
+++ b/pylops/signalprocessing/Shift.py
@@ -15,6 +15,7 @@ def Shift(
     real=False,
     engine="numpy",
     dtype="complex128",
+    name="S",
     **kwargs_fftw
 ):
     r"""Shift operator
@@ -45,6 +46,10 @@ def Shift(
         ``numpy`` when working with CuPy arrays.
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
     **kwargs_fftw
             Arbitrary keyword arguments
             for :py:class:`pyfftw.FTTW`
@@ -98,4 +103,5 @@ def Shift(
     Op.dims = Op.dimsd = Fop.dims
     # force dtype to that of input (FFT always upcasts it to complex)
     Op.dtype = dtype
+    Op.name = name
     return Op

--- a/pylops/signalprocessing/Sliding1D.py
+++ b/pylops/signalprocessing/Sliding1D.py
@@ -10,7 +10,7 @@ from pylops.utils.tapers import taper
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
-def Sliding1D(Op, dim, dimd, nwin, nover, tapertype="hanning", design=False):
+def Sliding1D(Op, dim, dimd, nwin, nover, tapertype="hanning", design=False, name="S"):
     r"""1D Sliding transform operator.
 
     Apply a transform operator ``Op`` repeatedly to slices of the model
@@ -50,6 +50,10 @@ def Sliding1D(Op, dim, dimd, nwin, nover, tapertype="hanning", design=False):
         Type of taper (``hanning``, ``cosine``, ``cosinesquare`` or ``None``)
     design : :obj:`bool`, optional
         Print number of sliding window (``True``) or not (``False``)
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -110,4 +114,5 @@ def Sliding1D(Op, dim, dimd, nwin, nover, tapertype="hanning", design=False):
     )
     Sop = aslinearoperator(combining * OOp)
     Sop.dims, Sop.dimsd = (nwins, int(dim // nwins)), dimd
+    Sop.name = name
     return Sop

--- a/pylops/signalprocessing/Sliding2D.py
+++ b/pylops/signalprocessing/Sliding2D.py
@@ -38,7 +38,9 @@ def _slidingsteps(ntr, nwin, nover):
     return starts, ends
 
 
-def Sliding2D(Op, dims, dimsd, nwin, nover, tapertype="hanning", design=False):
+def Sliding2D(
+    Op, dims, dimsd, nwin, nover, tapertype="hanning", design=False, name="S"
+):
     """2D Sliding transform operator.
 
     Apply a transform operator ``Op`` repeatedly to slices of the model
@@ -82,6 +84,10 @@ def Sliding2D(Op, dims, dimsd, nwin, nover, tapertype="hanning", design=False):
         Type of taper (``hanning``, ``cosine``, ``cosinesquare`` or ``None``)
     design : :obj:`bool`, optional
         Print number of sliding window (``True``) or not (``False``)
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -142,4 +148,5 @@ def Sliding2D(Op, dims, dimsd, nwin, nover, tapertype="hanning", design=False):
     )
     Sop = aslinearoperator(combining * OOp)
     Sop.dims, Sop.dimsd = (nwins, int(dims[0] // nwins), dims[1]), dimsd
+    Sop.name = name
     return Sop

--- a/pylops/signalprocessing/Sliding3D.py
+++ b/pylops/signalprocessing/Sliding3D.py
@@ -9,9 +9,18 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def Sliding3D(
-    Op, dims, dimsd, nwin, nover, nop, tapertype="hanning", design=False, nproc=1
+    Op,
+    dims,
+    dimsd,
+    nwin,
+    nover,
+    nop,
+    tapertype="hanning",
+    design=False,
+    nproc=1,
+    name="S",
 ):
-    """3D Sliding transform operator.
+    """3D Sliding transform operator.w
 
     Apply a transform operator ``Op`` repeatedly to patches of the model
     vector in forward mode and patches of the data vector in adjoint mode.
@@ -60,6 +69,10 @@ def Sliding3D(
         Type of taper (``hanning``, ``cosine``, ``cosinesquare`` or ``None``)
     design : :obj:`bool`, optional
         Print number sliding window (``True``) or not (``False``)
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -159,4 +172,5 @@ def Sliding3D(
         int(dims[1] // nwins1),
         dims[2],
     ), dimsd
+    Sop.name = name
     return Sop

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import string
 
@@ -46,6 +47,8 @@ compositeops = (
     BlockDiag,
 )
 
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+
 
 def _in_notebook():
     """Check if code is running inside notebook"""
@@ -79,7 +82,8 @@ def _assign_name(Op, Ops, names):
     # Add a suffix when all letters of the alphabet are already in use. This
     # decision is made by counting the length of the names list and using the
     # English vocabulary (26 characters)
-    suffix = "1" * (len(names) // 26)
+    suffix = str(len(names) // 26) * (len(names) // 26 > 0)
+
     # Propose a new name, where a random letter is chosen if Op does not
     # have a name
     proposedname = (
@@ -96,7 +100,7 @@ def _assign_name(Op, Ops, names):
         while proposedname in names:
             proposedname = random.choice(string.ascii_letters).upper() + suffix
         name = proposedname
-        print(
+        logging.warning(
             f"The user has used the same name {origname} for two distinct operators, "
             f"changing name of operator {type(Op).__name__} to {name}..."
         )

--- a/pylops/waveeqprocessing/lsm.py
+++ b/pylops/waveeqprocessing/lsm.py
@@ -161,7 +161,18 @@ def _traveltime_table(z, x, srcs, recs, vel, y=None, mode="eikonal"):
 
 
 def Demigration(
-    z, x, t, srcs, recs, vel, wav, wavcenter, y=None, trav=None, mode="eikonal"
+    z,
+    x,
+    t,
+    srcs,
+    recs,
+    vel,
+    wav,
+    wavcenter,
+    y=None,
+    trav=None,
+    mode="eikonal",
+    name="D",
 ):
     r"""Kirchhoff Demigration operator.
 
@@ -197,6 +208,10 @@ def Demigration(
         Traveltime table of size
         :math:`\lbrack (n_y) n_x n_z \times n_r \rbrack` (to be provided if
         ``mode='byot'``)
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -270,6 +285,7 @@ def Demigration(
         demop = cop * sop
     else:
         raise NotImplementedError("method must be analytic or eikonal")
+    demop.name = name
     return demop
 
 

--- a/pylops/waveeqprocessing/mdd.py
+++ b/pylops/waveeqprocessing/mdd.py
@@ -155,6 +155,7 @@ def MDC(
     conj=False,
     usematmul=False,
     prescaled=False,
+    name="M",
 ):
     r"""Multi-dimensional convolution.
 
@@ -220,6 +221,10 @@ def MDC(
         spatial and temporal summations. In case ``prescaled=True``, the
         kernel is assumed to have been pre-scaled when passed to the MDC
         routine.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Raises
     ------
@@ -265,7 +270,7 @@ def MDC(
        pp. 1335-1364. 2011.
 
     """
-    return _MDC(
+    MOp = _MDC(
         G,
         nt,
         nv,
@@ -281,6 +286,8 @@ def MDC(
         args_FFT={"engine": fftengine},
         args_Fredholm1={"usematmul": usematmul},
     )
+    MOp.name = name
+    return MOp
 
 
 def MDD(

--- a/pylops/waveeqprocessing/oneway.py
+++ b/pylops/waveeqprocessing/oneway.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy.sparse.linalg import lsqr
 
 from pylops import Diagonal, Identity, LinearOperator, Pad
+from pylops.LinearOperator import aslinearoperator
 from pylops.signalprocessing import FFT
 from pylops.utils import dottest as Dottest
 from pylops.utils.backend import to_cupy_conditional
@@ -97,7 +98,7 @@ class _PhaseShift(LinearOperator):
         return y.ravel()
 
 
-def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64"):
+def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64", name="P"):
     r"""Phase shift operator
 
     Apply positive (forward) phase shift with constant velocity in
@@ -123,6 +124,10 @@ def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64"):
         (centered around 0) of size :math:`[n_y \times 1]`.
     dtype : :obj:`str`, optional
         Type of elements in input array
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -187,7 +192,9 @@ def PhaseShift(vel, dz, nt, freq, kx, ky=None, dtype="float64"):
     # We know this is correct because forward and inverse FFTs are applied at
     # the beginning and end of this combined operator
     Pop.dtype = dtype
-    return LinearOperator(Pop)
+    Pop = aslinearoperator(Pop)
+    Pop.name = name
+    return Pop
 
 
 def Deghosting(

--- a/pylops/waveeqprocessing/wavedecomposition.py
+++ b/pylops/waveeqprocessing/wavedecomposition.py
@@ -221,6 +221,7 @@ def PressureToVelocity(
     topressure=False,
     backend="numpy",
     dtype="complex128",
+    name="P",
 ):
     r"""Pressure to Vertical velocity conversion.
 
@@ -260,6 +261,10 @@ def PressureToVelocity(
         (``numpy`` or ``cupy``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -338,6 +343,7 @@ def PressureToVelocity(
 
     # create conversion operator
     Cop = FFTop.H * OBLop * FFTop
+    Cop.name = name
     return Cop
 
 
@@ -354,6 +360,7 @@ def UpDownComposition2D(
     scaling=1.0,
     backend="numpy",
     dtype="complex128",
+    name="U",
 ):
     r"""2D Up-down wavefield composition.
 
@@ -397,6 +404,10 @@ def UpDownComposition2D(
         (``numpy`` or ``cupy``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -504,6 +515,7 @@ def UpDownComposition2D(
         )
         * BlockDiag([FFTop, FFTop])
     )
+    UDop.name = name
     return UDop
 
 
@@ -520,6 +532,7 @@ def UpDownComposition3D(
     scaling=1.0,
     backend="numpy",
     dtype="complex128",
+    name="U",
 ):
     r"""3D Up-down wavefield composition.
 
@@ -563,6 +576,10 @@ def UpDownComposition3D(
         (``numpy`` or ``cupy``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Returns
     -------
@@ -622,6 +639,7 @@ def UpDownComposition3D(
         )
         * BlockDiag([FFTop, FFTop])
     )
+    UDop.name = name
     return UDop
 
 


### PR DESCRIPTION
Add an optional parameter `name` to every linear operator to be used in describe method. Addresses the last main points of discussion in https://github.com/PyLops/pylops/issues/293