### PR TITLE
Support for non-flattened array multiplication

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -253,12 +253,32 @@ class LinearOperator(spLinearOperator):
         elif np.isscalar(x):
             return _ScaledLinearOperator(self, x)
         else:
-            if x.ndim == 1:  # or x.ndim == 2 and x.shape[1] == 1:
-                return self.matvec(x)
+            dims = getattr(self, "dims", None)
+            dimsd = getattr(self, "dimsd", None)
+
+            reshape_out = False
+            if x.shape == dims and dimsd is not None:
+                reshape_out = True
+                x = x.ravel()
+
+            if x.ndim == 1:
+                y = self.matvec(x)
+                if reshape_out:
+                    y = y.reshape(dimsd)
+                return y
             elif x.ndim == 2:
                 return self.matmat(x)
             else:
-                raise ValueError("expected 1-d or 2-d array or matrix, got %r" % x)
+                raise ValueError(
+                    (
+                        "Wrong shape.\nFor vector multiplication, expects either a 1d "
+                        "array or, an ndarray of size `dims` when `dims` and `dimsd` "
+                        "both are available.\n"
+                        "For matrix multiplication, expects a 2d array with its first "
+                        f"dimension is equal to {self.shape[1]}.\n"
+                        f"Instead, received an array of shape {x.shape}."
+                    )
+                )
 
     def div(self, y, niter=100):
         r"""Solve the linear problem :math:`\mathbf{y}=\mathbf{A}\mathbf{x}`.

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -627,7 +627,7 @@ class AVOLinearModelling(LinearOperator):
                 + self.spatdims
             )
         y = self.ncp.sum(self.G * x[:, :, self.ncp.newaxis], axis=1)
-        return y
+        return y.ravel()
 
     def _rmatvec(self, x):
         if self.spatdims is None:
@@ -641,4 +641,4 @@ class AVOLinearModelling(LinearOperator):
                 + self.spatdims
             )
         y = self.ncp.sum(self.G * x[:, self.ncp.newaxis], axis=2)
-        return y
+        return y.ravel()

--- a/pylops/basicoperators/Symmetrize.py
+++ b/pylops/basicoperators/Symmetrize.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_tuple
+from pylops.utils._internal import _value_or_list_like_to_tuple, reshape_flatten
 from pylops.utils.backend import get_array_module
 
 
@@ -72,24 +72,22 @@ class Symmetrize(LinearOperator):
         self.dtype = np.dtype(dtype)
         self.explicit = False
 
+    @reshape_flatten()
     def _matvec(self, x):
         ncp = get_array_module(x)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
-        x = ncp.reshape(x, self.dims)
         x = ncp.swapaxes(x, self.axis, -1)
         y = ncp.swapaxes(y, self.axis, -1)
         y[..., self.nsym - 1 :] = x
         y[..., : self.nsym - 1] = x[..., -1:0:-1]
         y = ncp.swapaxes(y, -1, self.axis)
-        y = y.ravel()
         return y
 
+    @reshape_flatten(forward=False)
     def _rmatvec(self, x):
         ncp = get_array_module(x)
-        x = ncp.reshape(x, self.dimsd)
         x = ncp.swapaxes(x, self.axis, -1)
         y = x[..., self.nsym - 1 :].copy()
         y[..., 1:] += x[..., self.nsym - 2 :: -1]
         y = ncp.swapaxes(y, -1, self.axis)
-        y = y.ravel()
         return y


### PR DESCRIPTION
Follow-up to #348.

This draft PR implements a basic support for non-flat vector, in hopes of spurring further discussion on design choices for this feature.

The key part of the implementation relies in [`LinearOperator.dot`](https://github.com/cako/pylops/blob/9ecd38010c7a2c7a9b8a0a230f563ed225451e4d/pylops/LinearOperator.py#L233) identifying whether `dims` and `dimsd` are present. If this is true, it flattens the array and passes it onto `LinearOperator.matvec`. Upon the return of a (flattened) vector, it then reshapes to `dimsd` any array that came in as a `dims`-shaped operator. In this way, matrix-matrix multiplications remain unchanged and do no support ndarrays.

An example of expected behavior using the Symmetrize operator can be found in [FlattenDims.ipynb](https://github.com/cako/pylops_notebooks/blob/master/developement/FlattenDims.ipynb), summarized below:

|     dims   |    dimsd   | expected dimsd | correct? |
--------------|--------------|----------------------|-------------|
|   (20, 20) |   (30, 20) |     (30, 20)   | ✓|
|     (400,) |    error   |       error    | ✓|
|(2, 10, 20) |    error   |       error    | ✓|
|    (2, 10) |    (3, 10) |      (3, 10)   | ✓|
| (2, 10, 1) |    error   |       error    | ✓|
|      (20,) |      (30,) |        (30,)   | ✓|
|    (20, 1) |    (30, 1) |      (30, 1)   | ✓|

There is an argument for using matmat for `(2, 10, X)` instead of erroring, but for the sake of simplicity this was not implemented.

In addition to the changed to `LinearOperator`, I am also providing a decorator to simplify the reshape/flatten pattern, exemplified in this PR by Symmetrize:
 https://github.com/PyLops/pylops/blob/9ecd38010c7a2c7a9b8a0a230f563ed225451e4d/pylops/basicoperators/Symmetrize.py#L75-L93

### Next steps
If we want to proceed with this, there are a few things to sort out. First, we need to decide which shapes are accepted, and which are not. The above table is only a suggestion.

Once that is defined, we need to make dims/dimsd "first-class" attributes which get passed onto transpose/adjoint, multiplications, etc.

