### PR TITLE
fix: flake8 warnings and errors

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -19,6 +19,7 @@ if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import _ProductLinearOperator
 else:
     from scipy.sparse.linalg._interface import _ProductLinearOperator
+
 from pylops.optimization.solver import cgls
 from pylops.utils.backend import get_array_module, get_module, get_sparse_eye
 from pylops.utils.estimators import trace_hutchinson, trace_hutchpp, trace_nahutchpp

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -47,7 +47,6 @@ utils
 
 from .LinearOperator import LinearOperator
 from .basicoperators import *
-
 from . import (
     avo,
     basicoperators,

--- a/pylops/avo/__init__.py
+++ b/pylops/avo/__init__.py
@@ -23,7 +23,6 @@ and a list of applications:
 from .poststack import *
 from .prestack import *
 
-
 __all__ = [
     "AVOLinearModelling",
     "PoststackLinearModelling",

--- a/pylops/avo/poststack.py
+++ b/pylops/avo/poststack.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.sparse.linalg import lsqr
 
 from pylops import FirstDerivative, Laplacian, MatrixMult, SecondDerivative
-from pylops.LinearOperator import aslinearoperator
 from pylops.optimization.leastsquares import RegularizedInversion
 from pylops.optimization.solver import cgls
 from pylops.optimization.sparsity import SplitBregman

--- a/pylops/basicoperators/Diagonal.py
+++ b/pylops/basicoperators/Diagonal.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator

--- a/pylops/basicoperators/FirstDerivative.py
+++ b/pylops/basicoperators/FirstDerivative.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 

--- a/pylops/basicoperators/Flip.py
+++ b/pylops/basicoperators/Flip.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator

--- a/pylops/basicoperators/Gradient.py
+++ b/pylops/basicoperators/Gradient.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from pylops.basicoperators import FirstDerivative, VStack
 from pylops.utils._internal import _value_or_list_like_to_tuple
 

--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -1,6 +1,3 @@
-import warnings
-
-import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops.basicoperators import SecondDerivative

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import numpy.ma as np_ma
 from numpy.core.multiarray import normalize_axis_index

--- a/pylops/basicoperators/Roll.py
+++ b/pylops/basicoperators/Roll.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 

--- a/pylops/basicoperators/Smoothing1D.py
+++ b/pylops/basicoperators/Smoothing1D.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops.signalprocessing import Convolve1D

--- a/pylops/basicoperators/Smoothing2D.py
+++ b/pylops/basicoperators/Smoothing2D.py
@@ -1,7 +1,4 @@
-import warnings
-
 import numpy as np
-from numpy.core.multiarray import normalize_axis_index
 
 from pylops.signalprocessing import Convolve2D
 

--- a/pylops/basicoperators/Sum.py
+++ b/pylops/basicoperators/Sum.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -56,7 +56,6 @@ from .Transpose import *
 from .Roll import *
 from .Pad import *
 from .Sum import *
-
 from .VStack import *
 from .HStack import *
 from .Block import *
@@ -65,10 +64,8 @@ from .Kronecker import *
 from .Real import *
 from .Imag import *
 from .Conj import *
-
 from .Smoothing1D import *
 from .Smoothing2D import *
-
 from .CausalIntegration import *
 from .FirstDerivative import *
 from .SecondDerivative import *

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -828,7 +828,7 @@ def ISTA(
        pp. 1413-1457. 2004.
 
     """
-    if not threshkind in [
+    if threshkind not in [
         "hard",
         "soft",
         "half",
@@ -1128,7 +1128,7 @@ def FISTA(
        Imaging Sciences, vol. 2, pp. 183-202. 2009.
 
     """
-    if not threshkind in [
+    if threshkind not in [
         "hard",
         "soft",
         "half",

--- a/pylops/signalprocessing/Convolve1D.py
+++ b/pylops/signalprocessing/Convolve1D.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops import LinearOperator

--- a/pylops/signalprocessing/Convolve2D.py
+++ b/pylops/signalprocessing/Convolve2D.py
@@ -1,7 +1,3 @@
-import warnings
-
-from numpy.core.multiarray import normalize_axis_index
-
 from pylops.signalprocessing import ConvolveND
 
 

--- a/pylops/signalprocessing/ConvolveND.py
+++ b/pylops/signalprocessing/ConvolveND.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 

--- a/pylops/signalprocessing/DWT.py
+++ b/pylops/signalprocessing/DWT.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from math import ceil, log
 
 import numpy as np

--- a/pylops/signalprocessing/DWT2D.py
+++ b/pylops/signalprocessing/DWT2D.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from math import ceil, log
 
 import numpy as np

--- a/pylops/signalprocessing/Shift.py
+++ b/pylops/signalprocessing/Shift.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from pylops.basicoperators import Diagonal

--- a/pylops/signalprocessing/_ChirpRadon3D.py
+++ b/pylops/signalprocessing/_ChirpRadon3D.py
@@ -4,7 +4,7 @@ from pylops.utils.backend import get_array_module
 
 try:
     import pyfftw
-except:
+except ImportError:
     pyfftw = None
 
 

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -273,7 +273,7 @@ def _describe(Op, Ops, names):
 
 
 def describe(Op):
-    """Describe a PyLops operator
+    r"""Describe a PyLops operator
 
     .. versionadded:: 1.17.0
 

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -16,7 +16,6 @@ from pylops.signalprocessing import (
     Sliding2D,
     Sliding3D,
 )
-from pylops.utils.backend import get_array_module
 from pylops.utils.dottest import dottest as Dottest
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
@@ -203,8 +202,6 @@ def SeismicInterpolation(
           in 3-dimensional case
 
     """
-    ncp = get_array_module(data)
-
     dtype = data.dtype
     ndims = data.ndim
     if ndims == 1 or ndims > 3:


### PR DESCRIPTION
Following #352, but not clo sing it, this PR removes all errors pointed out by the following linting config:
```
[flake8]
ignore = E203, E501, W503, E402
per-file-ignores =
    __init__.py: F401, F403, F405
max-line-length = 88
```

A good follow-up to this PR would be to cl ose #352 by incorporating a linter into the development process somehow. Since that is still under debate, this PR will does note attempt that.