### PR TITLE
Support for NDArray multiplication

### DIFF
--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -14,3 +14,27 @@ should be used as a checklist when converting a piece of code using PyLops from 
   When using `raiseerror=True` it now emits an `AttributeError` instead of a `ValueError`.
 - `dims_fft` in the FFT operators is deprecated in favor of `dimsd`.
 - `dims_d` in `Sum` is deprecated in favor or `dimsd`
+- Multiplication of N-D arrays is now supported. It relies on the ``dims``/``dimsd`` properties which are now available for every operator by default. While the change is mostly backwards compatible, there are some operators (e.g. the ``Bilinear`` transpose/conjugate) which can output reshaped arrays instead of 1d-arrays. To ensure no breakage, you can entirely disable this feature either globally by setting ``pylops.set_ndarray_multiplication(False)``, or locally with the context manager ``pylops.disabled_ndarray_multiplication()``. Both will revert to v1.x behavior. At this time, PyLops sparse solvers do *not* support N-D array multiplication.
+- If you intend to use the new operators with `scipy.sparse.linalg` solvers such as `cg`, make sure you convert them to an N-D-array-enabled function, for example, with
+
+   ```python
+   from pylops.utils.decorators import add_ndarray_support_to_solver
+   cg = add_ndarray_support_to_solver(cg)
+   ```
+
+## Table of supported multiplication shapes
+Suppose that LOp.dims = (5, 10) and LOp.dimsd = (9, 21).
+
+| Reference | x.shape                 | (LOp @ x).shape | Note                                          |
+| --------- | ----------------------- | --------------- | --------------------------------------------- |
+| V0        | (50,)                   | (189,)          | Standard vector multiplication                |
+| V1        | (5, 10)                 | (9, 21)         | "Vector" of size (5, 10)                      |
+| M0        | (50, 1)                 | (189, 1)        | Standard one-column matrix multiplication     |
+| M1        | (5, 10, 1)              | (9, 21, 1)      | "One-column matrix" of "vector" (5, 10)       |
+| M2        | (50, 20)                | (189, 20)       | Standard matrix multiplication                |
+| M3        | (5, 10, 20)             | (9, 21, 20)     | "Matrix" of 20 x (5, 10)                      |
+| M4        | (1000,)                 | error           | Could be reshaped to (50, 20) but is ambigous |
+| X         | any other kind of shape | error           |                                               |
+
+In v1.x, V0, M0 and M2 are the only supported operations. Since v2.0, in addition, V1, M1 and M3 are supported.
+You can disable their support globally by setting ``pylops.set_ndarray_multiplication(False)``, or locally by using the context manager ``pylops.disabled_ndarray_multiplication``.

--- a/docs/source/api/others.rst
+++ b/docs/source/api/others.rst
@@ -17,6 +17,16 @@ Dot-test
 
     dottest
 
+Decorators
+--------
+
+.. currentmodule:: pylops.utils.decorators
+
+.. autosummary::
+   :toctree: generated/
+
+    reshaped
+
 Describe
 --------
 

--- a/examples/plot_bilinear.py
+++ b/examples/plot_bilinear.py
@@ -28,7 +28,7 @@ iava = np.vstack(
 )
 
 Bop = pylops.signalprocessing.Bilinear(iava, (nz, nx))
-y = Bop * x.ravel()
+y = Bop * x
 
 ###############################################################################
 # At this point we try to reconstruct the input signal imposing a smooth

--- a/examples/plot_nmo.py
+++ b/examples/plot_nmo.py
@@ -19,6 +19,7 @@ from scipy.ndimage import gaussian_filter
 
 from pylops import LinearOperator, Spread
 from pylops.utils import dottest
+from pylops.utils.decorators import reshaped
 from pylops.utils.seismicevents import hyperbolic2d, makeaxis
 from pylops.utils.wavelets import ricker
 
@@ -180,7 +181,7 @@ def nmo_forward(data, taxis, haxis, vels_rms):
         h = haxis[ih]
         for it0, (t0, vrms) in enumerate(zip(taxis, vels_rms)):
             # Compute NMO traveltime
-            tx = np.sqrt(t0 ** 2 + (h / vrms) ** 2)
+            tx = np.sqrt(t0**2 + (h / vrms) ** 2)
             it_frac = (tx - ot) / dt  # Fractional index
             it_floor = floor(it_frac)
             it_ceil = it_floor + 1
@@ -245,7 +246,7 @@ def nmo_adjoint(dnmo, taxis, haxis, vels_rms):
         h = haxis[ih]
         for it0, (t0, vrms) in enumerate(zip(taxis, vels_rms)):
             # Compute NMO traveltime
-            tx = np.sqrt(t0 ** 2 + (h / vrms) ** 2)
+            tx = np.sqrt(t0**2 + (h / vrms) ** 2)
             it_frac = (tx - ot) / dt  # Fractional index
             it_floor = floor(it_frac)
             it_ceil = it_floor + 1
@@ -264,30 +265,28 @@ def nmo_adjoint(dnmo, taxis, haxis, vels_rms):
 # Finally, we can create our linear operator. To exemplify the
 # class-based interface we will subclass :py:class:`pylops.LinearOperator` and
 # implement the required methods: ``_matvec`` which will compute the forward and
-# ``_rmatvec`` which will compute the adjoint.
+# ``_rmatvec`` which will compute the adjoint. Note the use of the ``reshaped``
+# decorator which allows us to pass ``x`` directly into our auxiliary function
+# without having to do ``x.reshape(self.dims)`` and to output without having to
+# call ``ravel()``.
 class NMO(LinearOperator):
     def __init__(self, taxis, haxis, vels_rms, dtype=None):
         self.taxis = taxis
         self.haxis = haxis
         self.vels_rms = vels_rms
-        self.dims = (len(haxis), len(taxis))
 
-        # Required LinearOperator attributes
-        self.explicit = False
-        self.shape = (np.prod(self.dims),) * 2
-        argdtypes = np.result_type(taxis.dtype, haxis.dtype, vels_rms.dtype)
-        self.dtype = argdtypes if dtype is None else dtype
-        self.clinear = False
+        dims = (len(haxis), len(taxis))
+        if dtype is None:
+            dtype = np.result_type(taxis.dtype, haxis.dtype, vels_rms.dtype)
+        super().__init__(dims=dims, dimsd=dims, dtype=dtype)
 
+    @reshaped
     def _matvec(self, x):
-        y = nmo_forward(x.reshape(self.dims), self.taxis, self.haxis, self.vels_rms)
-        y = y.ravel()
-        return y
+        return nmo_forward(x, self.taxis, self.haxis, self.vels_rms)
 
+    @reshaped
     def _rmatvec(self, y):
-        x = nmo_adjoint(y.reshape(self.dims), self.taxis, self.haxis, self.vels_rms)
-        x = x.ravel()
-        return x
+        return nmo_adjoint(y, self.taxis, self.haxis, self.vels_rms)
 
 
 ###############################################################################
@@ -296,7 +295,7 @@ class NMO(LinearOperator):
 # and adjoint transforms truly are adjoints of each other.
 
 NMOOp = NMO(t, x, vel_t)
-dottest(NMOOp, *NMOOp.shape, rtol=1e-4)
+dottest(NMOOp, rtol=1e-4)
 
 ###############################################################################
 # NMO using :py:class:`pylops.Spread`
@@ -348,7 +347,7 @@ def create_tables(taxis, haxis, vels_rms):
     for ih, h in enumerate(haxis):
         for it0, (t0, vrms) in enumerate(zip(taxis, vels_rms)):
             # Compute NMO traveltime
-            tx = np.sqrt(t0 ** 2 + (h / vrms) ** 2)
+            tx = np.sqrt(t0**2 + (h / vrms) ** 2)
             it_frac = (tx - ot) / dt
             it_floor = floor(it_frac)
             w = it_frac - it_floor
@@ -364,25 +363,26 @@ nmo_table, nmo_dtable = create_tables(t, x, vel_t)
 
 ###############################################################################
 SpreadNMO = Spread(
-    data.shape,  # "Input" shape: NMO-ed data shape
-    data.shape,  # "Output" shape: original data shape
+    dims=data.shape,  # "Input" shape: NMO-ed data shape
+    dimsd=data.shape,  # "Output" shape: original data shape
     table=nmo_table,  # Table of time indices
     dtable=nmo_dtable,  # Table of weights for linear interpolation
     engine="numba",  # numba or numpy
 ).H  # To perform NMO *correction*, we need the adjoint
-dottest(SpreadNMO, *SpreadNMO.shape, rtol=1e-4)
+dottest(SpreadNMO, rtol=1e-4)
 
 ###############################################################################
 # We see it passes the dot test, but are the results right? Let's find out.
-dnmo_spr = (SpreadNMO @ data.ravel()).reshape(data.shape)
+dnmo_spr = SpreadNMO @ data
 
 start = time()
-SpreadNMO @ data.ravel()
+SpreadNMO @ data
 end = time()
 
 print(f"Ran in {1e6*(end-start):.0f} μs")
-
 ###############################################################################
+# Note that since v2.0, we do not need to pass a flattened array. Consequently,
+# the output will not be flattened, but will have ``SpreadNMO.dimsd`` as shape.
 
 # Plot Data and NMO-corrected data
 fig = plt.figure(figsize=(6.5, 5))

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -66,6 +66,17 @@ class LinearOperator(spLinearOperator):
         .. versionadded:: 1.17.0
 
         Operator is complex-linear. Defaults to ``True``.
+    flattened : :obj:`bool`, optional
+        .. versionadded:: 2.0.0
+
+        Defaults to ``False``. If ``False``, multiplications by N-dimensional arrays
+        are accepted if they have shape ``dims`` or ``(*dims, P)``. For an ``(M, N)``
+        operator, the respective outputs will have shaped ``dimsd`` and
+        ``(*dimsd, P)``.
+
+        When ``True``, the operator only multiplies flattened inputs, that is,
+        arrays with shapes ``(N,)`` or ``(N, P)``. The respective outputs will have
+        shapes ``(M,)`` and ``(M, P)``. This behavior is equivalent to PyLops v1.x.
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -475,15 +475,23 @@ class LinearOperator(spLinearOperator):
             return Op
         else:
             is_dims_shaped = x.shape == self.dims
+            is_dims_shaped_matrix = len(x.shape) > 1 and x.shape[:-1] == self.dims
             if is_dims_shaped:
+                # (dims1, ..., dimsK) => (dims1 * ... * dimsK,) == self.shape
                 x = x.ravel()
+            if is_dims_shaped_matrix:
+                # (dims1, ..., dimsK, P) => (dims1 * ... * dimsK, P)
+                x = x.reshape((-1, x.shape[-1]))
             if x.ndim == 1:
                 y = self.matvec(x)
                 if is_dims_shaped:
                     y = y.reshape(self.dimsd)
                 return y
             elif x.ndim == 2:
-                return self.matmat(x)
+                y = self.matmat(x)
+                if is_dims_shaped_matrix:
+                    y = y.reshape((*self.dimsd, -1))
+                return y
             else:
                 raise ValueError(
                     (

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -474,18 +474,13 @@ class LinearOperator(spLinearOperator):
             self._copy_attributes(Op)
             return Op
         else:
-            dims = getattr(self, "dims", None)
-            dimsd = getattr(self, "dimsd", None)
-
-            reshape_out = False
-            if x.shape == dims and dimsd is not None:
-                reshape_out = True
+            is_dims_shaped = x.shape == self.dims
+            if is_dims_shaped:
                 x = x.ravel()
-
             if x.ndim == 1:
                 y = self.matvec(x)
-                if reshape_out:
-                    y = y.reshape(dimsd)
+                if is_dims_shaped:
+                    y = y.reshape(self.dimsd)
                 return y
             elif x.ndim == 2:
                 return self.matmat(x)

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -494,6 +494,12 @@ class LinearOperator(spLinearOperator):
             self._copy_attributes(Op)
             return Op
         else:
+            if self.flattened and (
+                x.ndim > 2 or (x.ndim == 2 and x.shape[0] != self.shape[1])
+            ):
+                raise ValueError(
+                    "A flattened operator can only be applied 1D vectors or 2D matrices"
+                )
             is_dims_shaped = x.shape == self.dims
             is_dims_shaped_matrix = len(x.shape) > 1 and x.shape[:-1] == self.dims
             if is_dims_shaped:

--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -45,6 +45,7 @@ utils
 
 """
 
+from .config import *
 from .LinearOperator import LinearOperator
 from .basicoperators import *
 from . import (

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -632,7 +632,7 @@ class AVOLinearModelling(LinearOperator):
                 + self.spatdims
             )
         y = self.ncp.sum(self.G * x[:, :, self.ncp.newaxis], axis=1)
-        return y
+        return y.ravel()
 
     def _rmatvec(self, x):
         if self.spatdims is None:
@@ -646,4 +646,4 @@ class AVOLinearModelling(LinearOperator):
                 + self.spatdims
             )
         y = self.ncp.sum(self.G * x[:, self.ncp.newaxis], axis=2)
-        return y
+        return y.ravel()

--- a/pylops/basicoperators/Symmetrize.py
+++ b/pylops/basicoperators/Symmetrize.py
@@ -1,8 +1,9 @@
 import numpy as np
 
 from pylops import LinearOperator
-from pylops.utils._internal import _value_or_list_like_to_tuple, reshape_flatten
+from pylops.utils._internal import _value_or_list_like_to_tuple
 from pylops.utils.backend import get_array_module
+from pylops.utils.decorators import reshaped
 
 
 class Symmetrize(LinearOperator):
@@ -63,33 +64,25 @@ class Symmetrize(LinearOperator):
     """
 
     def __init__(self, dims, axis=-1, dtype="float64", name="S"):
-        self.dims = _value_or_list_like_to_tuple(dims)
+        dims = _value_or_list_like_to_tuple(dims)
         self.axis = axis
-        dimsd = list(self.dims)
-        dimsd[self.axis] = self.dims[self.axis] * 2 - 1
-        self.dimsd = tuple(dimsd)
-        self.nsym = self.dims[self.axis]
+        self.nsym = dims[self.axis]
+        dimsd = list(dims)
+        dimsd[self.axis] = 2 * dims[self.axis] - 1
 
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
+        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
 
-    @reshape_flatten()
+    @reshaped(swapaxis=True)
     def _matvec(self, x):
         ncp = get_array_module(x)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
-        x = ncp.swapaxes(x, self.axis, -1)
-        y = ncp.swapaxes(y, self.axis, -1)
+        y = y.swapaxes(self.axis, -1)
         y[..., self.nsym - 1 :] = x
         y[..., : self.nsym - 1] = x[..., -1:0:-1]
-        y = ncp.swapaxes(y, -1, self.axis)
         return y
 
-    @reshape_flatten(forward=False)
+    @reshaped(swapaxis=True)
     def _rmatvec(self, x):
-        ncp = get_array_module(x)
-        x = ncp.swapaxes(x, self.axis, -1)
         y = x[..., self.nsym - 1 :].copy()
         y[..., 1:] += x[..., self.nsym - 2 :: -1]
-        y = ncp.swapaxes(y, -1, self.axis)
         return y

--- a/pylops/config.py
+++ b/pylops/config.py
@@ -29,7 +29,7 @@ __all__ = [
 
 @dataclass
 class Config:
-    ndarray_multiplication: int = True
+    ndarray_multiplication: bool = True
 
 
 _config = Config()

--- a/pylops/config.py
+++ b/pylops/config.py
@@ -1,0 +1,63 @@
+"""
+Configuration
+=============
+
+The configuration module controls module-level behavior in PyLops.
+
+You can either set behavior globally with getter/setter:
+
+    get_ndarray_multiplication              Check the status of ndarray multiplication (True/False).
+    set_ndarray_multiplication              Enable/disable ndarray multiplication.
+
+or use context managers (with blocks):
+
+    enabled_ndarray_multiplication          Enable ndarray multiplication within context.
+    disabled_ndarray_multiplication         Disable ndarray multiplication within context.
+
+"""
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+__all__ = [
+    "get_ndarray_multiplication",
+    "set_ndarray_multiplication",
+    "enabled_ndarray_multiplication",
+    "disabled_ndarray_multiplication",
+]
+
+
+@dataclass
+class Config:
+    ndarray_multiplication: int = True
+
+
+_config = Config()
+
+
+def get_ndarray_multiplication():
+    return _config.ndarray_multiplication
+
+
+def set_ndarray_multiplication(val):
+    _config.ndarray_multiplication = val
+
+
+@contextmanager
+def enabled_ndarray_multiplication():
+    enabled = get_ndarray_multiplication()
+    set_ndarray_multiplication(True)
+    try:
+        yield enabled
+    finally:
+        set_ndarray_multiplication(enabled)
+
+
+@contextmanager
+def disabled_ndarray_multiplication():
+    enabled = get_ndarray_multiplication()
+    set_ndarray_multiplication(False)
+    try:
+        yield enabled
+    finally:
+        set_ndarray_multiplication(enabled)

--- a/pylops/optimization/leastsquares.py
+++ b/pylops/optimization/leastsquares.py
@@ -108,6 +108,18 @@ def NormalEquationsInversion(
     """
     ncp = get_array_module(data)
 
+    # Ensure compatibility with SciPy functions
+    flattened_store_op = Op.flattened
+    Op.flattened = True
+    flattened_store_regs = []
+    if Regs is not None:
+        for Reg in Regs:
+            flattened_store_regs.append(Reg.flattened)
+            Reg.flattened = True
+    if Weight is not None:
+        flattened_store_w = Weight.flattened
+        Weight.flattened = True
+
     # store adjoint
     OpH = Op.H
 
@@ -160,6 +172,14 @@ def NormalEquationsInversion(
         istop = None
     if x0 is not None:
         xinv = x0 + xinv
+
+    # Restore original flattened
+    Op.flattened = flattened_store_op
+    if Regs is not None:
+        for flattened, Reg in zip(flattened_store_regs, Regs):
+            Reg.flattened = flattened
+    if Weight is not None:
+        Weight.flattened = flattened_store_w
 
     if returninfo:
         return xinv, istop

--- a/pylops/optimization/leastsquares.py
+++ b/pylops/optimization/leastsquares.py
@@ -2,6 +2,7 @@ import numpy as np
 from scipy.sparse.linalg import cg as sp_cg
 from scipy.sparse.linalg import lsqr
 
+from pylops import disabled_ndarray_multiplication
 from pylops.basicoperators import Diagonal, VStack
 from pylops.optimization.solver import cg, cgls
 from pylops.utils.backend import get_array_module
@@ -106,85 +107,66 @@ def NormalEquationsInversion(
     implicitly assumed to be zero.
 
     """
-    ncp = get_array_module(data)
+    with disabled_ndarray_multiplication():
+        ncp = get_array_module(data)
 
-    # Ensure compatibility with SciPy functions
-    flattened_store_op = Op.flattened
-    Op.flattened = True
-    flattened_store_regs = []
-    if Regs is not None:
-        for Reg in Regs:
-            flattened_store_regs.append(Reg.flattened)
-            Reg.flattened = True
-    if Weight is not None:
-        flattened_store_w = Weight.flattened
-        Weight.flattened = True
+        # store adjoint
+        OpH = Op.H
 
-    # store adjoint
-    OpH = Op.H
+        # create dataregs and epsRs if not provided
+        if dataregs is None and Regs is not None:
+            dataregs = [ncp.zeros(int(Reg.shape[0]), dtype=Reg.dtype) for Reg in Regs]
+        if epsRs is None and Regs is not None:
+            epsRs = [1] * len(Regs)
 
-    # create dataregs and epsRs if not provided
-    if dataregs is None and Regs is not None:
-        dataregs = [ncp.zeros(int(Reg.shape[0]), dtype=Reg.dtype) for Reg in Regs]
-    if epsRs is None and Regs is not None:
-        epsRs = [1] * len(Regs)
+        # Normal equations
+        if Weight is not None:
+            y_normal = OpH * Weight * data
+        else:
+            y_normal = OpH * data
+        if Weight is not None:
+            Op_normal = OpH * Weight * Op
+        else:
+            Op_normal = OpH * Op
 
-    # Normal equations
-    if Weight is not None:
-        y_normal = OpH * Weight * data
-    else:
-        y_normal = OpH * data
-    if Weight is not None:
-        Op_normal = OpH * Weight * Op
-    else:
-        Op_normal = OpH * Op
+        # Add regularization terms
+        if epsI > 0:
+            Op_normal += epsI**2 * Diagonal(
+                ncp.ones(int(Op.shape[1]), dtype=Op.dtype), dtype=Op.dtype
+            )
 
-    # Add regularization terms
-    if epsI > 0:
-        Op_normal += epsI ** 2 * Diagonal(
-            ncp.ones(int(Op.shape[1]), dtype=Op.dtype), dtype=Op.dtype
-        )
+        if Regs is not None:
+            for epsR, Reg, datareg in zip(epsRs, Regs, dataregs):
+                RegH = Reg.H
+                y_normal += epsR**2 * RegH * datareg
+                Op_normal += epsR**2 * RegH * Reg
 
-    if Regs is not None:
-        for epsR, Reg, datareg in zip(epsRs, Regs, dataregs):
-            RegH = Reg.H
-            y_normal += epsR ** 2 * RegH * datareg
-            Op_normal += epsR ** 2 * RegH * Reg
+        if NRegs is not None:
+            for epsNR, NReg in zip(epsNRs, NRegs):
+                Op_normal += epsNR**2 * NReg
 
-    if NRegs is not None:
-        for epsNR, NReg in zip(epsNRs, NRegs):
-            Op_normal += epsNR ** 2 * NReg
+        # solver
+        if x0 is not None:
+            y_normal = y_normal - Op_normal * x0
+        if ncp == np:
+            if "atol" not in kwargs_solver:
+                kwargs_solver["atol"] = "legacy"
+            xinv, istop = sp_cg(Op_normal, y_normal, **kwargs_solver)
+        else:
+            xinv = cg(
+                Op_normal,
+                y_normal,
+                ncp.zeros(int(Op_normal.shape[1]), dtype=Op_normal.dtype),
+                **kwargs_solver
+            )[0]
+            istop = None
+        if x0 is not None:
+            xinv = x0 + xinv
 
-    # solver
-    if x0 is not None:
-        y_normal = y_normal - Op_normal * x0
-    if ncp == np:
-        if "atol" not in kwargs_solver:
-            kwargs_solver["atol"] = "legacy"
-        xinv, istop = sp_cg(Op_normal, y_normal, **kwargs_solver)
-    else:
-        xinv = cg(
-            Op_normal,
-            y_normal,
-            ncp.zeros(int(Op_normal.shape[1]), dtype=Op_normal.dtype),
-            **kwargs_solver
-        )[0]
-        istop = None
-    if x0 is not None:
-        xinv = x0 + xinv
-
-    # Restore original flattened
-    Op.flattened = flattened_store_op
-    if Regs is not None:
-        for flattened, Reg in zip(flattened_store_regs, Regs):
-            Reg.flattened = flattened
-    if Weight is not None:
-        Weight.flattened = flattened_store_w
-
-    if returninfo:
-        return xinv, istop
-    else:
-        return xinv
+        if returninfo:
+            return xinv, istop
+        else:
+            return xinv
 
 
 def RegularizedOperator(Op, Regs, epsRs=(1,)):

--- a/pylops/optimization/leastsquares.py
+++ b/pylops/optimization/leastsquares.py
@@ -117,7 +117,7 @@ def NormalEquationsInversion(
 
     # create dataregs and epsRs if not provided
     if dataregs is None and Regs is not None:
-        dataregs = [ncp.zeros(int(Reg.shape[0]), dtype=Reg.dtype) for Reg in Regs]
+        dataregs = [ncp.zeros(Reg.dimsd, dtype=Reg.dtype) for Reg in Regs]
     if epsRs is None and Regs is not None:
         epsRs = [1] * len(Regs)
 
@@ -134,7 +134,7 @@ def NormalEquationsInversion(
     # Add regularization terms
     if epsI > 0:
         Op_normal += epsI**2 * Diagonal(
-            ncp.ones(int(Op.shape[1]), dtype=Op.dtype), dtype=Op.dtype
+            ncp.ones(Op.dims, dtype=Op.dtype), dims=Op.dims, dtype=Op.dtype
         )
 
     if Regs is not None:
@@ -158,7 +158,7 @@ def NormalEquationsInversion(
         xinv = cg(
             Op_normal,
             y_normal,
-            ncp.zeros(int(Op_normal.shape[1]), dtype=Op_normal.dtype),
+            ncp.zeros(Op_normal.dims, dtype=Op_normal.dtype),
             **kwargs_solver
         )[0]
         istop = None

--- a/pylops/optimization/solver.py
+++ b/pylops/optimization/solver.py
@@ -3,9 +3,11 @@ import time
 import numpy as np
 
 from pylops.utils.backend import get_array_module
+from pylops.utils.decorators import add_ndarray_support_to_solver
 
 
-def cg(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
+@add_ndarray_support_to_solver
+def cg(Op, y, x0=None, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
     r"""Conjugate gradient
 
     Solve a square system of equations given an operator ``Op`` and
@@ -104,7 +106,8 @@ def cg(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
     return x, iiter, cost[:iiter]
 
 
-def cgls(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
+@add_ndarray_support_to_solver
+def cgls(Op, y, x0=None, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
     r"""Conjugate gradient least squares
 
     Solve an overdetermined system of equations given an operator ``Op`` and
@@ -179,7 +182,7 @@ def cgls(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
         head1 = "    Itn           x[0]              r1norm          r2norm"
         print(head1)
 
-    damp = damp ** 2
+    damp = damp**2
     if x0 is None:
         x = ncp.zeros(Op.shape[1], dtype=y.dtype)
         s = y.copy()
@@ -242,10 +245,11 @@ def cgls(Op, y, x0, niter=10, damp=0.0, tol=1e-4, show=False, callback=None):
     return x, istop, iiter, r1norm, r2norm, cost[:iiter]
 
 
+@add_ndarray_support_to_solver
 def lsqr(
     Op,
     y,
-    x0,
+    x0=None,
     damp=0.0,
     atol=1e-08,
     btol=1e-08,
@@ -401,7 +405,7 @@ def lsqr(
         ctol = 1.0 / conlim
     anorm = 0
     acond = 0
-    dampsq = damp ** 2
+    dampsq = damp**2
     ddnorm = 0
     res2 = 0
     xnorm = 0
@@ -510,18 +514,18 @@ def lsqr(
         gambar = -cs2 * rho
         rhs = phi - delta * z
         zbar = rhs / gambar
-        xnorm = ncp.sqrt(xxnorm + zbar ** 2)
+        xnorm = ncp.sqrt(xxnorm + zbar**2)
         gamma = np.linalg.norm([gambar, theta])
         cs2 = gambar / gamma
         sn2 = theta / gamma
         z = rhs / gamma
-        xxnorm = xxnorm + z ** 2.0
+        xxnorm = xxnorm + z**2.0
 
         # test for convergence. First, estimate the condition of the matrix
         # Opbar, and the norms of rbar and Opbar'rbar
         acond = anorm * ncp.sqrt(ddnorm)
-        res1 = phibar ** 2
-        res2 = res2 + psi ** 2
+        res1 = phibar**2
+        res2 = res2 + psi**2
         rnorm = ncp.sqrt(res1 + res2)
         arnorm = alfa * abs(tau)
 
@@ -529,7 +533,7 @@ def lsqr(
         # r2norm = sqrt(r1norm^2 + damp^2*||x||^2).
         # Estimate r1norm = sqrt(r2norm^2 - damp^2*||x||^2).
         # Although there is cancellation, it might be accurate enough.
-        r1sq = rnorm ** 2 - dampsq * xxnorm
+        r1sq = rnorm**2 - dampsq * xxnorm
         r1norm = ncp.sqrt(ncp.abs(r1sq))
         cost[itn] = r1norm
         if r1sq < 0:

--- a/pylops/utils/_internal.py
+++ b/pylops/utils/_internal.py
@@ -1,47 +1,4 @@
-from functools import wraps
-
 import numpy as np
-
-
-def reshape_flatten(forward=True):
-    """Decorator for the common reshape/flatten pattern used in many operators.
-
-    Example
-    =======
-    A ``_matvec`` (forward) function can be simplified from
-
-    .. code-block:: python
-
-        def _matvec(self, x):
-            x = np.reshape(x, self.dims)
-            y = do_things_to_reshaped(y)
-            y = y.ravel()
-            return y
-
-    to
-
-    .. code-block:: python
-        @reshape_flatten()
-        def _matvec(self, x):
-            y = do_things_to_reshaped(y)
-            return y
-
-    Similarly, an ``_rmatvec`` (adjoint) function can be simplified with by calling
-    ``reshape_flatten`` with ``forward=False``.
-
-    """
-    inp_dims = "dims" if forward else "dimsd"
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(self, x):
-            x = x.reshape(getattr(self, inp_dims))
-            y = func(self, x)
-            return y.ravel()
-
-        return wrapper
-
-    return decorator
 
 
 def _value_or_list_like_to_array(value_or_list_like, repeat=1):

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -13,16 +13,14 @@ def add_ndarray_support_to_solver(func):
         Solver type function. Its signature must be ``func(A, b, x0=None, **kwargs)``.
         Its output must be a result-type tuple: ``(xinv, ...)``.
     """
-    from pylops import LinearOperator  # handle circular import
 
     @wraps(func)
     def wrapper(A, b, x0=None, **kwargs):  # SciPy-type signature
-        A = A if isinstance(A, LinearOperator) else LinearOperator(A)
         if x0 is not None:
             x0 = x0.ravel()
         with disabled_ndarray_multiplication():
             res = list(func(A, b.ravel(), x0=x0, **kwargs))
-            res[0] = res[0].reshape(A.dims)
+            res[0] = res[0].reshape(getattr(A, "dims", (A.shape[1],)))
         return tuple(res)
 
     return wrapper

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -1,8 +1,6 @@
 from functools import wraps
 from typing import Callable, Optional
 
-import numpy.typing as npt
-
 
 def reshaped(
     func: Optional[Callable] = None,
@@ -61,7 +59,7 @@ def reshaped(
         inp_dims = "dims" if forward else "dimsd"
 
         @wraps(f)
-        def wrapper(self, x: npt.NDArray):
+        def wrapper(self, x):
             x = x.reshape(getattr(self, inp_dims))
             if swapaxis:
                 x = x.swapaxes(self.axis, -1)

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -24,14 +24,14 @@ def reshaped(
         If True, swaps the last axis of the input array of the decorated function with
         ``self.axis``. Only use if the decorated LinearOperator has ``axis`` attribute.
 
-    Example
-    -------
+    Notes
+    -----
     A ``_matvec`` (forward) function can be simplified from
 
     .. code-block:: python
 
         def _matvec(self, x):
-            x = np.reshape(x, self.dims)
+            x = x.reshape(self.dims)
             x = x.swapaxes(self.axis, -1)
             y = do_things_to_reshaped_swapped(y)
             y = y.swapaxes(self.axis, -1)
@@ -41,16 +41,16 @@ def reshaped(
     to
 
     .. code-block:: python
+
         @reshape(swapaxis=True)
         def _matvec(self, x):
             y = do_things_to_reshaped_swapped(y)
             return y
 
-    Notes
-    -----
     When the decorator has no arguments, it can be called without parenthesis, e.g.:
 
     .. code-block:: python
+
         @reshape
         def _matvec(self, x):
             y = do_things_to_reshaped(y)

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -1,0 +1,80 @@
+from ast import Call
+from functools import wraps
+
+import numpy.typing as npt
+
+from typing import Optional, Callable
+
+
+def reshaped(
+    func: Optional[Callable] = None,
+    forward: Optional[bool] = None,
+    swapaxis: Optional[bool] = False,
+) -> Callable:
+    """Decorator for the common reshape/flatten pattern used in many operators.
+
+    Parameters
+    ----------
+    func : :obj:`callable`, optional
+        Function to be decorated when no arguments are provided
+    forward : :obj:`bool`, optional
+        Reshape to ``dims`` if True, otherwise to ``dimsd``. If not provided, the decorated
+        function's name will be inspected to infer the mode.
+    swapaxis : :obj:`bool`, optional
+        If True, swaps the last axis of the input array of the decorated function with
+        ``self.axis``. Only use if the decorated LinearOperator has ``axis`` attribute.
+
+    Example
+    -------
+    A ``_matvec`` (forward) function can be simplified from
+
+    .. code-block:: python
+
+        def _matvec(self, x):
+            x = np.reshape(x, self.dims)
+            x = x.swapaxes(self.axis, -1)
+            y = do_things_to_reshaped_swapped(y)
+            y = y.swapaxes(self.axis, -1)
+            y = y.ravel()
+            return y
+
+    to
+
+    .. code-block:: python
+        @reshape(swapaxis=True)
+        def _matvec(self, x):
+            y = do_things_to_reshaped_swapped(y)
+            return y
+
+    Notes
+    -----
+    When the decorator has no arguments, it can be called without parenthesis, e.g.:
+
+    .. code-block:: python
+        @reshape
+        def _matvec(self, x):
+            y = do_things_to_reshaped(y)
+            return y
+
+    """
+
+    def decorator(f: Callable):
+        forward = "rmat" not in f.__name__
+        inp_dims = "dims" if forward else "dimsd"
+
+        @wraps(f)
+        def wrapper(self, x: npt.NDArray):
+            x = x.reshape(getattr(self, inp_dims))
+            if swapaxis:
+                x = x.swapaxes(self.axis, -1)
+            y = f(self, x)
+            if swapaxis:
+                y = y.swapaxes(self.axis, -1)
+            y = y.ravel()
+            return y
+
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    return decorator

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -1,12 +1,7 @@
 from functools import wraps
-from typing import Callable, Optional
 
 
-def reshaped(
-    func: Optional[Callable] = None,
-    forward: Optional[bool] = None,
-    swapaxis: Optional[bool] = False,
-) -> Callable:
+def reshaped(func=None, forward=None, swapaxis=False):
     """Decorator for the common reshape/flatten pattern used in many operators.
 
     Parameters
@@ -54,7 +49,7 @@ def reshaped(
 
     """
 
-    def decorator(f: Callable):
+    def decorator(f):
         forward = "rmat" not in f.__name__
         inp_dims = "dims" if forward else "dimsd"
 

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -1,9 +1,7 @@
-from ast import Call
 from functools import wraps
+from typing import Callable, Optional
 
 import numpy.typing as npt
-
-from typing import Optional, Callable
 
 
 def reshaped(

--- a/pytests/test_leastsquares.py
+++ b/pytests/test_leastsquares.py
@@ -2,7 +2,14 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from pylops.basicoperators import Diagonal, HStack, Identity, MatrixMult, Smoothing1D
+from pylops.basicoperators import (
+    Diagonal,
+    HStack,
+    Identity,
+    MatrixMult,
+    Smoothing1D,
+    Symmetrize,
+)
 from pylops.optimization.leastsquares import (
     NormalEquationsInversion,
     PreconditionedInversion,
@@ -274,26 +281,45 @@ def test_skinnyregularization(par):
     x = np.arange(par["nx"] - 1)
     y = Dop * x
 
-    xinv = NormalEquationsInversion(
-        Dop,
-        [
-            Regop,
-        ],
-        y,
-        epsRs=[
-            1e-4,
-        ],
-    )
+    xinv = NormalEquationsInversion(Dop, [Regop], y, epsRs=[1e-4])
     assert_array_almost_equal(x, xinv, decimal=2)
 
-    xinv = RegularizedInversion(
-        Dop,
-        [
-            Regop,
-        ],
-        y,
-        epsRs=[
-            1e-4,
-        ],
-    )
+    xinv = RegularizedInversion(Dop, [Regop], y, epsRs=[1e-4])
     assert_array_almost_equal(x, xinv, decimal=2)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par4j)]
+)
+def test_NormalEquationsInversion_ndarray(par):
+    """Solve inversion with a skinny regularization (rows are smaller than
+    the number of elements in the model vector)
+    """
+    np.random.seed(10)
+    x = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"]) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+    Dop = Symmetrize(x.shape, axis=-1, dtype=par["dtype"])
+    assert x.shape == Dop.dims
+
+    y = Dop * x
+    assert y.shape == Dop.dimsd
+
+    xinv = NormalEquationsInversion(
+        Dop, [], y, epsI=0, epsRs=[0], returninfo=False, **dict(maxiter=200, tol=1e-10)
+    )
+    assert xinv.shape == Dop.dims
+
+    assert_array_almost_equal(x, xinv, decimal=3)
+    xinv = NormalEquationsInversion(
+        Dop,
+        [],
+        y,
+        epsI=0,
+        epsRs=[0],
+        x0=np.zeros_like(x),
+        returninfo=False,
+        **dict(maxiter=200, tol=1e-10)
+    )
+    assert xinv.shape == Dop.dims
+    assert_array_almost_equal(x, xinv, decimal=3)

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
+import pylops
 from pylops import LinearOperator
 from pylops.basicoperators import (
     Diagonal,
@@ -42,7 +43,7 @@ def test_overloads(par):
     # *
     assert isinstance(Dop * Dop, LinearOperator)
     # **
-    assert isinstance(Dop ** 2, LinearOperator)
+    assert isinstance(Dop**2, LinearOperator)
 
 
 @pytest.mark.parametrize("par", [(par1), (par1j)])
@@ -275,8 +276,8 @@ def test_copy_dims_dimsd(par):
     assert (S @ Dx).dims == dims
     assert (S @ Dx).dimsd == dimsd_sym
     # **
-    assert (Dx ** 3).dims == dims
-    assert (Dx ** 3).dimsd == dimsd
+    assert (Dx**3).dims == dims
+    assert (Dx**3).dimsd == dimsd
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
@@ -305,8 +306,8 @@ def test_non_flattened_arrays(par):
     assert_array_equal(Y_S, S @ D @ X_nd)
     assert_array_equal(Y_S, (S @ D @ X_1d).reshape((*S.dimsd, -1)))
 
-    D.flattened = True
-    with pytest.raises(ValueError):
-        D @ x_nd
-    with pytest.raises(ValueError):
-        D @ X_nd
+    with pylops.disabled_ndarray_multiplication():
+        with pytest.raises(ValueError):
+            D @ x_nd
+        with pytest.raises(ValueError):
+            D @ X_nd

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -306,5 +306,7 @@ def test_non_flattened_arrays(par):
     assert_array_equal(Y_S, (S @ D @ X_1d).reshape((*S.dimsd, -1)))
 
     D.flattened = True
-    assert_array_equal(D @ x_1d, D @ x_nd)
-    assert_array_equal(S @ D @ x_1d, S @ D @ x_nd)
+    with pytest.raises(ValueError):
+        D @ x_nd
+    with pytest.raises(ValueError):
+        D @ X_nd

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -304,3 +304,7 @@ def test_non_flattened_arrays(par):
     assert_array_equal(Y_D, (D @ X_1d).reshape((*D.dimsd, -1)))
     assert_array_equal(Y_S, S @ D @ X_nd)
     assert_array_equal(Y_S, (S @ D @ X_1d).reshape((*S.dimsd, -1)))
+
+    D.flattened = True
+    assert_array_equal(D @ x_1d, D @ x_nd)
+    assert_array_equal(S @ D @ x_1d, S @ D @ x_nd)

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -93,6 +93,35 @@ def test_cg(par):
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
 )
+def test_cg_ndarray(par):
+    """CG with linear operator"""
+    np.random.seed(10)
+
+    dims = dimsd = (par["nx"], par["ny"])
+    x = np.ones(dims) + par["imag"] * np.ones(dims)
+
+    A = np.random.normal(0, 10, (x.size, x.size)) + par["imag"] * np.random.normal(
+        0, 10, (x.size, x.size)
+    )
+    A = np.conj(A).T @ A  # to ensure definite positive matrix
+    Aop = MatrixMult(A, dtype=par["dtype"])
+    Aop.dims = dims
+    Aop.dimsd = dimsd
+
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, dims) + par["imag"] * np.random.normal(0, 10, dims)
+    else:
+        x0 = None
+
+    y = Aop * x
+    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=1e-5, show=True)[0]
+    assert xinv.shape == x.shape
+    assert_array_almost_equal(x, xinv, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
 def test_cgls(par):
     """CGLS with linear operator"""
     np.random.seed(10)


### PR DESCRIPTION
This PR takes over from #353 in introducing valid multiplication by ND-arrays without the need for reshaping
The current version works like this:

1. Every LOp has `dims` and `dimsd`. They are arbitrary tuples which must be compatible with LOp.shape.
2. Suppose that LOp.dims = (5, 10) and LOp.dimsd = (9, 10). The following shapes are obtained on LOp @ x

   |    | Reference   | x.shape                 | (LOp @ x).shape                           | Note                                             |
   |----|-------------|-------------------------|-------------------------------------------|--------------------------------------------------|
   | V0 | (50,)       | (90,)                   | Standard vector multiplication            |                                                  |
   | V1 | (5, 10)     | (9, 10)                 | "Vector" of size (5, 10)                  |                                                  |
   | M0 | (50, 1)     | (90, 1)                 | Standard one-column matrix multiplication |                                                  |
   | M1 | (5, 10, 1)  | (9, 10, 1)              | "One-column matrix" of "vector" (5, 10)   |                                                  |
   | M2 | (50, 20)    | (90, 20)                | Standard matrix multiplication            |                                                  |
   | M3 | (5, 10, 20) | (9, 10, 20)             | "Matrix" of 20 x (5, 10)                  |                                                  |
   |    |             | (1000,)                 | error                                     | Could be reshaped to (50, 20) but is ambigous |
   |    |             | any other kind of shape | error                                     |                                                  |
3. SciPy solvers will struggle with V1, M1 and M3. These cases can be coerced to error if LOp.flattened is set to True. Any operator with flattened = True will have legacy behavior. I'm happy to hear about other ways on how we can do this.

This PR also provides a `reshape`` decorator. It relies primarily on the name of the function being decorated to find out which dimensions to reshape by, and also includes an optional swapaxis call. See the new Symmetrize operator for examples. 

