### PR TITLE
bugfix: import pylops _SumLinearOperator in describe

### DIFF
--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -11,20 +11,18 @@ if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
     from scipy.sparse.linalg.interface import (
         _AdjointLinearOperator,
         _ProductLinearOperator,
-        _SumLinearOperator,
         _TransposedLinearOperator,
     )
 else:
     from scipy.sparse.linalg._interface import (
         _AdjointLinearOperator,
         _ProductLinearOperator,
-        _SumLinearOperator,
         _TransposedLinearOperator,
     )
 
 from pylops import LinearOperator
 from pylops.basicoperators import BlockDiag, HStack, VStack
-from pylops.LinearOperator import _ScaledLinearOperator
+from pylops.LinearOperator import _ScaledLinearOperator, _SumLinearOperator
 
 try:
     from sympy import BlockDiagMatrix, BlockMatrix, MatrixSymbol


### PR DESCRIPTION
After introducing _SumLinearOperator in LinearOperator instead of using scipy's one (https://github.com/PyLops/pylops/commit/5c1b5cc7c6601a2e70ab647079785928d49f08a6), the describe mehtod should import this class instead of the one from scipy.