### PR TITLE
Refactor operators using super and reshaped

### DIFF
--- a/pylops/basicoperators/BlockDiag.py
+++ b/pylops/basicoperators/BlockDiag.py
@@ -114,13 +114,10 @@ class BlockDiag(LinearOperator):
         self.pool = None
         if self.nproc > 1:
             self.pool = mp.Pool(processes=nproc)
-        self.shape = (self.nops, self.mops)
-        if dtype is None:
-            self.dtype = _get_dtype(ops)
-        else:
-            self.dtype = np.dtype(dtype)
-        self.explicit = False
-        self.clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+
+        dtype = _get_dtype(ops) if dtype is None else np.dtype(dtype)
+        clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+        super().__init__(dtype=dtype, shape=(self.nops, self.mops), clinear=clinear)
 
     @property
     def nproc(self):

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_list_like_to_tuple
-from pylops.utils.backend import get_array_module
 
 
 class Conj(LinearOperator):

--- a/pylops/basicoperators/Conj.py
+++ b/pylops/basicoperators/Conj.py
@@ -46,16 +46,13 @@ class Conj(LinearOperator):
     """
 
     def __init__(self, dims, dtype="complex128", name="C"):
-        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
-
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=False, name=name)
+        dims = _value_or_list_like_to_tuple(dims)
+        super().__init__(
+            dtype=np.dtype(dtype), dims=dims, dimsd=dims, clinear=False, name=name
+        )
 
     def _matvec(self, x):
-        ncp = get_array_module(x)
-        return ncp.conj(x)
+        return x.conj()
 
     def _rmatvec(self, x):
-        ncp = get_array_module(x)
-        return ncp.conj(x)
+        return x.conj()

--- a/pylops/basicoperators/Flip.py
+++ b/pylops/basicoperators/Flip.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_list_like_to_tuple
+from pylops.utils.decorators import reshaped
 
 
 class Flip(LinearOperator):
@@ -48,17 +49,13 @@ class Flip(LinearOperator):
     """
 
     def __init__(self, dims, axis=-1, dtype="float64", name="F"):
-        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
+        dims = _value_or_list_like_to_tuple(dims)
+        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dims, name=name)
         self.axis = axis
 
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
-
+    @reshaped(swapaxis=True)
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
-        y = np.flip(x, axis=self.axis)
-        y = y.ravel()
+        y = np.flip(x, axis=-1)
         return y
 
     def _rmatvec(self, x):

--- a/pylops/basicoperators/FunctionOperator.py
+++ b/pylops/basicoperators/FunctionOperator.py
@@ -65,32 +65,31 @@ class FunctionOperator(LinearOperator):
     """
 
     def __init__(self, f, *args, **kwargs):
-        try:
-            self.dtype = kwargs["dtype"]
-        except KeyError:
-            self.dtype = "float64"
-        super().__init__(explicit=False, clinear=True, name=kwargs.get("name", "F"))
-        super().__init__()
-
-        self.f = f
-
         # call is FunctionOperator(f, n)
         if len(args) == 1:
-            self.shape = (args[0], args[0])
-            self.fc = None
+            shape = (args[0], args[0])
+            fc = None
         elif len(args) == 2:
             # call is FunctionOperator(f, n, m)
             if isinstance(args[0], Integral):
-                self.shape = (args[0], args[1])
-                self.fc = None
+                shape = (args[0], args[1])
+                fc = None
             # call is FunctionOperator(f, fc, n)
             else:
-                self.fc = args[0]
-                self.shape = (args[1], args[1])
+                fc = args[0]
+                shape = (args[1], args[1])
         # call is FunctionOperator(f, fc, n, m)
         elif len(args) == 3:
-            self.fc = args[0]
-            self.shape = args[1:3]
+            fc = args[0]
+            shape = args[1:3]
+
+        super().__init__(
+            dtype=kwargs.get("dtype", "float64"),
+            shape=shape,
+            name=kwargs.get("name", "F"),
+        )
+        self.f = f
+        self.fc = fc
 
     def _matvec(self, x):
         return self.f(x)
@@ -98,5 +97,4 @@ class FunctionOperator(LinearOperator):
     def _rmatvec(self, x):
         if self.fc is None:
             raise NotImplementedError("Adjoint not implemented")
-        else:
-            return self.fc(x)
+        return self.fc(x)

--- a/pylops/basicoperators/HStack.py
+++ b/pylops/basicoperators/HStack.py
@@ -113,13 +113,10 @@ class HStack(LinearOperator):
         self.pool = None
         if self.nproc > 1:
             self.pool = mp.Pool(processes=nproc)
-        self.shape = (self.nops, self.mops)
-        if dtype is None:
-            self.dtype = _get_dtype(self.ops)
-        else:
-            self.dtype = np.dtype(dtype)
-        self.explicit = False
-        self.clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+
+        dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
+        clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+        super().__init__(dtype=dtype, shape=(self.nops, self.mops), clinear=clinear)
 
     @property
     def nproc(self):

--- a/pylops/basicoperators/Identity.py
+++ b/pylops/basicoperators/Identity.py
@@ -81,10 +81,8 @@ class Identity(LinearOperator):
 
     def __init__(self, N, M=None, dtype="float64", inplace=True, name="I"):
         M = N if M is None else M
+        super().__init__(dtype=np.dtype(dtype), shape=(N, M), name=name)
         self.inplace = inplace
-        self.shape = (N, M)
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_list_like_to_tuple
-from pylops.utils.backend import get_array_module
 
 
 class Imag(LinearOperator):

--- a/pylops/basicoperators/Imag.py
+++ b/pylops/basicoperators/Imag.py
@@ -48,17 +48,14 @@ class Imag(LinearOperator):
     """
 
     def __init__(self, dims, dtype="complex128", name="I"):
-        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
-
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
+        dims = _value_or_list_like_to_tuple(dims)
+        super().__init__(
+            dtype=np.dtype(dtype), dims=dims, dimsd=dims, clinear=False, name=name
+        )
         self.rdtype = np.real(np.ones(1, self.dtype)).dtype
-        super().__init__(explicit=False, clinear=False, name=name)
 
     def _matvec(self, x):
-        ncp = get_array_module(x)
-        return ncp.imag(x).astype(self.rdtype)
+        return x.imag.astype(self.rdtype)
 
     def _rmatvec(self, x):
-        ncp = get_array_module(x)
-        return (0 + 1j * ncp.real(x)).astype(self.dtype)
+        return (0 + 1j * x.real).astype(self.dtype)

--- a/pylops/basicoperators/Kronecker.py
+++ b/pylops/basicoperators/Kronecker.py
@@ -64,12 +64,11 @@ class Kronecker(LinearOperator):
         self.Op2 = Op2
         self.Op1H = self.Op1.H
         self.Op2H = self.Op2.H
-        self.shape = (
+        shape = (
             self.Op1.shape[0] * self.Op2.shape[0],
             self.Op1.shape[1] * self.Op2.shape[1],
         )
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
+        super().__init__(dtype=np.dtype(dtype), shape=shape, name=name)
 
     def _matvec(self, x):
         x = x.reshape(self.Op1.shape[1], self.Op2.shape[1])

--- a/pylops/basicoperators/MatrixMult.py
+++ b/pylops/basicoperators/MatrixMult.py
@@ -56,30 +56,28 @@ class MatrixMult(LinearOperator):
         else:
             self.complex = np.iscomplexobj(A.data)
         if otherdims is None:
-            self.dims, self.dimsd = (A.shape[1],), (A.shape[0],)
+            dims, dimsd = (A.shape[1],), (A.shape[0],)
             self.reshape = False
-            self.shape = A.shape
             explicit = True
         else:
             otherdims = _value_or_list_like_to_array(otherdims)
             self.otherdims = np.array(otherdims, dtype=int)
-            self.dims, self.dimsd = np.insert(
-                self.otherdims, 0, self.A.shape[1]
-            ), np.insert(self.otherdims, 0, self.A.shape[0])
+            dims, dimsd = np.insert(self.otherdims, 0, self.A.shape[1]), np.insert(
+                self.otherdims, 0, self.A.shape[0]
+            )
             self.dimsflatten, self.dimsdflatten = np.insert(
                 [np.prod(self.otherdims)], 0, self.A.shape[1]
             ), np.insert([np.prod(self.otherdims)], 0, self.A.shape[0])
             self.reshape = True
-            self.shape = (np.prod(self.dimsd), np.prod(self.dims))
             explicit = False
-        self.dtype = np.dtype(dtype)
+
         # Check dtype for correctness (upcast to complex when A is complex)
-        if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=self.dtype)):
-            self.dtype = A.dtype
-            logging.warning(
-                "Matrix A is a complex object, dtype cast to %s" % self.dtype
-            )
-        super().__init__(explicit=explicit, clinear=True, name=name)
+        if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=dtype)):
+            dtype = A.dtype
+            logging.warning("Matrix A is a complex object, dtype cast to %s" % dtype)
+        super().__init__(
+            dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, explicit=explicit, name=name
+        )
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/basicoperators/MemoizeOperator.py
+++ b/pylops/basicoperators/MemoizeOperator.py
@@ -30,9 +30,7 @@ class MemoizeOperator(LinearOperator):
     """
 
     def __init__(self, Op, max_neval=10):
-        super().__init__(
-            Op=Op, explicit=False, clinear=None, name=getattr(Op, "name", None)
-        )
+        super().__init__(Op=Op)
 
         self.max_neval = max_neval
         self.store = []  # Store a list of Tuples (x, y)

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_list_like_to_tuple
-from pylops.utils.backend import get_array_module
 
 
 class Real(LinearOperator):

--- a/pylops/basicoperators/Real.py
+++ b/pylops/basicoperators/Real.py
@@ -48,17 +48,14 @@ class Real(LinearOperator):
     """
 
     def __init__(self, dims, dtype="complex128", name="R"):
-        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
-
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
+        dims = _value_or_list_like_to_tuple(dims)
+        super().__init__(
+            dtype=np.dtype(dtype), dims=dims, dimsd=dims, clinear=False, name=name
+        )
         self.rdtype = np.real(np.ones(1, self.dtype)).dtype
-        super().__init__(explicit=False, clinear=False, name=name)
 
     def _matvec(self, x):
-        ncp = get_array_module(x)
-        return ncp.real(x).astype(self.rdtype)
+        return x.real.astype(self.rdtype)
 
     def _rmatvec(self, x):
-        ncp = get_array_module(x)
-        return (ncp.real(x) + 0j).astype(self.dtype)
+        return (x.real + 0j).astype(self.dtype)

--- a/pylops/basicoperators/Regression.py
+++ b/pylops/basicoperators/Regression.py
@@ -82,26 +82,25 @@ class Regression(LinearOperator):
     def __init__(self, taxis, order, dtype="float64", name="R"):
         ncp = get_array_module(taxis)
         if not isinstance(taxis, ncp.ndarray):
-            logging.error("t must be numpy.ndarray...")
-            raise TypeError("t must be numpy.ndarray...")
+            logging.error("t must be ndarray...")
+            raise TypeError("t must be ndarray...")
         else:
             self.taxis = taxis
         self.order = order
-        self.shape = (len(self.taxis), self.order + 1)
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
+        shape = (len(self.taxis), self.order + 1)
+        super().__init__(dtype=np.dtype(dtype), shape=shape, name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)
         y = ncp.zeros_like(self.taxis)
         for i in range(self.order + 1):
-            y += x[i] * self.taxis ** i
+            y += x[i] * self.taxis**i
         return y
 
     def _rmatvec(self, x):
         ncp = get_array_module(x)
 
-        return ncp.vstack([ncp.dot(self.taxis ** i, x) for i in range(self.order + 1)])
+        return ncp.vstack([ncp.dot(self.taxis**i, x) for i in range(self.order + 1)])
 
     def apply(self, t, x):
         """Return values along y-axis given certain ``t`` location(s) along

--- a/pylops/basicoperators/Roll.py
+++ b/pylops/basicoperators/Roll.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_list_like_to_tuple
+from pylops.utils.decorators import reshaped
 
 
 class Roll(LinearOperator):
@@ -44,20 +45,15 @@ class Roll(LinearOperator):
     """
 
     def __init__(self, dims, axis=-1, shift=1, dtype="float64", name="R"):
-        self.dims = self.dimsd = _value_or_list_like_to_tuple(dims)
+        dims = _value_or_list_like_to_tuple(dims)
+        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dims, name=name)
         self.axis = axis
         self.shift = shift
 
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
-
+    @reshaped(swapaxis=True)
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
-        y = np.roll(x, shift=self.shift, axis=self.axis)
-        return y.ravel()
+        return np.roll(x, shift=self.shift, axis=-1)
 
+    @reshaped(swapaxis=True)
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dims)
-        y = np.roll(x, shift=-self.shift, axis=self.axis)
-        return y.ravel()
+        return np.roll(x, shift=-self.shift, axis=-1)

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -94,13 +94,8 @@ class SecondDerivative(LinearOperator):
         elif kind == "centered":
             self._matvec = self._matvec_centered
             self._rmatvec = self._rmatvec_centered
-        elif kind == "backward":
-            self._matvec = self._matvec_backward
-            self._rmatvec = self._rmatvec_backward
         else:
-            raise NotImplementedError(
-                "'kind' must be 'forward', 'centered', or 'backward'"
-            )
+            raise NotImplementedError("'kind' must be 'forward' or 'centered'")
 
     @reshaped(swapaxis=True)
     def _matvec_forward(self, x):

--- a/pylops/basicoperators/VStack.py
+++ b/pylops/basicoperators/VStack.py
@@ -113,13 +113,10 @@ class VStack(LinearOperator):
         self.pool = None
         if self.nproc > 1:
             self.pool = mp.Pool(processes=nproc)
-        self.shape = (self.nops, self.mops)
-        if dtype is None:
-            self.dtype = _get_dtype(self.ops)
-        else:
-            self.dtype = np.dtype(dtype)
-        self.explicit = False
-        self.clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+
+        dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
+        clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
+        super().__init__(dtype=dtype, shape=(self.nops, self.mops), clinear=clinear)
 
     @property
     def nproc(self):

--- a/pylops/basicoperators/Zero.py
+++ b/pylops/basicoperators/Zero.py
@@ -50,9 +50,7 @@ class Zero(LinearOperator):
 
     def __init__(self, N, M=None, dtype="float64", name="Z"):
         M = N if M is None else M
-        self.shape = (N, M)
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
+        super().__init__(dtype=np.dtype(dtype), shape=(N, M), name=name)
 
     def _matvec(self, x):
         ncp = get_array_module(x)

--- a/pylops/signalprocessing/DWT2D.py
+++ b/pylops/signalprocessing/DWT2D.py
@@ -85,18 +85,17 @@ class DWT2D(LinearOperator):
             raise ModuleNotFoundError(pywt_message)
         _checkwavelet(wavelet)
 
-        self.dims = tuple(dims)
         # define padding for length to be power of 2
-        ndimpow2 = [max(2 ** ceil(log(self.dims[ax], 2)), 2 ** level) for ax in axes]
-        pad = [(0, 0)] * len(self.dims)
+        ndimpow2 = [max(2 ** ceil(log(dims[ax], 2)), 2**level) for ax in axes]
+        pad = [(0, 0)] * len(dims)
         for i, ax in enumerate(axes):
-            pad[ax] = (0, ndimpow2[i] - self.dims[ax])
-        self.pad = Pad(self.dims, pad)
+            pad[ax] = (0, ndimpow2[i] - dims[ax])
+        self.pad = Pad(dims, pad)
         self.axes = axes
-        dimsd = list(self.dims)
+        dimsd = list(dims)
         for i, ax in enumerate(axes):
             dimsd[ax] = ndimpow2[i]
-        self.dimsd = tuple(dimsd)
+        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
 
         # apply transform once again to find out slices
         _, self.sl = pywt.coeffs_to_array(
@@ -112,10 +111,6 @@ class DWT2D(LinearOperator):
         self.wavelet = wavelet
         self.waveletadj = _adjointwavelet(wavelet)
         self.level = level
-
-        self.shape = (np.prod(self.dimsd), np.prod(self.dims))
-        self.dtype = np.dtype(dtype)
-        super().__init__(explicit=False, clinear=True, name=name)
 
     def _matvec(self, x):
         x = self.pad.matvec(x)

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -5,6 +5,7 @@ import numpy as np
 import scipy.fft
 
 from pylops.signalprocessing._BaseFFTs import _BaseFFT, _FFTNorms
+from pylops.utils.decorators import reshaped
 
 try:
     import pyfftw
@@ -61,8 +62,8 @@ class _FFT_numpy(_BaseFFT):
         elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = 1.0 / self.nfft
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before:
             x = np.fft.ifftshift(x, axes=self.axis)
         if not self.clinear:
@@ -79,12 +80,11 @@ class _FFT_numpy(_BaseFFT):
             y *= self._scale
         if self.fftshift_after:
             y = np.fft.fftshift(y, axes=self.axis)
-        y = y.ravel()
         y = y.astype(self.cdtype)
         return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after:
             x = np.fft.ifftshift(x, axes=self.axis)
         if self.real:
@@ -108,7 +108,6 @@ class _FFT_numpy(_BaseFFT):
             y = np.real(y)
         if self.ifftshift_before:
             y = np.fft.fftshift(y, axes=self.axis)
-        y = y.ravel()
         y = y.astype(self.rdtype)
         return y
 
@@ -153,8 +152,8 @@ class _FFT_scipy(_BaseFFT):
         elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = 1.0 / self.nfft
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before:
             x = scipy.fft.ifftshift(x, axes=self.axis)
         if not self.clinear:
@@ -171,11 +170,10 @@ class _FFT_scipy(_BaseFFT):
             y *= self._scale
         if self.fftshift_after:
             y = scipy.fft.fftshift(y, axes=self.axis)
-        y = y.ravel()
         return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after:
             x = scipy.fft.ifftshift(x, axes=self.axis)
         if self.real:
@@ -199,7 +197,6 @@ class _FFT_scipy(_BaseFFT):
             y = np.real(y)
         if self.ifftshift_before:
             y = scipy.fft.fftshift(y, axes=self.axis)
-        y = y.ravel()
         return y
 
     def __truediv__(self, y):
@@ -299,8 +296,8 @@ class _FFT_fftw(_BaseFFT):
             self.y, self.x, axes=(self.axis,), direction="FFTW_BACKWARD", **kwargs_fftw
         )
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before:
             x = np.fft.ifftshift(x, axes=self.axis)
         if not self.clinear:
@@ -325,10 +322,10 @@ class _FFT_fftw(_BaseFFT):
             y = np.swapaxes(y, self.axis, -1)
         if self.fftshift_after:
             y = np.fft.fftshift(y, axes=self.axis)
-        return y.ravel()
+        return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after:
             x = np.fft.ifftshift(x, axes=self.axis)
 
@@ -361,7 +358,7 @@ class _FFT_fftw(_BaseFFT):
             y = np.fft.fftshift(y, axes=self.axis)
         if not self.clinear:
             y = np.real(y)
-        return y.ravel()
+        return y
 
     def __truediv__(self, y):
         if self.norm is _FFTNorms.ORTHO:

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -5,6 +5,7 @@ import numpy as np
 import scipy.fft
 
 from pylops.signalprocessing._BaseFFTs import _BaseFFTND, _FFTNorms
+from pylops.utils.decorators import reshaped
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
@@ -57,8 +58,8 @@ class _FFT2D_numpy(_BaseFFTND):
         elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = 1.0 / np.prod(self.nffts)
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before.any():
             x = np.fft.ifftshift(x, axes=self.axes[self.ifftshift_before])
         if not self.clinear:
@@ -76,10 +77,10 @@ class _FFT2D_numpy(_BaseFFTND):
         y = y.astype(self.cdtype)
         if self.fftshift_after.any():
             y = np.fft.fftshift(y, axes=self.axes[self.fftshift_after])
-        return y.ravel()
+        return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = np.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -104,7 +105,7 @@ class _FFT2D_numpy(_BaseFFTND):
         y = y.astype(self.rdtype)
         if self.ifftshift_before.any():
             y = np.fft.fftshift(y, axes=self.axes[self.ifftshift_before])
-        return y.ravel()
+        return y
 
     def __truediv__(self, y):
         if self.norm is not _FFTNorms.ORTHO:
@@ -156,8 +157,8 @@ class _FFT2D_scipy(_BaseFFTND):
         elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = np.sqrt(1.0 / np.prod(self.nffts))
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before.any():
             x = scipy.fft.ifftshift(x, axes=self.axes[self.ifftshift_before])
         if not self.clinear:
@@ -174,10 +175,10 @@ class _FFT2D_scipy(_BaseFFTND):
             y *= self._scale
         if self.fftshift_after.any():
             y = scipy.fft.fftshift(y, axes=self.axes[self.fftshift_after])
-        return y.ravel()
+        return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = scipy.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -197,7 +198,7 @@ class _FFT2D_scipy(_BaseFFTND):
             y = np.real(y)
         if self.ifftshift_before.any():
             y = scipy.fft.fftshift(y, axes=self.axes[self.ifftshift_before])
-        return y.ravel()
+        return y
 
     def __truediv__(self, y):
         if self.norm is not _FFTNorms.ORTHO:

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -5,6 +5,7 @@ import numpy as np
 import scipy.fft
 
 from pylops.signalprocessing._BaseFFTs import _BaseFFTND, _FFTNorms
+from pylops.utils.decorators import reshaped
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
@@ -48,8 +49,8 @@ class _FFTND_numpy(_BaseFFTND):
         elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = 1.0 / np.prod(self.nffts)
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before.any():
             x = np.fft.ifftshift(x, axes=self.axes[self.ifftshift_before])
         if not self.clinear:
@@ -67,10 +68,10 @@ class _FFTND_numpy(_BaseFFTND):
         y = y.astype(self.cdtype)
         if self.fftshift_after.any():
             y = np.fft.fftshift(y, axes=self.axes[self.fftshift_after])
-        return y.ravel()
+        return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = np.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -94,7 +95,7 @@ class _FFTND_numpy(_BaseFFTND):
         y = y.astype(self.rdtype)
         if self.ifftshift_before.any():
             y = np.fft.fftshift(y, axes=self.axes[self.ifftshift_before])
-        return y.ravel()
+        return y
 
     def __truediv__(self, y):
         if self.norm is not _FFTNorms.ORTHO:
@@ -137,8 +138,8 @@ class _FFTND_scipy(_BaseFFTND):
         elif self.norm is _FFTNorms.ONE_OVER_N:
             self._scale = 1.0 / np.prod(self.nffts)
 
+    @reshaped
     def _matvec(self, x):
-        x = np.reshape(x, self.dims)
         if self.ifftshift_before.any():
             x = scipy.fft.ifftshift(x, axes=self.axes[self.ifftshift_before])
         if not self.clinear:
@@ -155,10 +156,10 @@ class _FFTND_scipy(_BaseFFTND):
             y *= self._scale
         if self.fftshift_after.any():
             y = scipy.fft.fftshift(y, axes=self.axes[self.fftshift_after])
-        return y.ravel()
+        return y
 
+    @reshaped
     def _rmatvec(self, x):
-        x = np.reshape(x, self.dimsd)
         if self.fftshift_after.any():
             x = scipy.fft.ifftshift(x, axes=self.axes[self.fftshift_after])
         if self.real:
@@ -181,7 +182,7 @@ class _FFTND_scipy(_BaseFFTND):
             y = np.real(y)
         if self.ifftshift_before.any():
             y = scipy.fft.fftshift(y, axes=self.axes[self.ifftshift_before])
-        return y.ravel()
+        return y
 
     def __truediv__(self, y):
         if self.norm is not _FFTNorms.ORTHO:

--- a/pylops/signalprocessing/_BaseFFTs.py
+++ b/pylops/signalprocessing/_BaseFFTs.py
@@ -6,11 +6,7 @@ import numpy as np
 from numpy.core.multiarray import normalize_axis_index
 
 from pylops import LinearOperator
-from pylops.utils._internal import (
-    _raise_on_wrong_dtype,
-    _value_or_list_like_to_array,
-    _value_or_list_like_to_tuple,
-)
+from pylops.utils._internal import _raise_on_wrong_dtype, _value_or_list_like_to_array
 from pylops.utils.backend import get_complex_dtype, get_real_dtype
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -53,7 +53,9 @@ def reshaped(func=None, forward=None, swapaxis=False):
         Function to be decorated when no arguments are provided
     forward : :obj:`bool`, optional
         Reshape to ``dims`` if True, otherwise to ``dimsd``. If not provided, the decorated
-        function's name will be inspected to infer the mode.
+        function's name will be inspected to infer the mode. Any operator having a name
+        with 'rmat' as substring or whose name is 'div' or '__truediv__' will reshape
+        to ``dimsd``.
     swapaxis : :obj:`bool`, optional
         If True, swaps the last axis of the input array of the decorated function with
         ``self.axis``. Only use if the decorated LinearOperator has ``axis`` attribute.
@@ -93,7 +95,11 @@ def reshaped(func=None, forward=None, swapaxis=False):
     """
 
     def decorator(f):
-        forward = "rmat" not in f.__name__
+        forward = (
+            "rmat" not in f.__name__
+            and f.__name__ != "div"
+            and f.__name__ != "__truediv__"
+        )
         inp_dims = "dims" if forward else "dimsd"
 
         @wraps(f)

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -95,12 +95,15 @@ def reshaped(func=None, forward=None, swapaxis=False):
     """
 
     def decorator(f):
-        forward = (
-            "rmat" not in f.__name__
-            and f.__name__ != "div"
-            and f.__name__ != "__truediv__"
-        )
-        inp_dims = "dims" if forward else "dimsd"
+        if forward is None:
+            fwd = (
+                "rmat" not in f.__name__
+                and f.__name__ != "div"
+                and f.__name__ != "__truediv__"
+            )
+        else:
+            fwd = forward
+        inp_dims = "dims" if fwd else "dimsd"
 
         @wraps(f)
         def wrapper(self, x):


### PR DESCRIPTION
## Description

This PR refactors linear operators based on the new pattern of calling `super().__init__` as soon as `dtype`, `dims`, `dimsd`, and other relevant parameters are defined, as introduced in #365. In addition, it also refactors many operators to rely on the `reshaped` decorator, introduced in #367.

Other changes: `Pad` and `DWT` always reshape internally (simplifies the code); `FirstDerivative` and `SecondDerivative` offload registering methods based on `kind` onto a separate method; `ChirpRadon2D`, `ChirpRadon3D` and `Fredholm1` now have `dims` and `dimsd`, allowing them to work with nd-array multiplication.