### PR TITLE
Refractor MDC, MDD and Marchenko

### DIFF
--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -23,8 +23,14 @@ should be used as a checklist when converting a piece of code using PyLops from 
   must now provide the directions along which the operator is applied through `axes`. The default value for `axis` and
   `axes` are chosen to be -1 and (-2, -1), respectively, whereas the default `dir` and `dirs` was 0 and (0, 1), respectively.
   Be careful to check all operators where `dir`, `dirs` and `nodir` was not provided explicitly.
-- `dims_fft` in the FFT operators is deprecated in favor of `dimsd`.
+### Basic
 - `dims_d` in `Sum` is deprecated in favor or `dimsd`
+### Signal processing
+- `dims_fft` in the FFT operators is deprecated in favor of `dimsd`.
+### Wave-equation processing
+- The optional arguments ``fast``, ``transpose``, and ``dtype`` have been deprecated in ``pylops.waveeqprocessing.mdd.MDC``.
+  As previously stated in a warning message, the recommended option ``transpose=True`` is now selected as default.
+  Ensure that the input array ``G`` is organized as follows ``[n_fmax X n_s X n_r]``.
 
 ## Utils
 - `utils.dottest`: Change `tol` into `rtol`. Absolute tolerance is now also supported via the keyword `atol`.

--- a/examples/plot_ista.py
+++ b/examples/plot_ista.py
@@ -2,10 +2,10 @@ r"""
 MP, OMP, ISTA and FISTA
 =======================
 
-This example shows how to use the :py:class:`pylops.optimization.sparsity.OMP`,
-:py:class:`pylops.optimization.sparsity.IRLS`,
-:py:class:`pylops.optimization.sparsity.ISTA`, and
-:py:class:`pylops.optimization.sparsity.FISTA` solvers.
+This example shows how to use the :py:class:`pylops.optimization.sparsity.omp`,
+:py:class:`pylops.optimization.sparsity.irls`,
+:py:class:`pylops.optimization.sparsity.ista`, and
+:py:class:`pylops.optimization.sparsity.fista` solvers.
 
 These solvers can be used when the model to retrieve is supposed to have
 a sparse representation in a certain domain. MP and OMP use a L0 norm and
@@ -90,12 +90,12 @@ plt.tight_layout()
 # from a signal that we assume being composed by a train of spikes convolved
 # with a certain wavelet. We will see how solving such a problem with a
 # least-squares solver such as
-# :py:class:`pylops.optimization.leastsquares.RegularizedInversion` does not
+# :py:class:`pylops.optimization.leastsquares.regularized_inversion` does not
 # produce the expected results (especially in the presence of noisy data),
-# conversely using the :py:class:`pylops.optimization.sparsity.ISTA` and
-# :py:class:`pylops.optimization.sparsity.FISTA` solvers allows us
+# conversely using the :py:class:`pylops.optimization.sparsity.ista` and
+# :py:class:`pylops.optimization.sparsity.fista` solvers allows us
 # to succesfully retrieve the input signal even in the presence of noise.
-# :py:class:`pylops.optimization.sparsity.FISTA` shows faster convergence which
+# :py:class:`pylops.optimization.sparsity.fista` shows faster convergence which
 # is particularly useful for this problem.
 
 nt = 61

--- a/examples/plot_mdc.py
+++ b/examples/plot_mdc.py
@@ -83,8 +83,6 @@ MDCop = pylops.waveeqprocessing.MDC(
     nv=1,
     dt=0.004,
     dr=1.0,
-    transpose=False,
-    dtype="float32",
 )
 
 # Create data

--- a/pylops/signalprocessing/Fredholm1.py
+++ b/pylops/signalprocessing/Fredholm1.py
@@ -30,7 +30,7 @@ class Fredholm1(LinearOperator):
         Use :func:`numpy.matmul` (``True``) or for-loop with :func:`numpy.dot`
         (``False``). As it is not possible to define which approach is more
         performant (this is highly dependent on the size of ``G`` and input
-        arrays as well as the hardware used in the compution), we advise users
+        arrays as well as the hardware used in the computation), we advise users
         to time both methods for their specific problem prior to making a
         choice.
     dtype : :obj:`str`, optional

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import numpy as np
 from scipy.signal import filtfilt
@@ -108,9 +107,6 @@ class Marchenko:
         domain of size :math:`[n_s \times n_r \times n_t (n_{f_\text{max}})]`. If
         provided in time, ``R`` should not be of complex type. Note that the
         reflection response should have already been multiplied by 2.
-    R1 : :obj:`bool`, optional
-        *Deprecated*, will be removed in v2.0.0. Simply kept for
-        back-compatibility with previous implementation
     dt : :obj:`float`, optional
         Sampling of time integration axis
     nt : :obj:`float`, optional
@@ -224,7 +220,6 @@ class Marchenko:
     def __init__(
         self,
         R,
-        R1=None,
         dt=0.004,
         nt=None,
         dr=1.0,
@@ -237,17 +232,6 @@ class Marchenko:
         prescaled=False,
         fftengine="numpy",
     ):
-        warnings.warn(
-            "A new implementation of Marchenko is provided in v1.5.0. "
-            "This currently affects only the inner working of the "
-            "operator, end-users can continue using the operator in "
-            "the same way. Nevertheless, R1 is not required anymore"
-            "even when R is provided in frequency domain. It is "
-            "recommended to start using the operator without the R1 "
-            "input as this behaviour will become default in "
-            "version v2.0.0 and R1 will be removed from the inputs.",
-            FutureWarning,
-        )
         # Save inputs into class
         self.dt = dt
         self.dr = dr

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -19,7 +19,7 @@ def directwave(wav, trav, nt, dt, nfft=None, dist=None, kind="2d", derivative=Tr
     r"""Analytical direct wave in acoustic media
 
     Compute the analytical acoustic 2d or 3d Green's function in frequency
-    domain givena wavelet ``wav``, traveltime curve ``trav`` and distance
+    domain given a wavelet ``wav``, traveltime curve ``trav`` and distance
     ``dist`` (for 3d case only).
 
     Parameters
@@ -301,7 +301,6 @@ class Marchenko:
         rtm=False,
         greens=False,
         dottest=False,
-        fast=None,
         usematmul=False,
         **kwargs_solver
     ):
@@ -379,11 +378,9 @@ class Marchenko:
             twosided=True,
             conj=False,
             fftengine=self.fftengine,
-            transpose=False,
             saveGt=self.saveRt,
             prescaled=self.prescaled,
             usematmul=usematmul,
-            dtype=self.dtype,
         )
         R1op = MDC(
             self.Rtwosided_fft,
@@ -394,11 +391,9 @@ class Marchenko:
             twosided=True,
             conj=True,
             fftengine=self.fftengine,
-            transpose=False,
             saveGt=self.saveRt,
             prescaled=self.prescaled,
             usematmul=usematmul,
-            dtype=self.dtype,
         )
         Rollop = Roll(
             (self.nt2, self.ns),
@@ -590,10 +585,8 @@ class Marchenko:
             twosided=True,
             conj=False,
             fftengine=self.fftengine,
-            transpose=False,
             prescaled=self.prescaled,
             usematmul=usematmul,
-            dtype=self.dtype,
         )
         R1op = MDC(
             self.Rtwosided_fft,
@@ -604,10 +597,8 @@ class Marchenko:
             twosided=True,
             conj=True,
             fftengine=self.fftengine,
-            transpose=False,
             prescaled=self.prescaled,
             usematmul=usematmul,
-            dtype=self.dtype,
         )
         Rollop = Roll(
             (self.nt2, self.ns, nvs),

--- a/pylops/waveeqprocessing/mdd.py
+++ b/pylops/waveeqprocessing/mdd.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 import numpy as np
 from scipy.signal import filtfilt

--- a/pylops/waveeqprocessing/mdd.py
+++ b/pylops/waveeqprocessing/mdd.py
@@ -25,9 +25,6 @@ def _MDC(
     dt=1.0,
     dr=1.0,
     twosided=True,
-    fast=None,
-    dtype=None,
-    transpose=True,
     saveGt=True,
     conj=False,
     prescaled=False,
@@ -36,39 +33,23 @@ def _MDC(
     _FFT=FFT,
     _Fredholm1=Fredholm1,
     args_Identity={},
-    args_Transpose={},
     args_FFT={},
     args_Identity1={},
-    args_Transpose1={},
     args_FFT1={},
     args_Fredholm1={},
 ):
     r"""Multi-dimensional convolution.
 
-    Used to be able to provide operators from different libraries to
+    Used to be able to provide operators from different libraries (e.g., pylops-distributed) to
     MDC. It operates in the same way as public method
-    (PoststackLinearModelling) but has additional input parameters allowing
+    (MDC) but has additional input parameters allowing
     passing a different operator and additional arguments to be passed to such
     operator.
 
     """
-    warnings.warn(
-        "A new implementation of MDC is provided in v1.5.0. This "
-        "currently affects only the inner working of the operator, "
-        "end-users can continue using the operator in the same way. "
-        "Nevertheless, it is now recommended to start using the "
-        "operator with transpose=True, as this behaviour will "
-        "become default in version v2.0.0 and the behaviour with "
-        "transpose=False will be deprecated.",
-        FutureWarning,
-    )
 
     if twosided and nt % 2 == 0:
         raise ValueError("nt must be odd number")
-
-    # transpose G
-    if transpose:
-        G = np.transpose(G, axes=(2, 0, 1))
 
     # find out dtype of G
     dtype = G[0, 0, 0].dtype
@@ -119,20 +100,8 @@ def _MDC(
     F1opH = F1op.H
     I1opH = I1op.H
 
-    # create transpose operator
-    if transpose:
-        dims = [nr, nt] if nv == 1 else [nr, nv, nt]
-        axes = (1, 0) if nv == 1 else (2, 0, 1)
-        Top = _Transpose(dims, axes, dtype=dtype, **args_Transpose)
-
-        dims = [nt, ns] if nv == 1 else [nt, ns, nv]
-        axes = (1, 0) if nv == 1 else (1, 2, 0)
-        TopH = _Transpose(dims, axes, dtype=dtype, **args_Transpose1)
-
     # create MDC operator
     MDCop = F1opH * I1opH * Frop * Iop * Fop
-    if transpose:
-        MDCop = TopH * MDCop * Top
 
     # force dtype to be real (as FFT operators assume real inputs and outputs)
     MDCop.dtype = rdtype
@@ -147,10 +116,7 @@ def MDC(
     dt=1.0,
     dr=1.0,
     twosided=True,
-    fast=None,
-    dtype=None,
     fftengine="numpy",
-    transpose=True,
     saveGt=True,
     conj=False,
     usematmul=False,
@@ -159,29 +125,17 @@ def MDC(
 ):
     r"""Multi-dimensional convolution.
 
-    Apply multi-dimensional convolution between two datasets. If
-    ``transpose=True``, model and data should be provided after flattening
-    2- or 3-dimensional arrays of size :math:`[n_r \;(\times n_{vs}) \times n_t]`
-    and :math:`[n_s \;(\times n_{vs}) \times n_t]` (or :math:`2n_t-1` for
-    ``twosided=True``), respectively. If ``transpose=False``, model and data
-    should be provided after flattening 2- or 3-dimensional arrays of size
-    :math:`[n_t \times n_r \;(\times n_{vs})]` and
+    Apply multi-dimensional convolution between two datasets.
+    Model and data should be provided after flattening 2- or 3-dimensional arrays
+    of size :math:`[n_t \times n_r \;(\times n_{vs})]` and
     :math:`[n_t \times n_s \;(\times n_{vs})]` (or :math:`2n_t-1` for
     ``twosided=True``), respectively.
-
-    .. warning:: A new implementation of MDC is provided in v1.5.0. This
-      currently affects only the inner working of the operator and end-users
-      can use the operator in the same way as they used to do with the previous
-      one. Nevertheless, it is now reccomended to use the operator with
-      ``transpose=False``, as this behaviour will become default in version
-      v2.0.0 and the behaviour with ``transpose=True`` will be deprecated.
 
     Parameters
     ----------
     G : :obj:`numpy.ndarray`
         Multi-dimensional convolution kernel in frequency domain of size
-        :math:`[n_s \times n_r \times n_{f_\text{max}}]` if ``transpose=True``
-        or size :math:`[n_{f_\text{max}} \times n_s \times n_r]` if ``transpose=False``
+        :math:`[n_{f_\text{max}} \times n_s \times n_r]`
     nt : :obj:`int`
         Number of samples along time axis for model and data (note that this
         must be equal to :math:`2n_t-1` when working with ``twosided=True``.
@@ -194,17 +148,8 @@ def MDC(
     twosided : :obj:`bool`, optional
         MDC operator has both negative and positive time (``True``) or
         only positive (``False``)
-    fast : :obj:`bool`, optional
-        *Deprecated*, will be removed in v2.0.0
-    dtype : :obj:`str`, optional
-        *Deprecated*, will be removed in v2.0.0
     fftengine : :obj:`str`, optional
         Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
-    transpose : :obj:`bool`, optional
-        Transpose ``G`` and inputs such that time/frequency is placed in first
-        dimension. This allows back-compatibility with v1.4.0 and older but
-        will be removed in v2.0.0 where time/frequency axis will be required
-        to be in first dimension for efficiency reasons.
     saveGt : :obj:`bool`, optional
         Save ``G`` and ``G.H`` to speed up the computation of adjoint of
         :class:`pylops.signalprocessing.Fredholm1` (``True``) or create
@@ -277,9 +222,6 @@ def MDC(
         dt=dt,
         dr=dr,
         twosided=twosided,
-        fast=fast,
-        dtype=dtype,
-        transpose=transpose,
         saveGt=saveGt,
         conj=conj,
         prescaled=prescaled,
@@ -301,7 +243,6 @@ def MDD(
     causality_precond=False,
     adjoint=False,
     psf=False,
-    dtype="float64",
     dottest=False,
     saveGt=True,
     add_negative=True,
@@ -354,8 +295,6 @@ def MDD(
         Compute and return adjoint(s)
     psf : :obj:`bool`, optional
         Compute and return Point Spread Function (PSF) and its inverse
-    dtype : :obj:`bool`, optional
-        Type of elements in input array.
     dottest : :obj:`bool`, optional
         Apply dot-test
     saveGt : :obj:`bool`, optional
@@ -465,7 +404,6 @@ def MDD(
         dt=dt,
         dr=dr,
         twosided=twosided,
-        transpose=False,
         saveGt=saveGt,
         fftengine=fftengine,
     )
@@ -477,7 +415,6 @@ def MDD(
             dt=dt,
             dr=dr,
             twosided=twosided,
-            transpose=False,
             saveGt=saveGt,
             fftengine=fftengine,
         )

--- a/pytests/test_marchenko.py
+++ b/pytests/test_marchenko.py
@@ -89,7 +89,6 @@ def test_Marchenko_freq(par):
         R1twosided_fft_sc = R1twosided_fft
     MarchenkoWM = Marchenko(
         Rtwosided_fft_sc,
-        R1=R1twosided_fft_sc,
         nt=nt,
         dt=dt,
         dr=dr,
@@ -147,7 +146,7 @@ def test_Marchenko_time_ana(par):
 
     _, _, g_inv_minus, g_inv_plus = MarchenkoWM.apply_onepoint(
         trav,
-        nfft=2 ** 11,
+        nfft=2**11,
         rtm=False,
         greens=True,
         dottest=True,
@@ -170,7 +169,7 @@ def test_Marchenko_timemulti_ana(par):
 
     _, _, g_inv_minus, g_inv_plus = MarchenkoWM.apply_multiplepoints(
         trav_multi,
-        nfft=2 ** 11,
+        nfft=2**11,
         rtm=False,
         greens=True,
         dottest=True,

--- a/pytests/test_waveeqprocessing.py
+++ b/pytests/test_waveeqprocessing.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal
 
 from pylops.utils import dottest
 from pylops.utils.seismicevents import linear2d, linear3d, makeaxis

--- a/pytests/test_waveeqprocessing.py
+++ b/pytests/test_waveeqprocessing.py
@@ -107,74 +107,7 @@ def test_MDC_1virtualsource(par):
     # Define MDC linear operator
     Gwav_fft = np.fft.fft(Gwav, par["nt2"], axis=-1)
     Gwav_fft = Gwav_fft[..., : par["nfmax"]]
-    MDCop = MDC(
-        Gwav_fft,
-        nt=par["nt2"],
-        nv=1,
-        dt=par["dt"],
-        dr=par["dx"],
-        fftengine="fftw",
-        twosided=par["twosided"],
-        dtype="float32",
-    )
-    dottest(MDCop, par["nt2"] * par["ny"], par["nt2"] * par["nx"])
-    # Create data
-    d = MDCop * mwav.ravel()
-    d = d.reshape(par["ny"], par["nt2"])
 
-    # Check that events are at correct time and correct amplitude
-    for it, amp in zip(it0_G, amp_G):
-        ittot = it0_m + it
-        if par["twosided"]:
-            ittot += par["nt"] - 1
-        assert (
-            np.abs(
-                d[par["ny"] // 2, ittot]
-                - np.abs(wav ** 2).sum()
-                * amp_m
-                * amp
-                * par["nx"]
-                * par["dx"]
-                * par["dt"]
-                * np.sqrt(par["nt2"])
-            )
-            < 1e-2
-        )
-
-    # Check that MDC with prescaled=True gives same result
-    MDCpreop = MDC(
-        np.sqrt(par["nt2"]) * par["dt"] * par["dx"] * Gwav_fft,
-        nt=par["nt2"],
-        nv=1,
-        dt=par["dt"],
-        dr=par["dx"],
-        fftengine="fftw",
-        twosided=par["twosided"],
-        prescaled=True,
-        dtype="float32",
-    )
-    dottest(MDCpreop, par["nt2"] * par["ny"], par["nt2"] * par["nx"])
-    dpre = MDCpreop * mwav.ravel()
-    dpre = dpre.reshape(par["ny"], par["nt2"])
-    assert_array_equal(d, dpre)
-
-    # Apply mdd function
-    minv = MDD(
-        Gwav[:, :, par["nt"] - 1 :] if par["twosided"] else Gwav,
-        d[:, par["nt"] - 1 :] if par["twosided"] else d,
-        dt=par["dt"],
-        dr=par["dx"],
-        nfmax=par["nfmax"],
-        twosided=par["twosided"],
-        adjoint=False,
-        psf=False,
-        dtype="complex64",
-        dottest=False,
-        **dict(damp=1e-10, iter_lim=50, show=0)
-    )
-    assert_array_almost_equal(mwav, minv, decimal=2)
-
-    # Same tests for future behaviour (remove tests above in v2.0.0)
     MDCop = MDC(
         Gwav_fft.transpose(2, 0, 1),
         nt=par["nt2"],
@@ -182,8 +115,6 @@ def test_MDC_1virtualsource(par):
         dt=par["dt"],
         dr=par["dx"],
         twosided=par["twosided"],
-        transpose=False,
-        dtype="float32",
     )
     dottest(MDCop, par["nt2"] * par["ny"], par["nt2"] * par["nx"])
     mwav = mwav.T
@@ -197,7 +128,7 @@ def test_MDC_1virtualsource(par):
         assert (
             np.abs(
                 d[ittot, par["ny"] // 2]
-                - np.abs(wav ** 2).sum()
+                - np.abs(wav**2).sum()
                 * amp_m
                 * amp
                 * par["nx"]
@@ -218,7 +149,6 @@ def test_MDC_1virtualsource(par):
         add_negative=True,
         adjoint=False,
         psf=False,
-        dtype="complex64",
         dottest=False,
         **dict(damp=1e-10, iter_lim=50, show=0)
     )
@@ -273,62 +203,12 @@ def test_MDC_Nvirtualsources(par):
     Gwav_fft = Gwav_fft[..., : par["nfmax"]]
 
     MDCop = MDC(
-        Gwav_fft,
-        nt=par["nt2"],
-        nv=par["nx"],
-        dt=par["dt"],
-        dr=par["dx"],
-        twosided=par["twosided"],
-        dtype="float32",
-    )
-    dottest(
-        MDCop, par["nt2"] * par["ny"] * par["nx"], par["nt2"] * par["nx"] * par["nx"]
-    )
-
-    # Create data
-    d = MDCop * mwav.ravel()
-    d = d.reshape(par["ny"], par["nx"], par["nt2"])
-
-    # Check that events are at correct time
-    for it, amp in zip(it0_G, amp_G):
-        ittot = it0_m + it
-        if par["twosided"]:
-            ittot += par["nt"] - 1
-        assert (
-            d[par["ny"] // 2, par["nx"] // 2, ittot]
-            > d[par["ny"] // 2, par["nx"] // 2, ittot - 1]
-        )
-        assert (
-            d[par["ny"] // 2, par["nx"] // 2, ittot]
-            > d[par["ny"] // 2, par["nx"] // 2, ittot + 1]
-        )
-
-    # Apply mdd function
-    minv = MDD(
-        Gwav[:, :, par["nt"] - 1 :] if par["twosided"] else Gwav,
-        d[:, :, par["nt"] - 1 :] if par["twosided"] else d,
-        dt=par["dt"],
-        dr=par["dx"],
-        nfmax=par["nfmax"],
-        twosided=par["twosided"],
-        adjoint=False,
-        psf=False,
-        dtype="complex64",
-        dottest=False,
-        **dict(damp=1e-10, iter_lim=50, show=0)
-    )
-    assert_array_almost_equal(mwav, minv, decimal=2)
-
-    # Same tests for future behaviour (remove tests above in v2.0.0)
-    MDCop = MDC(
         Gwav_fft.transpose(2, 0, 1),
         nt=par["nt2"],
         nv=par["nx"],
         dt=par["dt"],
         dr=par["dx"],
         twosided=par["twosided"],
-        transpose=False,
-        dtype="float32",
     )
     dottest(
         MDCop, par["nt2"] * par["ny"] * par["nx"], par["nt2"] * par["nx"] * par["nx"]
@@ -363,7 +243,6 @@ def test_MDC_Nvirtualsources(par):
         add_negative=True,
         adjoint=False,
         psf=False,
-        dtype="complex64",
         dottest=False,
         **dict(damp=1e-10, iter_lim=50, show=0)
     )

--- a/tutorials/mdd.py
+++ b/tutorials/mdd.py
@@ -74,15 +74,19 @@ Gwav2 = np.concatenate((np.zeros((par["ny"], par["nx"], par["nt"] - 1)), Gwav), 
 
 # Define MDC linear operator
 Gwav_fft = np.fft.rfft(Gwav2, 2 * par["nt"] - 1, axis=-1)
-Gwav_fft = Gwav_fft[..., : par["nfmax"]]
+Gwav_fft = (Gwav_fft[..., : par["nfmax"]]).transpose(2, 0, 1)
 
 MDCop = pylops.waveeqprocessing.MDC(
-    Gwav_fft, nt=2 * par["nt"] - 1, nv=1, dt=0.004, dr=1.0, dtype="float32"
+    Gwav_fft,
+    nt=2 * par["nt"] - 1,
+    nv=1,
+    dt=0.004,
+    dr=1.0,
 )
 
 # Create data
-d = MDCop * m.ravel()
-d = d.reshape(par["ny"], 2 * par["nt"] - 1)
+d = MDCop * m.T.ravel()
+d = d.reshape(2 * par["nt"] - 1, par["ny"]).T
 
 ###############################################################################
 # Let's display what we have so far: operator, input model, and data
@@ -154,7 +158,6 @@ minv, madj, psfinv, psfadj = pylops.waveeqprocessing.MDD(
     add_negative=True,
     adjoint=True,
     psf=True,
-    dtype="complex64",
     dottest=False,
     **dict(damp=1e-4, iter_lim=20, show=0)
 )
@@ -242,7 +245,6 @@ minvprec = pylops.waveeqprocessing.MDD(
     adjoint=False,
     psf=False,
     causality_precond=True,
-    dtype="complex64",
     dottest=False,
     **dict(damp=1e-4, iter_lim=50, show=0)
 )


### PR DESCRIPTION
This PR handles https://github.com/PyLops/pylops/issues/392 by cleaning up the MDC, MDD, and Marchenko operators removing all input parameters that have been deprecated through time and enforcing the behavior of `transpose=False`