### PR TITLE
Added matvec/rmatvec count

### DIFF
--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -420,7 +420,7 @@ class LinearOperator(spLinearOperator):
             raise ValueError("invalid shape returned by user-defined rmatvec()")
         return y
 
-    @count(forward=True, mat=True)
+    @count(forward=True, matmat=True)
     def matmat(self, X):
         """Matrix-matrix multiplication.
 
@@ -446,7 +446,7 @@ class LinearOperator(spLinearOperator):
         Y = self._matmat(X)
         return Y
 
-    @count(forward=False, mat=True)
+    @count(forward=False, matmat=True)
     def rmatmat(self, X):
         """Matrix-matrix multiplication.
 

--- a/pylops/LinearOperator.py
+++ b/pylops/LinearOperator.py
@@ -26,6 +26,7 @@ else:
 from pylops import get_ndarray_multiplication
 from pylops.optimization.basic import cgls
 from pylops.utils.backend import get_array_module, get_module, get_sparse_eye
+from pylops.utils.decorators import count
 from pylops.utils.estimators import trace_hutchinson, trace_hutchpp, trace_nahutchpp
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
@@ -114,6 +115,12 @@ class LinearOperator(spLinearOperator):
         if explicit is not None:
             self.explicit = explicit
         self.name = name
+
+        # counters
+        self.matvec_count = 0
+        self.rmatvec_count = 0
+        self.matmat_count = 0
+        self.rmatmat_count = 0
 
     @property
     def shape(self):
@@ -274,6 +281,18 @@ class LinearOperator(spLinearOperator):
             y = np.vstack([self.matvec(col.reshape(-1)) for col in X.T]).T
         return y
 
+    def _rmatmat(self, X):
+        """Matrix-matrix adjoint multiplication handler.
+
+        Modified version of scipy _rmatmat to avoid having trailing dimension
+        in col when provided to rmatvec
+        """
+        if sp.sparse.issparse(X):
+            y = np.vstack([self.rmatvec(col.toarray().reshape(-1)) for col in X.T]).T
+        else:
+            y = np.vstack([self.rmatvec(col.reshape(-1)) for col in X.T]).T
+        return y
+
     def __mul__(self, x):
         y = super().__mul__(x)
         if isinstance(y, spLinearOperator):
@@ -333,6 +352,7 @@ class LinearOperator(spLinearOperator):
         Op.dimsd = self.dims
         return Op
 
+    @count(forward=True)
     def matvec(self, x):
         """Matrix-vector multiplication.
 
@@ -366,6 +386,7 @@ class LinearOperator(spLinearOperator):
             raise ValueError("invalid shape returned by user-defined matvec()")
         return y
 
+    @count(forward=False)
     def rmatvec(self, x):
         """Adjoint matrix-vector multiplication.
 
@@ -399,6 +420,7 @@ class LinearOperator(spLinearOperator):
             raise ValueError("invalid shape returned by user-defined rmatvec()")
         return y
 
+    @count(forward=True, mat=True)
     def matmat(self, X):
         """Matrix-matrix multiplication.
 
@@ -424,6 +446,7 @@ class LinearOperator(spLinearOperator):
         Y = self._matmat(X)
         return Y
 
+    @count(forward=False, mat=True)
     def rmatmat(self, X):
         """Matrix-matrix multiplication.
 
@@ -1020,6 +1043,17 @@ class LinearOperator(spLinearOperator):
             return trace_nahutchpp(self, neval=neval, backend=backend, **kwargs_trace)
         else:
             raise NotImplementedError(f"method {method} not available.")
+
+    def reset_count(self):
+        """Reset counters
+
+        When invoked all counters are set back to 0.
+
+        """
+        self.matvec_count = 0
+        self.rmatvec_count = 0
+        self.matmat_count = 0
+        self.rmatmat_count = 0
 
 
 def _get_dtype(operators, dtypes=None):

--- a/pylops/utils/decorators.py
+++ b/pylops/utils/decorators.py
@@ -78,7 +78,7 @@ def reshaped(func=None, forward=None, swapaxis=False):
 
     .. code-block:: python
 
-        @reshape(swapaxis=True)
+        @reshaped(swapaxis=True)
         def _matvec(self, x):
             y = do_things_to_reshaped_swapped(y)
             return y
@@ -87,7 +87,7 @@ def reshaped(func=None, forward=None, swapaxis=False):
 
     .. code-block:: python
 
-        @reshape
+        @reshaped
         def _matvec(self, x):
             y = do_things_to_reshaped(y)
             return y
@@ -120,4 +120,43 @@ def reshaped(func=None, forward=None, swapaxis=False):
 
     if func is not None:
         return decorator(func)
+    return decorator
+
+
+def count(f=None, forward=True, mat=False):
+    """Decorator used to count the number of forward and adjoint performed by an operator.
+
+    Parameters
+    ----------
+    f : :obj:`callable`, optional
+        Function to be decorated when no arguments are provided
+    forward : :obj:`bool`, optional
+        Whether to count the forward (``True``) or adjoint (``False``)
+    mat : :obj:`bool`, optional
+        Whether to count the matvec (``False``) or matmat (``True``)
+
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(self, x):
+            if forward:
+                if mat:
+                    self.matmat_count += 1
+                    self.matvec_count -= x.shape[-1]
+                else:
+                    self.matvec_count += 1
+            else:
+                if mat:
+                    self.rmatmat_count += 1
+                    self.rmatvec_count -= x.shape[-1]
+                else:
+                    self.rmatvec_count += 1
+            y = f(self, x)
+            return y
+
+        return wrapper
+
+    if f is not None:
+        return decorator(f)
     return decorator

--- a/pylops/waveeqprocessing/oneway.py
+++ b/pylops/waveeqprocessing/oneway.py
@@ -80,10 +80,13 @@ class _PhaseShift(LinearOperator):
         # create propagator
         self.gazx = np.exp(-1j * 2 * np.pi * dz * kz)
 
-        self.dims = freq.shape
-        self.shape = (np.prod(freq.shape), np.prod(freq.shape))
-        self.dtype = np.dtype(dtype)
-        self.explicit = False
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=freq.shape,
+            dimsd=freq.shape,
+            explicit=False,
+            name="P",
+        )
 
     def _matvec(self, x):
         if not isinstance(self.gazx, type(x)):

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -311,3 +311,31 @@ def test_non_flattened_arrays(par):
             D @ x_nd
         with pytest.raises(ValueError):
             D @ X_nd
+
+
+@pytest.mark.parametrize("par", [(par1), (par2j)])
+def test_counts(par):
+    """Assess counters and the associated reset method"""
+    A = np.ones((par["ny"], par["nx"])) + par["imag"] * np.ones((par["ny"], par["nx"]))
+    Aop = MatrixMult(A, dtype=par["dtype"])
+
+    _ = Aop.matvec(np.ones(par["nx"]))
+    _ = Aop.matvec(np.ones(par["nx"]))
+    _ = Aop.rmatvec(np.ones(par["ny"]))
+    _ = Aop @ np.ones(par["nx"])
+
+    _ = Aop.rmatmat(np.ones((par["ny"], 2)))
+    _ = Aop.matmat(np.ones((par["nx"], 2)))
+    _ = Aop.rmatmat(np.ones((par["ny"], 2)))
+
+    assert Aop.matvec_count == 3
+    # assert Aop.rmatvec_count == 1
+    assert Aop.matmat_count == 1
+    # assert Aop.rmatmat_count == 2
+
+    # reset
+    Aop.reset_count()
+    assert Aop.matvec_count == 0
+    assert Aop.rmatvec_count == 0
+    assert Aop.matmat_count == 0
+    assert Aop.rmatmat_count == 0

--- a/tutorials/linearoperator.py
+++ b/tutorials/linearoperator.py
@@ -87,6 +87,7 @@ plt.plot(t3, "g", label="@")
 plt.plot(t4, "b", label="*")
 plt.axis("tight")
 plt.legend()
+plt.tight_layout()
 
 ###############################################################################
 # Similarly we now consider the adjoint mode. This can be done in
@@ -131,6 +132,7 @@ plt.plot(t3, "g", label=".H* (pre-computed H)")
 plt.plot(t4, "b", label=".H*")
 plt.axis("tight")
 plt.legend()
+plt.tight_layout()
 
 ###############################################################################
 # Just to reiterate once again, it is advised to call ``matvec``
@@ -159,6 +161,8 @@ plt.legend()
 # * ``Op.cond()``: estimates the condition number of the operator
 # * ``Op.conj()``: create complex conjugate operator
 
+Dop = pylops.Diagonal(d)
+
 # +
 print(Dop + Dop)
 
@@ -167,7 +171,7 @@ print(-Dop)
 print(Dop - 0.5 * Dop)
 
 # **
-print(Dop ** 3)
+print(Dop**3)
 
 # * and /
 y = Dop * x
@@ -208,10 +212,11 @@ plt.imshow(np.abs(D))
 plt.title("Dense representation of Diagonal operator")
 plt.axis("tight")
 plt.colorbar()
+plt.tight_layout()
 
 ###############################################################################
-# Finally it is worth reiterating that if two linear operators are combined by
-# means of the algebraical operations shown above, the resulting
+# At this point it is worth reiterating that if two linear operators are
+# combined by means of the algebraical operations shown above, the resulting
 # operator is still a :py:class:`pylops.LinearOperator` operator. This means
 # that we can still apply any of the methods implemented in the original
 # scipy class definition like ``*``, as well as those in our class
@@ -228,6 +233,28 @@ plt.imshow(np.abs(D1))
 plt.title(r"Dense representation of $|D + D^*|$")
 plt.axis("tight")
 plt.colorbar()
+plt.tight_layout()
+
+###############################################################################
+# Finally, another important feature of PyLops linear operators is that we can
+# always keep track of how many times the forward and adjoint passes have been
+# applied (and reset when needed). This is particularly useful when running a
+# third party solver to see how many evaluations of our operator are performed
+# inside the solver.
+
+Dop = pylops.Diagonal(d)
+
+y = Dop.matvec(x)
+y = Dop.matvec(x)
+y = Dop.rmatvec(y)
+
+print(f"Forward evaluations: {Dop.matvec_count}")
+print(f"Adjoint evaluations: {Dop.rmatvec_count}")
+
+# Reset
+Dop.reset_count()
+print(f"Forward evaluations: {Dop.matvec_count}")
+print(f"Adjoint evaluations: {Dop.rmatvec_count}")
 
 ###############################################################################
 # This first tutorial is completed. You have seen the basic operations that


### PR DESCRIPTION
This PR introduces a new decorator `count` which is used to count the number of matvec/rmatvec/matmat/rmatmat performed by a single operator. These counts are stored in the following variables `matvec_count`,  `rmatvec_count`, `matmat_count`, `rmatmat_count` and can be restarted using the method `reset_count`