### PR TITLE
clean: reorganize init signatures for all operators

### DIFF
--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -16,6 +16,8 @@ should be used as a checklist when converting a piece of code using PyLops from 
   See the table at the end of this document for support ndarray operations.
 
 ## Operators
+- The declaration signature of all operators is now `Op(..., dtype, name)`. This has no effect for users relying on
+  keyword arguments. If using positional arguments in place of keyword arguments, ensure that they are ordered correctly.
 - Several operators have deprecated `N` as a keyword. To migrate, pass only `dims` if both `N` and `dims` are currently
   being passed. If only `N` is being passed, ensure it is being passed as a value and not a keyword argument (e.g.,
   change `Flip(N=100)` to `Flip(100)`).
@@ -25,8 +27,12 @@ should be used as a checklist when converting a piece of code using PyLops from 
   Be careful to check all operators where `dir`, `dirs` and `nodir` was not provided explicitly.
 ### Basic
 - `dims_d` in `Sum` is deprecated in favor or `dimsd`
+- `halfcurrent` in `CausalIntegration` is deprecated in favor or `kind=half`
+
 ### Signal processing
 - `dims_fft` in the FFT operators is deprecated in favor of `dimsd`.
+- `fftshift` in the FFT operators is deprecated in favor of `ifftshift_before`.
+
 ### Wave-equation processing
 - The optional arguments ``fast``, ``transpose``, and ``dtype`` have been deprecated in ``pylops.waveeqprocessing.mdd.MDC``.
   As previously stated in a warning message, the recommended option ``transpose=False`` is now selected as default.

--- a/examples/plot_causalintegration.py
+++ b/examples/plot_causalintegration.py
@@ -41,7 +41,7 @@ x = np.sin(t)
 # sample from the analytical integral to obtain the same result as the
 # numerical one.
 
-Cop = pylops.CausalIntegration(nt, sampling=dt, halfcurrent=True)
+Cop = pylops.CausalIntegration(nt, sampling=dt, kind="half")
 
 yana = -np.cos(t) + np.cos(t[0])
 y = Cop * x
@@ -116,7 +116,7 @@ ot = 0
 t = np.arange(nt) * dt + ot
 x = np.outer(np.sin(t), np.ones(nx))
 
-Cop = pylops.CausalIntegration(dims=(nt, nx), sampling=dt, axis=0, halfcurrent=True)
+Cop = pylops.CausalIntegration(dims=(nt, nx), sampling=dt, axis=0, kind="half")
 
 y = Cop * x
 yn = y + np.random.normal(0, 4e-1, y.shape)

--- a/pylops/avo/poststack.py
+++ b/pylops/avo/poststack.py
@@ -145,6 +145,8 @@ def PoststackLinearModelling(
     sparse : :obj:`bool`, optional
         Create a sparse matrix (``True``) or dense  (``False``) when
         ``explicit=True``
+    kind : :obj:`str`, optional
+        Derivative kind (``forward`` or ``centered``).
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 

--- a/pylops/basicoperators/CausalIntegration.py
+++ b/pylops/basicoperators/CausalIntegration.py
@@ -20,16 +20,12 @@ class CausalIntegration(LinearOperator):
         Axis along which the model is integrated.
     sampling : :obj:`float`, optional
         Sampling step ``dx``.
-    halfcurrent : :obj:`bool`, optional
-        Add half of current value (``True``) or the entire value (``False``).
-        This will be *deprecated* in v2.0.0, use instead `kind=half` to obtain
-        the same behaviour.
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     kind : :obj:`str`, optional
         Integration kind (``full``, ``half``, or ``trapezoidal``).
     removefirst : :obj:`bool`, optional
         Remove first sample (``True``) or not (``False``).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 
@@ -95,16 +91,15 @@ class CausalIntegration(LinearOperator):
         dims,
         axis=-1,
         sampling=1,
-        halfcurrent=True,
-        dtype="float64",
         kind="full",
         removefirst=False,
+        dtype="float64",
         name="C",
     ):
         self.axis = axis
         self.sampling = sampling
         # backwards compatible
-        self.kind = "half" if kind == "full" and halfcurrent else kind
+        self.kind = kind
         self.removefirst = removefirst
         dims = _value_or_list_like_to_tuple(dims)
         dimsd = list(dims)

--- a/pylops/basicoperators/DirectionalDerivative.py
+++ b/pylops/basicoperators/DirectionalDerivative.py
@@ -3,7 +3,12 @@ from pylops.basicoperators import Diagonal, Gradient, Sum
 
 
 def FirstDirectionalDerivative(
-    dims, v, sampling=1, edge=False, dtype="float64", kind="centered"
+    dims,
+    v,
+    sampling=1,
+    edge=False,
+    kind="centered",
+    dtype="float64",
 ):
     r"""First Directional derivative.
 
@@ -26,10 +31,10 @@ def FirstDirectionalDerivative(
     edge : :obj:`bool`, optional
         Use reduced order derivative at edges (``True``) or
         ignore them (``False``).
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     kind : :obj:`str`, optional
         Derivative kind (``forward``, ``centered``, or ``backward``).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
 
     Returns
     -------

--- a/pylops/basicoperators/Gradient.py
+++ b/pylops/basicoperators/Gradient.py
@@ -2,7 +2,7 @@ from pylops.basicoperators import FirstDerivative, VStack
 from pylops.utils._internal import _value_or_list_like_to_tuple
 
 
-def Gradient(dims, sampling=1, edge=False, dtype="float64", kind="centered"):
+def Gradient(dims, sampling=1, edge=False, kind="centered", dtype="float64"):
     r"""Gradient.
 
     Apply gradient operator to a multi-dimensional array.
@@ -19,10 +19,10 @@ def Gradient(dims, sampling=1, edge=False, dtype="float64", kind="centered"):
     edge : :obj:`bool`, optional
         Use reduced order derivative at edges (``True``) or
         ignore them (``False``).
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     kind : :obj:`str`, optional
         Derivative kind (``forward``, ``centered``, or ``backward``).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
 
     Returns
     -------

--- a/pylops/basicoperators/Identity.py
+++ b/pylops/basicoperators/Identity.py
@@ -19,12 +19,12 @@ class Identity(LinearOperator):
         Number of samples in data (and model, if ``M`` is not provided).
     M : :obj:`int`, optional
         Number of samples in model.
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     inplace : :obj:`bool`, optional
         Work inplace (``True``) or make a new copy (``False``). By default,
         data is a reference to the model (in forward) and model is a reference
         to the data (in adjoint).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 
@@ -79,7 +79,7 @@ class Identity(LinearOperator):
 
     """
 
-    def __init__(self, N, M=None, dtype="float64", inplace=True, name="I"):
+    def __init__(self, N, M=None, inplace=True, dtype="float64", name="I"):
         M = N if M is None else M
         super().__init__(dtype=np.dtype(dtype), shape=(N, M), name=name)
         self.inplace = inplace

--- a/pylops/basicoperators/Laplacian.py
+++ b/pylops/basicoperators/Laplacian.py
@@ -10,8 +10,8 @@ def Laplacian(
     weights=(1, 1),
     sampling=(1, 1),
     edge=False,
-    dtype="float64",
     kind="centered",
+    dtype="float64",
 ):
     r"""Laplacian.
 
@@ -36,10 +36,10 @@ def Laplacian(
     edge : :obj:`bool`, optional
         Use reduced order derivative at edges (``True``) or
         ignore them (``False``) for centered derivative
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     kind : :obj:`str`, optional
         Derivative kind (``forward``, ``centered``, or ``backward``)
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
 
     Returns
     -------

--- a/pylops/basicoperators/Restriction.py
+++ b/pylops/basicoperators/Restriction.py
@@ -37,12 +37,12 @@ class Restriction(LinearOperator):
         .. versionadded:: 2.0.0
 
         Axis along which restriction is applied to model.
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     inplace : :obj:`bool`, optional
         Work inplace (``True``) or make a new copy (``False``). By default,
         data is a reference to the model (in forward) and model is a reference
         to the data (in adjoint).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 
@@ -86,7 +86,7 @@ class Restriction(LinearOperator):
 
     """
 
-    def __init__(self, dims, iava, axis=-1, dtype="float64", inplace=True, name="R"):
+    def __init__(self, dims, iava, axis=-1, inplace=True, dtype="float64", name="R"):
         ncp = get_array_module(iava)
         dims = _value_or_list_like_to_tuple(dims)
         axis = normalize_axis_index(axis, len(dims))

--- a/pylops/basicoperators/SecondDerivative.py
+++ b/pylops/basicoperators/SecondDerivative.py
@@ -27,10 +27,10 @@ class SecondDerivative(LinearOperator):
     edge : :obj:`bool`, optional
         Use reduced order derivative at edges (``True``) or
         ignore them (``False``) for centered derivative
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     kind : :obj:`str`, optional
         Derivative kind (``forward``, ``centered``, or ``backward``).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 
@@ -73,8 +73,8 @@ class SecondDerivative(LinearOperator):
         axis=-1,
         sampling=1,
         edge=False,
-        dtype="float64",
         kind="centered",
+        dtype="float64",
         name="S",
     ):
         dims = _value_or_list_like_to_tuple(dims)

--- a/pylops/signalprocessing/Convolve1D.py
+++ b/pylops/signalprocessing/Convolve1D.py
@@ -120,7 +120,7 @@ class Convolve1D(LinearOperator):
     """
 
     def __init__(
-        self, dims, h, offset=0, axis=-1, dtype="float64", method=None, name="C"
+        self, dims, h, offset=0, axis=-1, method=None, dtype="float64", name="C"
     ):
         dims = _value_or_list_like_to_tuple(dims)
         super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dims, name=name)

--- a/pylops/signalprocessing/Convolve2D.py
+++ b/pylops/signalprocessing/Convolve2D.py
@@ -2,7 +2,7 @@ from pylops.signalprocessing import ConvolveND
 
 
 def Convolve2D(
-    dims, h, offset=(0, 0), axes=(-2, -1), dtype="float64", method="fft", name="C"
+    dims, h, offset=(0, 0), axes=(-2, -1), method="fft", dtype="float64", name="C"
 ):
     r"""2D convolution operator.
 
@@ -22,10 +22,10 @@ def Convolve2D(
         .. versionadded:: 2.0.0
 
         Axes along which convolution is applied
-    dtype : :obj:`str`, optional
-        Type of elements in input array.
     method : :obj:`str`, optional
         Method used to calculate the convolution (``direct`` or ``fft``).
+    dtype : :obj:`str`, optional
+        Type of elements in input array.
     name : :obj:`str`, optional
         .. versionadded:: 2.0.0
 

--- a/pylops/signalprocessing/FFT.py
+++ b/pylops/signalprocessing/FFT.py
@@ -373,7 +373,6 @@ def FFT(
     sampling=1.0,
     norm="ortho",
     real=False,
-    fftshift=None,
     ifftshift_before=None,
     fftshift_after=False,
     engine="numpy",
@@ -435,10 +434,6 @@ def FFT(
         Model to which fft is applied has real numbers (``True``) or not
         (``False``). Used to enforce that the output of adjoint of a real
         model is real.
-    fftshift : :obj:`bool`, optional
-        .. deprecated:: 1.17.0
-
-            Use ``ifftshift_before``.
     ifftshift_before : :obj:`bool`, optional
         .. versionadded:: 1.17.0
 
@@ -543,24 +538,6 @@ def FFT(
     signals.
 
     """
-    # Use fftshift if supplied, otherwise use ifftshift_before
-    # If neither are supplied, set to False
-    if fftshift is not None:
-        warnings.warn(
-            "fftshift is deprecated. Please use ifftshift_before.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        if ifftshift_before is not None:
-            warnings.warn(
-                "Passed fftshift and ifftshift_before, ignoring ifftshift_before. ",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-        ifftshift_before = fftshift
-    if fftshift is None and ifftshift_before is None:
-        ifftshift_before = False
-
     if engine == "fftw" and pyfftw is not None:
         f = _FFT_fftw(
             dims,

--- a/pylops/signalprocessing/FFT2D.py
+++ b/pylops/signalprocessing/FFT2D.py
@@ -215,8 +215,8 @@ def FFT2D(
     real=False,
     ifftshift_before=False,
     fftshift_after=False,
-    dtype="complex128",
     engine="numpy",
+    dtype="complex128",
     name="F",
 ):
     r"""Two dimensional Fast-Fourier Transform.

--- a/pylops/signalprocessing/FFTND.py
+++ b/pylops/signalprocessing/FFTND.py
@@ -199,8 +199,8 @@ def FFTND(
     real=False,
     ifftshift_before=False,
     fftshift_after=False,
-    dtype="complex128",
     engine="scipy",
+    dtype="complex128",
     name="F",
 ):
     r"""N-dimensional Fast-Fourier Transform.

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -121,8 +121,6 @@ class Marchenko:
         Time-offset to apply to traveltime
     nsmooth : :obj:`int`, optional
         Number of samples of smoothing operator to apply to window
-    dtype : :obj:`bool`, optional
-        Type of elements in input array.
     saveRt : :obj:`bool`, optional
         Save ``R`` and ``R.H`` to speed up the computation of adjoint of
         :class:`pylops.signalprocessing.Fredholm1` (``True``) or create
@@ -138,6 +136,8 @@ class Marchenko:
         .. versionadded:: 1.17.0
 
         Engine used for fft computation (``numpy``, ``scipy`` or ``fftw``)
+    dtype : :obj:`bool`, optional
+        Type of elements in input array.
 
     Attributes
     ----------
@@ -227,10 +227,10 @@ class Marchenko:
         wav=None,
         toff=0.0,
         nsmooth=10,
-        dtype="float64",
         saveRt=True,
         prescaled=False,
         fftengine="numpy",
+        dtype="float64",
     ):
         # Save inputs into class
         self.dt = dt
@@ -310,8 +310,6 @@ class Marchenko:
             Compute and return Green's functions
         dottest : :obj:`bool`, optional
             Apply dot-test
-        fast : :obj:`bool`
-            *Deprecated*, will be removed in v2.0.0
         usematmul : :obj:`bool`, optional
             Use :func:`numpy.matmul` (``True``) or for-loop with :func:`numpy.dot`
             (``False``) in :py:class:`pylops.signalprocessing.Fredholm1` operator.

--- a/pytests/test_causalintegration.py
+++ b/pytests/test_causalintegration.py
@@ -80,7 +80,6 @@ def test_CausalIntegration1d(par):
             par["nt"],
             sampling=par["dt"],
             kind=kind,
-            halfcurrent=False,
             removefirst=rf,
             dtype=par["dtype"],
         )
@@ -96,9 +95,9 @@ def test_CausalIntegration1d(par):
             y = Cop * x
             # analytical integration
             yana = (
-                t ** 2 / 2.0
+                t**2 / 2.0
                 - t[0] ** 2 / 2.0
-                + par["imag"] * (t ** 2 / 2.0 - t[0] ** 2 / 2.0)
+                + par["imag"] * (t**2 / 2.0 - t[0] ** 2 / 2.0)
             )
 
             assert_array_almost_equal(y, yana[rf1:], decimal=4)
@@ -133,7 +132,6 @@ def test_CausalIntegration2d(par):
             sampling=dt,
             axis=0,
             kind=kind,
-            halfcurrent=False,
             removefirst=rf,
             dtype=par["dtype"],
         )


### PR DESCRIPTION
The init signature of every operator is reorganized as follows: `Op(..., dtype, name)`.