### PR TITLE
feature: metrics

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -230,6 +230,7 @@ Callbacks
    :toctree: generated/
 
     Callbacks
+    MetricsCallback
 
 
 Applications

--- a/docs/source/api/others.rst
+++ b/docs/source/api/others.rst
@@ -42,7 +42,7 @@ Describe
 Estimators
 ----------
 
-.. currentmodule:: pylops.utils
+.. currentmodule:: pylops.utils.estimators
 
 .. autosummary::
    :toctree: generated/
@@ -50,6 +50,34 @@ Estimators
     trace_hutchinson
     trace_hutchpp
     trace_nahutchpp
+
+Metrics
+-------
+.. currentmodule:: pylops.utils.metrics
+
+.. autosummary::
+   :toctree: generated/
+
+    mae
+    mse
+    snr
+    psnr
+
+Geophysical Reservoir characterization
+--------------------------------------
+
+.. currentmodule:: pylops.avo
+
+.. autosummary::
+   :toctree: generated/
+
+    avo.zoeppritz_scattering
+    avo.zoeppritz_element
+    avo.zoeppritz_pp
+    avo.approx_zoeppritz_pp
+    avo.akirichards
+    avo.fatti
+    avo.ps
 
 Scalability test
 ----------------
@@ -83,8 +111,6 @@ Synthetics
 
    marchenko.directwave
 
-
-
 Signal-processing
 -----------------
 
@@ -98,7 +124,6 @@ Signal-processing
     signalprocessing.dip_estimate
     signalprocessing.slope_estimate
 
-
 Tapers
 ------
 
@@ -110,7 +135,6 @@ Tapers
     tapers.taper2d
     tapers.taper3d
     tapers.tapernd
-
 
 Wavelets
 --------
@@ -125,19 +149,3 @@ Wavelets
     wavelets.ormsby
     wavelets.ricker
 
-
-Geophysical Reservoir characterization
---------------------------------------
-
-.. currentmodule:: pylops.avo
-
-.. autosummary::
-   :toctree: generated/
-
-    avo.zoeppritz_scattering
-    avo.zoeppritz_element
-    avo.zoeppritz_pp
-    avo.approx_zoeppritz_pp
-    avo.akirichards
-    avo.fatti
-    avo.ps

--- a/pylops/optimization/callback.py
+++ b/pylops/optimization/callback.py
@@ -1,3 +1,6 @@
+from pylops.utils.metrics import *
+
+
 class Callbacks:
     r"""Callbacks
 
@@ -116,3 +119,35 @@ class Callbacks:
 
         """
         pass
+
+
+class MetricsCallback(Callbacks):
+    r"""Metrics callback
+
+    This callback can be used to store different metrics from the
+    ``pylops.utils.metrics`` module during iterations.
+
+    """
+
+    def __init__(self, xtrue, which=["mae", "mse", "snr", "psnr"]):
+        self.xtrue = xtrue
+        self.which = which
+        self.metrics = {}
+        if "mae" in self.which:
+            self.metrics["mae"] = []
+        if "mse" in self.which:
+            self.metrics["mse"] = []
+        if "snr" in self.which:
+            self.metrics["snr"] = []
+        if "psnr" in self.which:
+            self.metrics["psnr"] = []
+
+    def on_step_end(self, solver, x):
+        if "mae" in self.which:
+            self.metrics["mae"].append(mae(self.xtrue, x))
+        if "mse" in self.which:
+            self.metrics["mse"].append(mse(self.xtrue, x))
+        if "snr" in self.which:
+            self.metrics["snr"].append(snr(self.xtrue, x))
+        if "psnr" in self.which:
+            self.metrics["psnr"].append(psnr(self.xtrue, x))

--- a/pylops/optimization/callback.py
+++ b/pylops/optimization/callback.py
@@ -1,4 +1,4 @@
-from pylops.utils.metrics import *
+from pylops.utils.metrics import mae, mse, psnr, snr
 
 
 class Callbacks:
@@ -127,10 +127,20 @@ class MetricsCallback(Callbacks):
     This callback can be used to store different metrics from the
     ``pylops.utils.metrics`` module during iterations.
 
+    Parameters
+    ----------
+    xtrue : :obj:`np.ndarray`
+        True model vector
+    Op : :obj:`pylops.LinearOperator`, optional
+        Operator to apply to the solution prior to comparing it with `xtrue`
+    which : :obj:`tuple`, optional
+        List of metrics to compute (currently available: "mae", "mse", "snr",
+        and "psnr")
     """
 
-    def __init__(self, xtrue, which=["mae", "mse", "snr", "psnr"]):
+    def __init__(self, xtrue, Op=None, which=("mae", "mse", "snr", "psnr")):
         self.xtrue = xtrue
+        self.Op = Op
         self.which = which
         self.metrics = {}
         if "mae" in self.which:
@@ -143,6 +153,9 @@ class MetricsCallback(Callbacks):
             self.metrics["psnr"] = []
 
     def on_step_end(self, solver, x):
+        if self.Op is not None:
+            x = self.Op * x
+
         if "mae" in self.which:
             self.metrics["mae"].append(mae(self.xtrue, x))
         if "mse" in self.which:

--- a/pylops/utils/__init__.py
+++ b/pylops/utils/__init__.py
@@ -3,5 +3,6 @@ from .backend import *
 from .deps import *
 from .dottest import dottest
 from .estimators import *
+from .metrics import *
 from .multiproc import *
 from .utils import Report

--- a/pylops/utils/metrics.py
+++ b/pylops/utils/metrics.py
@@ -1,0 +1,95 @@
+import numpy as np
+
+
+def mae(xref, xcmp):
+    """Mean Absolute Error (MAE)
+
+    Compute Mean Absolute Error between two vectors
+
+    Parameters
+    ----------
+    xref : :obj:`numpy.ndarray`
+        Reference vector
+    xcmp : :obj:`numpy.ndarray`
+        Comparison vector
+
+    Returns
+    -------
+    mae : :obj:`float`
+        Mean Absolute Error
+
+    """
+    mae = np.mean(np.abs(xref - xcmp))
+    return mae
+
+
+def mse(xref, xcmp):
+    """Mean Square Error (MSE)
+
+    Compute Mean Square Error between two vectors
+
+    Parameters
+    ----------
+    xref : :obj:`numpy.ndarray`
+        Reference vector
+    xcmp : :obj:`numpy.ndarray`
+        Comparison vector
+
+    Returns
+    -------
+    mse : :obj:`float`
+        Mean Square Error
+
+    """
+    mse = np.mean(np.abs(xref - xcmp) ** 2)
+    return mse
+
+
+def snr(xref, xcmp):
+    """Signal to Noise Ratio (SNR)
+
+    Compute Signal to Noise Ratio between two vectors
+
+    Parameters
+    ----------
+    xref : :obj:`numpy.ndarray`
+        Reference vector
+    xcmp : :obj:`numpy.ndarray`
+        Comparison vector
+
+    Returns
+    -------
+    snr : :obj:`float`
+        Signal to Noise Ratio of ``xcmp`` with respect to ``xref``
+
+    """
+    xrefv = np.mean(np.abs(xref) ** 2)
+    snr = 10.0 * np.log10(xrefv / mse(xref, xcmp))
+    return snr
+
+
+def psnr(xref, xcmp, xmax=None):
+    """Peak Signal to Noise Ratio (PSNR)
+
+    Compute Peak Signal to Noise Ratio between two vectors.
+
+    Parameters
+    ----------
+    xref : :obj:`numpy.ndarray`
+        Reference vector
+    xcmp : :obj:`numpy.ndarray`
+        Comparison vector
+    xmax : :obj:`float`, optional
+      Maximum value to use. If ``None``, the actual maximum of
+      the reference vector is used
+
+    Returns
+    -------
+    psnr : :obj:`float`
+      Peak Signal to Noise Ratio of ``xcmp`` with respect to ``xref``
+
+    """
+    if xmax is None:
+        xmax = xref.max()
+    psrn = 10.0 * np.log10(xmax**2 / mse(xref, xcmp))
+    return psrn

--- a/pytests/test_metrics.py
+++ b/pytests/test_metrics.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from pylops.utils.metrics import mae, mse, psnr, snr
+
+par1 = {"nx": 11, "dtype": "float64"}  # float64
+par2 = {"nx": 11, "dtype": "float32"}  # float32
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_mae(par):
+    """Check MAE with same vector and vector of zeros"""
+    xref = np.ones(par["nx"])
+    xcmp = np.zeros(par["nx"])
+
+    maesame = mae(xref, xref)
+    maecmp = mae(xref, xcmp)
+    assert maesame == 0.0
+    assert maecmp == 1.0
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_mse(par):
+    """Check MSE with same vector and vector of zeros"""
+    xref = np.ones(par["nx"])
+    xcmp = np.zeros(par["nx"])
+
+    msesame = mse(xref, xref)
+    msecmp = mse(xref, xcmp)
+    assert msesame == 0.0
+    assert msecmp == 1.0
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_snr(par):
+    """Check SNR with same vector and vector of zeros"""
+    xref = np.random.normal(0, 1, par["nx"])
+    xcmp = np.zeros(par["nx"])
+
+    snrsame = snr(xref, xref)
+    snrcmp = snr(xref, xcmp)
+    assert snrsame == np.inf
+    assert snrcmp == 0.0
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_psnr(par):
+    """Check PSNR with same vector and vector of zeros"""
+    xref = np.ones(par["nx"])
+    xcmp = np.zeros(par["nx"])
+
+    psnrsame = psnr(xref, xref, xmax=1.0)
+    psnrcmp = psnr(xref, xcmp, xmax=1.0)
+    assert psnrsame == np.inf
+    assert psnrcmp == 0.0


### PR DESCRIPTION
# Motivation
Users are usually in the position of creating small routines to compute metrics (mse, snr, psnr, ...) and wrap them into a callback. It makes sense to create a small utility submodule `pylops.utils.metric` where we can add common metrics when 
needed. 

Moreover, leveraging the new Callbacks class, a new callback is created that computes all metrics during iterations