### PR TITLE
fix: bump rtd python version to 3.9

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,7 +1,7 @@
 # .readthedocs.yml
 
 python:
-  version: 3.6
+  version: 3.9
   setup_py_install: true
 
 requirements_file: requirements-dev.txt


### PR DESCRIPTION
This commit changes the rtd python version to 3.9 in order to work with newly introduced numpy typing annotations.