### PR TITLE
patch: fix problem in wavefielddecomposition tutorial

### DIFF
--- a/tutorials/wavefielddecomposition.py
+++ b/tutorials/wavefielddecomposition.py
@@ -223,6 +223,7 @@ pup_inv, pdown_inv = pylops.waveeqprocessing.WavefieldDecomposition(
     kind="inverse",
     critical=critical * 100,
     ntaper=ntaper,
+    scaling=1.0 / vz.max(),
     dtype="complex128",
     **dict(damp=1e-10, iter_lim=20)
 )


### PR DESCRIPTION
The last cell of the wavefielddecomposition tutorial started to show a problem when using python >3.8 due to changes in scipy lsqr solver tolerances. This problem is solved by applying a scaling to the operator and data.