### PR TITLE
fix: enforce float to scalars in optimizers for cupy compatibility

### DIFF
--- a/pylops/optimization/cls_basic.py
+++ b/pylops/optimization/cls_basic.py
@@ -316,9 +316,11 @@ class CGLS(Solver):
         # create variables to track the residual norm and iterations
         self.cost = []
         self.cost1 = []
-        self.cost.append(self.ncp.linalg.norm(self.s))
+        self.cost.append(float(self.ncp.linalg.norm(self.s)))
         self.cost1.append(
-            self.ncp.sqrt(self.cost[0] ** 2 + damp * self.ncp.abs(x.dot(x.conj())))
+            float(
+                self.ncp.sqrt(self.cost[0] ** 2 + damp * self.ncp.abs(x.dot(x.conj())))
+            )
         )
         self.iiter = 0
 
@@ -350,10 +352,13 @@ class CGLS(Solver):
         self.q = self.Op.matvec(self.c)
         self.kold = k
         self.iiter += 1
-        self.cost.append(self.ncp.linalg.norm(self.s))
+        self.cost.append(float(self.ncp.linalg.norm(self.s)))
         self.cost1.append(
             self.ncp.sqrt(
-                self.cost[self.iiter] ** 2 + self.damp * self.ncp.abs(x.dot(x.conj()))
+                float(
+                    self.cost[self.iiter] ** 2
+                    + self.damp * self.ncp.abs(x.dot(x.conj()))
+                )
             )
         )
         if show:
@@ -668,7 +673,10 @@ class LSQR(Solver):
             self.alfa = self.ncp.linalg.norm(self.v)
             if self.alfa > 0:
                 self.v = self.v / self.alfa
-                self.w = self.v.copy()
+        else:
+            self.v = x.copy()
+            self.alfa = 0
+        self.w = self.v.copy()
 
         # check if solution is already found
         self.arnorm = self.alfa * self.beta
@@ -719,7 +727,9 @@ class LSQR(Solver):
         self.beta = self.ncp.linalg.norm(self.u)
         if self.beta > 0:
             self.u = self.u / self.beta
-            self.anorm = np.linalg.norm([self.anorm, to_numpy(self.alfa), to_numpy(self.beta), self.damp])
+            self.anorm = np.linalg.norm(
+                [self.anorm, to_numpy(self.alfa), to_numpy(self.beta), self.damp]
+            )
             self.v = self.Op.rmatvec(self.u) - self.beta * self.v
             self.alfa = self.ncp.linalg.norm(self.v)
             if self.alfa > 0:

--- a/pylops/optimization/cls_sparsity.py
+++ b/pylops/optimization/cls_sparsity.py
@@ -751,7 +751,7 @@ class OMP(Solver):
         # create variables to track the residual norm and iterations
         self.res = self.y.copy()
         self.cost = [
-            np.linalg.norm(self.y),
+            float(np.linalg.norm(self.y)),
         ]
         self.iiter = 0
 
@@ -827,7 +827,7 @@ class OMP(Solver):
             self.res = self.y - Opcol.matvec(x)
 
         self.iiter += 1
-        self.cost.append(np.linalg.norm(self.res))
+        self.cost.append(float(np.linalg.norm(self.res)))
         if show:
             self._print_step(x)
         return x, cols
@@ -1289,7 +1289,7 @@ class ISTA(Solver):
 
         costdata = 0.5 * np.linalg.norm(res) ** 2
         costreg = self.eps * np.linalg.norm(x, ord=1)
-        self.cost.append(costdata + costreg)
+        self.cost.append(float(costdata + costreg))
         self.iiter += 1
         if show:
             self._print_step(x, costdata, costreg, xupdate)
@@ -1541,7 +1541,7 @@ class FISTA(ISTA):
                 self.normresold = self.normres
 
         # compute gradient
-        grad = self.alpha * self.Op.H @ resz
+        grad = self.alpha * (self.Op.H @ resz)
 
         # update inverted model
         x_unthesh = z + grad
@@ -1564,7 +1564,7 @@ class FISTA(ISTA):
 
         costdata = 0.5 * np.linalg.norm(self.y - self.Op @ x) ** 2
         costreg = self.eps * np.linalg.norm(x, ord=1)
-        self.cost.append(costdata + costreg)
+        self.cost.append(float(costdata + costreg))
         self.iiter += 1
         if show:
             self._print_step(x, costdata, costreg, xupdate)
@@ -2167,7 +2167,7 @@ class SplitBregman(Solver):
 
         # update history parameters
         self.iiter += 1
-        self.cost.append(self.costtot)
+        self.cost.append(float(self.costtot))
         if show:
             self._print_step(x)
         return x


### PR DESCRIPTION
A number of problems arose when running these solvers with cupy. They can all be reconducted to 1element arrays staying on the GPU versus scalars being automatically moved back to the CPU. 

This is now enforced throughout for values that we want to store in cost function history lists and similar.