### PR TITLE
Fix: todense in Diagonal method

### DIFF
--- a/pylops/basicoperators/diagonal.py
+++ b/pylops/basicoperators/diagonal.py
@@ -77,6 +77,7 @@ class Diagonal(LinearOperator):
         name: str = "D",
     ) -> None:
         self.diag = diag
+        self.axis = axis
         origdims = dims
         dims = self.diag.shape if dims is None else _value_or_sized_to_tuple(dims)
         super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dims, name=name)
@@ -128,4 +129,10 @@ class Diagonal(LinearOperator):
         densemat : :obj:`numpy.ndarray`
             Dense matrix.
         """
-        return self.matrix()
+        if self.diag.ndim == 1:
+            return self.matrix()
+        else:
+            dims = list(self.dims)
+            dims[self.axis] = 1
+            matrix = np.diag(np.tile(self.diag, dims).ravel())
+            return matrix

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -666,7 +666,7 @@ class LinearOperator(spLinearOperator):
             # use numpy for small matrices (faster but heavier on memory)
             identity = ncp.eye(shapemin, dtype=self.dtype)
         else:
-            # use scipy for small matrices (slower but lighter on memory)
+            # use scipy for large matrices (slower but lighter on memory)
             identity = get_sparse_eye(ncp.ones(1))(shapemin, dtype=self.dtype).tocsc()
 
         # Apply operator


### PR DESCRIPTION
Diagonal has its own 'fast' todense method. However, with the introduction of unflattened operations, this method was not correctly handling cases with multidimensional dims. This commit fixes it.