### PR TITLE
minor: remove devito from extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
             "PyWavelets",
             "scikit-fmm",
             "spgl1",
-            "devito",
         ]
     },
     packages=find_packages(exclude=["pytests"]),


### PR DESCRIPTION
Devito seems to have issues to be installed automatically when running `pip install pylops[advanced]` as part of one of the dependencies. To avoid issues for users, we prefer to take it out and let users install devito manually if interested.