### PR TITLE
Feature: TorchOperator with Nd-array inputs

### DIFF
--- a/pylops/torchoperator.py
+++ b/pylops/torchoperator.py
@@ -38,13 +38,10 @@ class TorchOperator(LinearOperator):
         PyLops operator
     batch : :obj:`bool`, optional
         Input has single sample (``False``) or batch of samples (``True``).
-        If ``batch==False`` the input must be a 1-d Torch tensor,
-        if ``batch==True`` the input must be a 2-d Torch tensor with
-        batches along the first dimension. Alternatively, if ``dims`` is
-        provided the input can be a NDarray (with batches along the first
-        dimension)
-    dims : :obj:`list` or :obj:`int`, optional
-        Number of samples for each dimension (excluding batch size)
+        If ``batch==False`` the input must be a 1-d Torch tensor or a tensor of
+        size equal to ``Op.dims``; if ``batch==True`` the input must be a 2-d Torch tensor with
+        batches along the first dimension or a tensor of
+        size equal to ``[nbatch, *Op.dims]`` where ``nbatch`` is the size of the batch.
     device : :obj:`str`, optional
         Device to be used when applying operator (``cpu`` or ``gpu``)
     devicetorch : :obj:`str`, optional
@@ -64,10 +61,13 @@ class TorchOperator(LinearOperator):
             raise NotImplementedError(torch_message)
         self.device = device
         self.devicetorch = devicetorch
+        super().__init__(
+            dtype=np.dtype(Op.dtype), dims=Op.dims, dimsd=Op.dims, name=Op.name
+        )
         # define transpose indices to bring batch to last dimension before applying
         # pylops forward and adjoint (this will call matmat and rmatmat)
-        self.transpf = np.roll(np.arange(2 if dims is None else len(dims) + 1), -1)
-        self.transpb = np.roll(np.arange(2 if dims is None else len(dims) + 1), 1)
+        self.transpf = np.roll(np.arange(2 if dims is None else len(self.dims) + 1), -1)
+        self.transpb = np.roll(np.arange(2 if dims is None else len(self.dims) + 1), 1)
         if not batch:
             self.matvec = Op.matvec
             self.rmatvec = Op.rmatvec
@@ -79,9 +79,6 @@ class TorchOperator(LinearOperator):
                 self.transpb
             )
         self.Top = _TorchOperator.apply
-        super().__init__(
-            dtype=np.dtype(Op.dtype), dims=Op.dims, dimsd=Op.dims, name=Op.name
-        )
 
     def apply(self, x: TensorTypeLike) -> TensorTypeLike:
         """Apply forward pass to input vector

--- a/pylops/torchoperator.py
+++ b/pylops/torchoperator.py
@@ -69,8 +69,8 @@ class TorchOperator(LinearOperator):
         self.transpf = np.roll(np.arange(2 if dims is None else len(self.dims) + 1), -1)
         self.transpb = np.roll(np.arange(2 if dims is None else len(self.dims) + 1), 1)
         if not batch:
-            self.matvec = Op.matvec
-            self.rmatvec = Op.rmatvec
+            self.matvec = lambda x: Op @ x
+            self.rmatvec = lambda x: Op.H @ x
         else:
             self.matvec = lambda x: (Op @ x.transpose(self.transpf)).transpose(
                 self.transpb

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -39,7 +39,7 @@ def test_TorchOperator(par):
 
 @pytest.mark.parametrize("par", [(par1)])
 def test_TorchOperator_batch(par):
-    """Apply forward for input with multiple samples (= batch)"""
+    """Apply forward for input with multiple samples (= batch) and flattened arrays"""
     Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
     Top = TorchOperator(Dop, batch=True)
 
@@ -48,6 +48,22 @@ def test_TorchOperator_batch(par):
     xt.requires_grad = True
 
     y = Dop.matmat(x.T).T
+    yt = Top.apply(xt)
+
+    assert_array_equal(y, yt.detach().cpu().numpy())
+
+
+@pytest.mark.parametrize("par", [(par1)])
+def test_TorchOperator_batch_nd(par):
+    """Apply forward for input with multiple samples (= batch) and nd-arrays"""
+    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,))
+    Top = TorchOperator(Dop, batch=True, dims=(par["nx"], 2))
+
+    x = np.random.normal(0.0, 1.0, (4, par["nx"], 2))
+    xt = torch.from_numpy(x)
+    xt.requires_grad = True
+
+    y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
     yt = Top.apply(xt)
 
     assert_array_equal(y, yt.detach().cpu().numpy())


### PR DESCRIPTION
This PR enables TorchOperator to work directly with Nd-tensor inputs both in single and batch mode. This is achieved by using the ``Op.dims`` parameter and changing the definitions of `self.matvec` and `self.rmatvec` to be able to handle Nd-arrays