### PR TITLE
bug: improved handling of haxes in radons

### DIFF
--- a/examples/plot_sliding.py
+++ b/examples/plot_sliding.py
@@ -229,10 +229,10 @@ for i in range(0, 305, 61):
 # :math:`n_y \times n_x \times n_t` composed of 3 hyperbolic events
 
 par = {
-    "oy": -15,
+    "oy": -13,
     "dy": 2,
     "ny": 14,
-    "ox": -18,
+    "ox": -17,
     "dx": 2,
     "nx": 18,
     "ot": 0,

--- a/pylops/signalprocessing/radon2d.py
+++ b/pylops/signalprocessing/radon2d.py
@@ -266,9 +266,9 @@ def Radon2D(
     dpx = dh / dt
     pxaxis = pxaxis * dpx
     if not centeredh:
-        haxisunitless = haxis // dh
+        haxisunitless = haxis / dh
     else:
-        haxisunitless = np.arange(nh) - nh // 2
+        haxisunitless = np.arange(nh) - nh // 2 + ((nh + 1) % 2) / 2
     dims = (npx, nt)
     dimsd = (nh, nt)
 

--- a/pylops/signalprocessing/radon3d.py
+++ b/pylops/signalprocessing/radon3d.py
@@ -293,11 +293,11 @@ def Radon3D(
     dpx = dhx / dt
     pxaxis = pxaxis * dpx
     if not centeredh:
-        hyaxisunitless = hyaxis // dhy
-        hxaxisunitless = hxaxis // dhx
+        hyaxisunitless = hyaxis / dhy
+        hxaxisunitless = hxaxis / dhx
     else:
-        hyaxisunitless = np.arange(nhy) - nhy // 2
-        hxaxisunitless = np.arange(nhx) - nhx // 2
+        hyaxisunitless = np.arange(nhy) - nhy // 2 + ((nhy + 1) % 2) / 2
+        hxaxisunitless = np.arange(nhx) - nhx // 2 + ((nhx + 1) % 2) / 2
 
     # create grid for py and px axis
     hyaxisunitless, hxaxisunitless = np.meshgrid(


### PR DESCRIPTION
This PR introduces two small improvements to the Radon operators:

- floating point division instead of floor division for when `centeredh==False`. This avoid shifting the axis (alongside normalizing it) when its samples are not multiples of dh
-  creating a normalized axis that is always symmetric when `centeredh==True` also when `nh` is even.

I identified these small inconsistencies when trying to re-implement this example (https://github.com/msacchi/Radon_Py) with PyLops - see https://github.com/PyLops/pylops_notebooks/blob/master/developement/RadonParabolic.ipynb.