### PR TITLE
Feature: Blending

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -121,6 +121,7 @@ Wave-Equation processing
     PressureToVelocity
     UpDownComposition2D
     UpDownComposition3D
+    Blending
     MDC
     PhaseShift
     Kirchhoff

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -121,7 +121,9 @@ Wave-Equation processing
     PressureToVelocity
     UpDownComposition2D
     UpDownComposition3D
-    Blending
+    BlendingContinuous
+    BlendingHalf
+    BlendingGroup
     MDC
     PhaseShift
     Kirchhoff

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -122,8 +122,8 @@ Wave-Equation processing
     UpDownComposition2D
     UpDownComposition3D
     BlendingContinuous
-    BlendingHalf
     BlendingGroup
+    BlendingHalf
     MDC
     PhaseShift
     Kirchhoff

--- a/examples/plot_blending.py
+++ b/examples/plot_blending.py
@@ -115,13 +115,12 @@ plt.figure(figsize=(12, 4))
 plt.plot(ignition_times, "k")
 plt.title("Continuous blending times")
 
-Bop = pylops.waveeqprocessing.Blending(
+Bop = pylops.waveeqprocessing.BlendingContinuous(
     nt,
     nr_streamer,
     ns_streamer,
     dt,
     ignition_times,
-    kind="continuous",
     dtype="complex128",
 )
 data_blended = Bop * data_streamer
@@ -182,7 +181,7 @@ plt.figure(figsize=(12, 4))
 plt.plot(ignition_times.reshape(group_size, n_groups).T, "k")
 plt.title("Group blending times")
 
-Bop = pylops.waveeqprocessing.Blending(
+Bop = pylops.waveeqprocessing.BlendingGroup(
     nt,
     nr_obc,
     ns_obc,
@@ -190,7 +189,6 @@ Bop = pylops.waveeqprocessing.Blending(
     ignition_times.reshape(group_size, n_groups),
     group_size=group_size,
     n_groups=n_groups,
-    kind="group",
     dtype="complex128",
 )
 data_blended = Bop * data_obc
@@ -247,7 +245,7 @@ plt.figure(figsize=(12, 4))
 plt.plot(ignition_times.reshape(group_size, n_groups).T, "k")
 plt.title("Half blending times")
 
-Bop = pylops.waveeqprocessing.Blending(
+Bop = pylops.waveeqprocessing.BlendingHalf(
     nt,
     nr_obc,
     ns_obc,
@@ -255,7 +253,6 @@ Bop = pylops.waveeqprocessing.Blending(
     ignition_times.reshape(group_size, n_groups),
     group_size=group_size,
     n_groups=n_groups,
-    kind="half",
     dtype="complex128",
     name=None,
 )

--- a/examples/plot_blending.py
+++ b/examples/plot_blending.py
@@ -1,0 +1,304 @@
+"""
+Blending
+========
+This example shows how to use the :py:class:`pylops.waveeqprocessing.blending.Blending`
+operator to blend seismic data to mimic state-of-the-art simultaneous shooting
+acquisition systems.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy as sp
+
+import pylops
+
+plt.close("all")
+np.random.seed(0)
+
+###############################################################################
+# Let's start by considering a streamer seismic dataset and apply blending in
+# so-called continuous blending mode
+
+inputdata = np.load("../testdata/marchenko/input.npz")
+data = inputdata["R"]
+data = np.pad(data, ((0, 0), (0, 0), (0, 50)))
+wav = inputdata["wav"]
+wav_c = np.argmax(wav)
+ns, nr, nt = data.shape
+
+# time axis
+dt = 0.004
+t = np.arange(nt) * dt
+
+# convolve with wavelet
+data = np.apply_along_axis(sp.signal.convolve, -1, data, wav, mode="full")
+data = data[..., wav_c:][..., :nt]
+
+# obc data
+data_obc = data[:-1, :-1]
+ns_obc, nr_obc, _ = data_obc.shape
+
+# streamer data
+nr_stremer = 21
+ns_stremer = ns - nr_stremer
+
+data_streamer = np.zeros((ns_stremer, nr_stremer, nt))
+for isrc in range(ns_stremer):
+    data_streamer[isrc] = data[isrc, isrc : isrc + nr_stremer]
+
+# visualize
+isrcplot = [0, ns_obc // 2, ns_obc - 1]
+fig, axs = plt.subplots(1, 3, sharey=True, figsize=(12, 8))
+fig.suptitle("OBC data")
+for i, ax in enumerate(axs):
+    ax.imshow(
+        data_obc[isrcplot[i]].T,
+        cmap="gray",
+        vmin=-0.1,
+        vmax=0.1,
+        extent=(0, nr, t[-1], 0),
+        interpolation="none",
+    )
+    ax.set_title(f"CSG {isrcplot[i]}")
+    ax.set_xlabel("#Rec")
+    ax.axis("tight")
+axs[0].set_ylabel("t [s]")
+plt.tight_layout()
+
+isrcplot = [0, ns_stremer // 2, ns_stremer - 1]
+fig, axs = plt.subplots(1, 3, sharey=True, figsize=(12, 8))
+fig.suptitle("Streamer data")
+for i, ax in enumerate(axs):
+    ax.imshow(
+        data_streamer[isrcplot[i]].T,
+        cmap="gray",
+        vmin=-0.1,
+        vmax=0.1,
+        extent=(0, nr_stremer, t[-1], 0),
+        interpolation="none",
+    )
+    ax.set_title(f"CSG {isrcplot[i]}")
+    ax.set_xlabel("#Rec")
+    ax.axis("tight")
+axs[0].set_ylabel("t [s]")
+plt.tight_layout()
+
+irecplot = [0, nr_stremer // 2, nr_stremer - 1]
+fig, axs = plt.subplots(1, 3, sharey=True, figsize=(12, 8))
+fig.suptitle("Streamer data")
+for i, ax in enumerate(axs):
+    ax.imshow(
+        data_streamer[:, irecplot[i]].T,
+        cmap="gray",
+        vmin=-0.1,
+        vmax=0.1,
+        extent=(0, ns_stremer, t[-1], 0),
+        interpolation="none",
+    )
+    ax.set_title(f"CRG {irecplot[i]}")
+    ax.set_xlabel("#Src")
+    ax.axis("tight")
+axs[0].set_ylabel("t [s]")
+plt.tight_layout()
+
+
+################################################################################
+# We can now consider the streamer seismic dataset and apply blending in
+# so-called continuous blending mode
+
+overlap = 0.5
+ignition_times = np.random.normal(0, 0.6, ns_stremer)
+ignition_times += (1 - overlap) * nt * dt
+ignition_times[0] = 0.0
+ignition_times = np.cumsum(ignition_times)
+
+plt.figure(figsize=(12, 4))
+plt.plot(ignition_times, "k")
+plt.title("Continous blending times")
+
+Bop = pylops.waveeqprocessing.Blending(
+    nt,
+    nr_stremer,
+    ns_stremer,
+    dt,
+    ignition_times,
+    kind="continuous",
+    dtype="complex128",
+)
+data_blended = Bop * data_streamer
+data_pseudo = Bop.H * data_blended
+
+fig, ax = plt.subplots(1, 1, figsize=(4, 19))
+ax.imshow(
+    data_blended.real.T,
+    cmap="gray",
+    vmin=-0.1,
+    vmax=0.1,
+    extent=(0, ns_stremer, Bop.nttot * dt, 0),
+    interpolation="none",
+)
+ax.set_title("Blender CSG")
+ax.set_xlabel("#Rec")
+ax.set_ylabel("t [s]")
+ax.axis("tight")
+ax.set_ylim(10, 0)
+plt.tight_layout()
+
+fig, axs = plt.subplots(1, 2, sharey=True, figsize=(12, 8))
+axs[0].imshow(
+    data_streamer[:, 0].real.T,
+    cmap="gray",
+    vmin=-0.01,
+    vmax=0.01,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+axs[0].set_title("Unblended CRG")
+axs[0].set_xlabel("#Src")
+axs[0].set_ylabel("t [s]")
+axs[0].axis("tight")
+axs[1].imshow(
+    data_pseudo[:, 0].real.T,
+    cmap="gray",
+    vmin=-0.01,
+    vmax=0.01,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+axs[1].set_title("Pseudo-deblended CRG")
+axs[1].set_xlabel("#Src")
+axs[1].axis("tight")
+plt.tight_layout()
+
+################################################################################
+# Similarly we can consider the OBC data and apply both group and half blending
+
+# Group
+group_size = 2
+n_groups = ns_obc // 2
+ignition_times = np.abs(np.random.normal(0.2, 0.5, ns_obc))  # only positive shifts
+ignition_times[0] = 0.0
+
+plt.figure(figsize=(12, 4))
+plt.plot(ignition_times.reshape(group_size, n_groups).T, "k")
+plt.title("Group blending times")
+
+Bop = pylops.waveeqprocessing.Blending(
+    nt,
+    nr_obc,
+    ns_obc,
+    dt,
+    ignition_times.reshape(group_size, n_groups),
+    group_size=group_size,
+    n_groups=n_groups,
+    kind="group",
+    dtype="complex128",
+)
+data_blended = Bop * data_obc
+data_pseudo = Bop.H * data_blended
+
+fig, ax = plt.subplots(1, 1, figsize=(12, 8))
+ax.imshow(
+    data_blended[n_groups // 2].real.T,
+    cmap="gray",
+    vmin=-0.1,
+    vmax=0.1,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+ax.set_title("Blender CSG")
+ax.set_xlabel("#Rec")
+ax.set_ylabel("t [s]")
+ax.axis("tight")
+plt.tight_layout()
+
+fig, axs = plt.subplots(1, 2, sharey=True, figsize=(12, 8))
+axs[0].imshow(
+    data_obc[:, 10].real.T,
+    cmap="gray",
+    vmin=-0.01,
+    vmax=0.01,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+axs[0].set_title("Unblended CRG")
+axs[0].set_xlabel("#Src")
+axs[0].set_ylabel("t [s]")
+axs[0].axis("tight")
+axs[1].imshow(
+    data_pseudo[:, 10].real.T,
+    cmap="gray",
+    vmin=-0.01,
+    vmax=0.01,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+axs[1].set_title("Pseudo-deblended CRG")
+axs[1].set_xlabel("#Src")
+axs[1].axis("tight")
+plt.tight_layout()
+
+# Half
+group_size = 2
+n_groups = ns_obc // 2
+ignition_times = np.abs(np.random.normal(0.1, 0.5, ns_obc))  # only positive shifts
+ignition_times[0] = 0.0
+
+plt.figure(figsize=(12, 4))
+plt.plot(ignition_times.reshape(group_size, n_groups).T, "k")
+plt.title("Half blending times")
+
+Bop = pylops.waveeqprocessing.Blending(
+    nt,
+    nr_obc,
+    ns_obc,
+    dt,
+    ignition_times.reshape(group_size, n_groups),
+    group_size=group_size,
+    n_groups=n_groups,
+    kind="half",
+    dtype="complex128",
+    name=None,
+)
+data_blended = Bop * data_obc
+data_pseudo = Bop.H * data_blended
+
+fig, ax = plt.subplots(1, 1, figsize=(12, 8))
+ax.imshow(
+    data_blended[n_groups // 2].real.T,
+    cmap="gray",
+    vmin=-0.1,
+    vmax=0.1,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+ax.set_title("Blender CSG")
+ax.set_xlabel("#Rec")
+ax.set_ylabel("t [s]")
+ax.axis("tight")
+plt.tight_layout()
+
+fig, axs = plt.subplots(1, 2, sharey=True, figsize=(12, 8))
+axs[0].imshow(
+    data_obc[:, 10].real.T,
+    cmap="gray",
+    vmin=-0.01,
+    vmax=0.01,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+axs[0].set_title("Unblended CRG")
+axs[0].set_xlabel("#Src")
+axs[0].set_ylabel("t [s]")
+axs[0].axis("tight")
+axs[1].imshow(
+    data_pseudo[:, 10].real.T,
+    cmap="gray",
+    vmin=-0.01,
+    vmax=0.01,
+    extent=(0, ns_stremer, t[-1], 0),
+    interpolation="none",
+)
+axs[1].set_title("Pseudo-deblended CRG")
+axs[1].set_xlabel("#Src")
+axs[1].axis("tight")
+plt.tight_layout()

--- a/examples/plot_blending.py
+++ b/examples/plot_blending.py
@@ -38,12 +38,12 @@ data_obc = data[:-1, :-1]
 ns_obc, nr_obc, _ = data_obc.shape
 
 # streamer data
-nr_stremer = 21
-ns_stremer = ns - nr_stremer
+nr_streamer = 21
+ns_streamer = ns - nr_streamer
 
-data_streamer = np.zeros((ns_stremer, nr_stremer, nt))
-for isrc in range(ns_stremer):
-    data_streamer[isrc] = data[isrc, isrc : isrc + nr_stremer]
+data_streamer = np.zeros((ns_streamer, nr_streamer, nt))
+for isrc in range(ns_streamer):
+    data_streamer[isrc] = data[isrc, isrc : isrc + nr_streamer]
 
 # visualize
 isrcplot = [0, ns_obc // 2, ns_obc - 1]
@@ -64,7 +64,7 @@ for i, ax in enumerate(axs):
 axs[0].set_ylabel("t [s]")
 plt.tight_layout()
 
-isrcplot = [0, ns_stremer // 2, ns_stremer - 1]
+isrcplot = [0, ns_streamer // 2, ns_streamer - 1]
 fig, axs = plt.subplots(1, 3, sharey=True, figsize=(12, 8))
 fig.suptitle("Streamer data")
 for i, ax in enumerate(axs):
@@ -73,7 +73,7 @@ for i, ax in enumerate(axs):
         cmap="gray",
         vmin=-0.1,
         vmax=0.1,
-        extent=(0, nr_stremer, t[-1], 0),
+        extent=(0, nr_streamer, t[-1], 0),
         interpolation="none",
     )
     ax.set_title(f"CSG {isrcplot[i]}")
@@ -82,7 +82,7 @@ for i, ax in enumerate(axs):
 axs[0].set_ylabel("t [s]")
 plt.tight_layout()
 
-irecplot = [0, nr_stremer // 2, nr_stremer - 1]
+irecplot = [0, nr_streamer // 2, nr_streamer - 1]
 fig, axs = plt.subplots(1, 3, sharey=True, figsize=(12, 8))
 fig.suptitle("Streamer data")
 for i, ax in enumerate(axs):
@@ -91,7 +91,7 @@ for i, ax in enumerate(axs):
         cmap="gray",
         vmin=-0.1,
         vmax=0.1,
-        extent=(0, ns_stremer, t[-1], 0),
+        extent=(0, ns_streamer, t[-1], 0),
         interpolation="none",
     )
     ax.set_title(f"CRG {irecplot[i]}")
@@ -106,19 +106,19 @@ plt.tight_layout()
 # so-called continuous blending mode
 
 overlap = 0.5
-ignition_times = np.random.normal(0, 0.6, ns_stremer)
+ignition_times = np.random.normal(0, 0.6, ns_streamer)
 ignition_times += (1 - overlap) * nt * dt
 ignition_times[0] = 0.0
 ignition_times = np.cumsum(ignition_times)
 
 plt.figure(figsize=(12, 4))
 plt.plot(ignition_times, "k")
-plt.title("Continous blending times")
+plt.title("Continuous blending times")
 
 Bop = pylops.waveeqprocessing.Blending(
     nt,
-    nr_stremer,
-    ns_stremer,
+    nr_streamer,
+    ns_streamer,
     dt,
     ignition_times,
     kind="continuous",
@@ -133,10 +133,10 @@ ax.imshow(
     cmap="gray",
     vmin=-0.1,
     vmax=0.1,
-    extent=(0, ns_stremer, Bop.nttot * dt, 0),
+    extent=(0, ns_streamer, Bop.nttot * dt, 0),
     interpolation="none",
 )
-ax.set_title("Blender CSG")
+ax.set_title("Blended CSG")
 ax.set_xlabel("#Rec")
 ax.set_ylabel("t [s]")
 ax.axis("tight")
@@ -149,7 +149,7 @@ axs[0].imshow(
     cmap="gray",
     vmin=-0.01,
     vmax=0.01,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
 axs[0].set_title("Unblended CRG")
@@ -161,7 +161,7 @@ axs[1].imshow(
     cmap="gray",
     vmin=-0.01,
     vmax=0.01,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
 axs[1].set_title("Pseudo-deblended CRG")
@@ -202,10 +202,10 @@ ax.imshow(
     cmap="gray",
     vmin=-0.1,
     vmax=0.1,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
-ax.set_title("Blender CSG")
+ax.set_title("Blended CSG")
 ax.set_xlabel("#Rec")
 ax.set_ylabel("t [s]")
 ax.axis("tight")
@@ -217,7 +217,7 @@ axs[0].imshow(
     cmap="gray",
     vmin=-0.01,
     vmax=0.01,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
 axs[0].set_title("Unblended CRG")
@@ -229,7 +229,7 @@ axs[1].imshow(
     cmap="gray",
     vmin=-0.01,
     vmax=0.01,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
 axs[1].set_title("Pseudo-deblended CRG")
@@ -268,10 +268,10 @@ ax.imshow(
     cmap="gray",
     vmin=-0.1,
     vmax=0.1,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
-ax.set_title("Blender CSG")
+ax.set_title("Blended CSG")
 ax.set_xlabel("#Rec")
 ax.set_ylabel("t [s]")
 ax.axis("tight")
@@ -283,7 +283,7 @@ axs[0].imshow(
     cmap="gray",
     vmin=-0.01,
     vmax=0.01,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
 axs[0].set_title("Unblended CRG")
@@ -295,7 +295,7 @@ axs[1].imshow(
     cmap="gray",
     vmin=-0.01,
     vmax=0.01,
-    extent=(0, ns_stremer, t[-1], 0),
+    extent=(0, ns_streamer, t[-1], 0),
     interpolation="none",
 )
 axs[1].set_title("Pseudo-deblended CRG")

--- a/pylops/waveeqprocessing/__init__.py
+++ b/pylops/waveeqprocessing/__init__.py
@@ -13,7 +13,9 @@ A list of operators present in pylops.waveeqprocessing:
     UpDownComposition3D             3D Up-down wavefield composition.
     MDC                             Multi-dimensional convolution.
     PhaseShift                      Phase shift operator.
-    Blending                        Blending operator.
+    BlendingContinuous              Continuous Blending operator.
+    BlendingGroup                   Group Blending operator.
+    BlendingHalf                    Half Blending operator.
     Kirchhoff                       Kirchoff demigration operator.
     AcousticWave2D                  Two-way wave equation demigration operator.
 
@@ -49,7 +51,9 @@ __all__ = [
     "WavefieldDecomposition",
     "PhaseShift",
     "Deghosting",
-    "Blending",
+    "BlendingContinuous",
+    "BlendingGroup",
+    "BlendingHalf",
     "Kirchhoff",
     "AcousticWave2D",
     "LSM",

--- a/pylops/waveeqprocessing/__init__.py
+++ b/pylops/waveeqprocessing/__init__.py
@@ -13,6 +13,7 @@ A list of operators present in pylops.waveeqprocessing:
     UpDownComposition3D             3D Up-down wavefield composition.
     MDC                             Multi-dimensional convolution.
     PhaseShift                      Phase shift operator.
+    Blending                        Blending operator.
     Kirchhoff                       Kirchoff demigration operator.
     AcousticWave2D                  Two-way wave equation demigration operator.
 
@@ -27,6 +28,7 @@ and a list of applications:
 
 """
 
+from .blending import *
 from .kirchhoff import *
 from .lsm import *
 from .marchenko import *
@@ -47,6 +49,7 @@ __all__ = [
     "WavefieldDecomposition",
     "PhaseShift",
     "Deghosting",
+    "Blending",
     "Kirchhoff",
     "AcousticWave2D",
     "LSM",

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -86,7 +86,7 @@ class _ContinuousBlending(LinearOperator):
             name=name,
         )
 
-    @reshaped()
+    @reshaped
     def _matvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         blended_data = ncp.zeros((self.nr, self.nttot), dtype=self.dtype)
@@ -98,7 +98,7 @@ class _ContinuousBlending(LinearOperator):
                 blended_data[:, shift_int : shift_int + self.nt + 1] += shifted_data
         return blended_data
 
-    @reshaped()
+    @reshaped
     def _rmatvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         deblended_data = ncp.zeros((self.ns, self.nr, self.nt), dtype=self.dtype)

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -1,0 +1,350 @@
+__all__ = ["Blending"]
+
+import numpy as np
+
+from pylops import LinearOperator
+from pylops.basicoperators import Block, BlockDiag, HStack, Pad
+from pylops.signalprocessing import Shift
+from pylops.utils.backend import get_array_module
+from pylops.utils.decorators import reshaped
+
+
+class _ContinuousBlending(LinearOperator):
+    """Continuous blending operator
+
+    Blend seismic shot gathers in continuous mode based on pre-defined sequence of firing times.
+
+    Parameters
+    ----------
+    nt : :obj:`int`
+        Number of time samples
+    nr : :obj:`int`
+        Number of receivers
+    ns : :obj:`int`
+        Number of sources
+    dt : :obj:`float`
+        Time sampling in seconds
+    times : :obj:`np.ndarray`
+        Dithering ignition times. This the firing time after the last shot.
+    nproc : :obj:`int`, optional
+        Number of processors used when applying operator
+    dtype : :obj:`str`, optional
+        Operator dtype
+
+    """
+
+    def __init__(self, nt, nr, ns, dt, times, dtype="float64", name: str = "B"):
+        self.dtype = np.dtype(dtype)
+        self.nt = nt
+        self.nr = nr
+        self.ns = ns
+        self.dt = dt
+        self.times = times
+        self.nttot = int(np.max(self.times) / self.dt + self.nt + 1)
+        self.PadOp = Pad((self.nr, self.nt), ((0, 0), (0, 1)), dtype=self.dtype)
+        # Define shift operators
+        self.shifts = []
+        self.ShiftOps = []
+        for i in range(self.ns):
+            shift = self.times[i]
+            # This is the part that fits on the grid
+            shift_int = int(shift // self.dt)
+            self.shifts.append(shift_int)
+            # This is the fractional part
+            diff = (shift / self.dt - shift_int) * self.dt
+            if diff == 0:
+                self.ShiftOps.append(None)
+            else:
+                self.ShiftOps.append(
+                    Shift(
+                        (self.nr, self.nt + 1),
+                        diff,
+                        axis=1,
+                        sampling=self.dt,
+                        real=False,
+                        dtype=self.dtype,
+                    )
+                )
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=(self.ns, self.nr, self.nt),
+            dimsd=(self.nr, self.nttot),
+            name=name,
+        )
+
+    @reshaped()
+    def _matvec(self, x):
+        ncp = get_array_module(x)
+        blended_data = ncp.zeros((self.nr, self.nttot), dtype=self.dtype)
+        for i, shift_int in enumerate(self.shifts):
+            if self.ShiftOps[i] is None:
+                blended_data[:, shift_int : shift_int + self.nt] += x[i, :, :]
+            else:
+                shifted_data = self.ShiftOps[i] * self.PadOp * x[i, :, :]
+                blended_data[:, shift_int : shift_int + self.nt + 1] += shifted_data
+        return blended_data
+
+    @reshaped()
+    def _rmatvec(self, x):
+        ncp = get_array_module(x)
+        deblended_data = ncp.zeros((self.ns, self.nr, self.nt), dtype=self.dtype)
+        for i, shift_int in enumerate(self.shifts):
+            if self.ShiftOps[i] is None:
+                deblended_data[i, :, :] = x[:, shift_int : shift_int + self.nt]
+            else:
+                shifted_data = (
+                    self.PadOp.H
+                    * self.ShiftOps[i].H
+                    * x[:, shift_int : shift_int + self.nt + 1]
+                )
+                deblended_data[i, :, :] = shifted_data
+        return deblended_data
+
+
+class _GroupBlending(LinearOperator):
+    """Group blending operator
+
+    Blend seismic shot gathers in group blending mode based on pre-defined
+    sequence of firing times. In group blending a number of spatially closed
+    sources are fired in a short interval. These sources belong to one group.
+    The next group of sources is fired after all the data of the previous
+    group has been recorded.
+
+    Parameters
+    ----------
+    nt : :obj:`int`
+        Number of time samples
+    nr : :obj:`int`
+        Number of receivers
+    ns : :obj:`int`
+        Number of sources. Equal to group_size x n_groups
+    dt : :obj:`float`
+        Time sampling in seconds
+    times : :obj:`np.ndarray`
+        Dithering ignition times.
+    group_size : :obj:`int`
+        The number of sources per group
+    n_groups : :obj:`int`
+        The number of groups
+    dtype : :obj:`str`, optional
+        Operator dtype
+
+    """
+
+    def __init__(
+        self,
+        nt,
+        nr,
+        ns,
+        dt,
+        times,
+        group_size,
+        n_groups,
+        dtype="float64",
+        name: str = "B",
+    ):
+        self.dtype = np.dtype(dtype)
+        self.nt = nt
+        self.nr = nr
+        self.ns = ns
+        self.dt = dt
+        self.group_size = group_size
+        self.n_groups = n_groups
+        self.times = times
+        # Define shift operators
+        self.ShiftOps = []
+        for i in range(n_groups):
+            for j in range(group_size):
+                self.ShiftOps.append(
+                    Shift(
+                        (self.nr, self.nt),
+                        self.times[j, i],
+                        axis=1,
+                        sampling=self.dt,
+                        real=False,
+                        dtype=dtype,
+                    )
+                )
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=(self.ns, self.nr, self.nt),
+            dimsd=(self.n_groups, self.nr, self.nt),
+            name=name,
+        )
+
+    @reshaped()
+    def _matvec(self, x):
+        ncp = get_array_module(x)
+        blended_data = ncp.zeros((self.n_groups, self.nr, self.nt), dtype=self.dtype)
+        for i in range(self.n_groups):
+            # shift n sources and sum them together
+            shifted_signal = ncp.zeros((self.nr, self.nt), dtype=self.dtype)
+            for j in range(self.group_size):
+                shot = x[i * self.group_size + j, :, :]
+                shifted_signal += self.ShiftOps[i * self.group_size + j] * shot
+            blended_data[i, :, :] = shifted_signal
+        return blended_data
+
+    @reshaped()
+    def _rmatvec(self, x):
+        ncp = get_array_module(x)
+        deblended_data = ncp.zeros((self.ns, self.nr, self.nt), dtype=self.dtype)
+        for i in range(self.n_groups):
+            # shift n sources and sum them together
+            shot = x[i, :, :]
+            for j in range(self.group_size):
+                shifted_signal = self.ShiftOps[i * self.group_size + j].H * shot
+                deblended_data[i * self.group_size + j, :, :] = shifted_signal
+        return deblended_data
+
+
+def _HalfBlending(
+    nt, nr, ns, dt, times, group_size, n_groups, nproc=1, dtype="float64", name="B"
+):
+    """Half blending operator
+
+    Blend seismic shot gathers in half blending mode based on pre-defined
+    sequence of firing times. This type of blending assumes that there are
+    multiple sources at different spatial locations firing at the same time.
+    This means that the blended data only partially overlaps in space.
+
+    Parameters
+    ----------
+    nt : :obj:`int`
+        Number of time samples
+    nr : :obj:`int`
+        Number of receivers
+    ns : :obj:`int`
+        Number of sources. Equal to group_size x n_groups
+    dt : :obj:`float`
+        Time sampling in seconds
+    times : :obj:`np.ndarray`
+        Dithering ignition times. This should have dimensions :math`n_{groups} \times group_{size}`,
+        where each row contains the firing times for every group.
+    group_size : :obj:`int`
+        The number of sources per group
+    n_groups : :obj:`int`
+        The number of groups
+    nproc : :obj:`int`, optional
+        Number of processors used when applying operator
+    dtype : :obj:`str`, optional
+        Operator dtype
+    """
+    if times.shape[0] != group_size:
+        raise ValueError("The first dimension of times must equal group_size")
+
+    H = []
+    for j in range(group_size):
+        OpShift = []
+        for i in range(n_groups):
+            ShiftOp = Shift(
+                (nr, nt), times[j, i], axis=1, sampling=dt, real=False, dtype=dtype
+            )
+            OpShift.append(ShiftOp)
+        D = BlockDiag(OpShift, nproc=nproc)
+        H.append(D)
+    Bop = HStack(H)
+    Bop.dims = (ns, nr, nt)
+    Bop.dimsd = (n_groups, nr, nt)
+    Bop.name = name
+    return Bop
+
+
+def Blending(
+    nt,
+    nr,
+    ns,
+    dt,
+    times,
+    group_size=None,
+    n_groups=None,
+    kind="continuous",
+    nproc=1,
+    dtype="float64",
+):
+    r"""Blending operator.
+
+    Blend seismic shot gathers in either of the following blending modes: continuous, group, or half. The size of input
+    model vector must be :math:`n_s \times n_r \times n_t` for any choice of ``kind``, whilst the size of the data
+    vector is :math:`n_r \times n_{t,tot}` for ``kind="continuous"`` and :math:`n_{groups} \times n_r \times n_{t,tot}`
+    for ``kind="group"`` or ``kind="half"``.
+
+    Parameters
+    ----------
+    nt : :obj:`int`
+        Number of time samples
+    nr : :obj:`int`
+        Number of receivers
+    ns : :obj:`int`
+        Number of sources. Equal to group_size x n_groups
+    dt : :obj:`float`
+        Time sampling in seconds
+    times : :obj:`np.ndarray`
+        Dithering ignition times. For both ``kind="group"`` and ``kind="half"``
+        it should have dimensions :math:`n_{groups} \times group_{size}`,
+        where each row contains the firing times for every group.
+    group_size : :obj:`int`, optional
+        Number of sources per group. Not required for ``kind=="continuous"``
+    n_groups : :obj:`int`
+        Number of groups, optional. Not required for ``kind=="continuous"``
+    kind : :obj:`str`, optional
+        Blending type: `continuous`, `group`, or `half`
+    nproc : :obj:`int`, optional
+        Number of processors used when applying the operator (only for ``kind=="half"``)
+    dtype : :obj:`str`, optional
+        Operator dtype
+
+    Returns
+    -------
+    Bop : :obj:`pylops.LinearOperator`
+        Blending operator
+
+    Notes
+    -----
+    Simultaneous shooting or blending is the process of acquiring seismic data firing consecutive sources
+    at short time intervals (shorter than the time requires for all significant waves to come back from the Earth
+    interior). Blending comes in different flavours, and this operator implements three different scenarios:
+
+    - continuous blending: a source towed behind a single vessel is fired at irregular time intervals (``times``) to
+      create a continuous recording
+
+      .. math::
+        \Phi = [\Phi_1, \Phi_2, ..., \Phi_N]
+
+    - group blending: two or more sources are towed behind a single vessel and fired at short time differences. The
+      same experiment is repeated :math:`n_{groups}` times to create :math:`n_{groups}` blended recordings. For the
+      case of 2 sources and an overall number of :math:`N=n_{groups}*group_{size}` shots
+
+    .. math::
+        \Phi = \begin{bmatrix}
+        \Phi_1     & \Phi_2      & \mathbf{0} & \mathbf{0} & ... & \mathbf{0} & \mathbf{0}  \\
+        \mathbf{0} & \mathbf{0}  & \Phi_3     & \Phi_4     & ... & \mathbf{0} & \mathbf{0}  \\
+        ...        & ...         & ...        & ...        & ... & ...        & ...  \\
+        \mathbf{0} & \mathbf{0}  & \mathbf{0} & \mathbf{0} & ... & \Phi_{N-1} & \Phi_{N}
+        \end{bmatrix}
+
+    - half blending: two or more vessels, each with a source are fired at short time differences. The
+      same experiment is repeated :math:`n_{groups}` times to create :math:`n_{groups}` blended recordings. For the
+      case of 2 sources and an overall number of :math:`N=n_{groups}*group_{size}` shots
+
+    .. math::
+        \Phi = \begin{bmatrix}
+        \Phi_1     & \mathbf{0}   & \mathbf{0}    & ...          & \Phi_{N/2}  & \mathbf{0}   & \mathbf{0}    &  \\
+        \mathbf{0} & \Phi_2       & \mathbf{0}    &              & \mathbf{0}  & \Phi_{N/2+1} & \mathbf{0}  \\
+        ...        & ...          & ...           & ...          & ...         & ...          & ...  \\
+        \mathbf{0} & \mathbf{0}   & \mathbf{0}    & \Phi_{N/2-1} & \mathbf{0}  & \mathbf{0}   & \Phi_{N} \\
+        \end{bmatrix}
+
+    """
+
+    if kind == "continuous":
+        Bop = _ContinuousBlending(nt, nr, ns, dt, times, dtype=dtype)
+    elif kind == "group":
+        Bop = _GroupBlending(nt, nr, ns, dt, times, group_size, n_groups, dtype=dtype)
+    elif kind == "half":
+        Bop = _HalfBlending(
+            nt, nr, ns, dt, times, group_size, n_groups, nproc=nproc, dtype=dtype
+        )
+    else:
+        raise NotImplementedError("kind must be continuous, group, or half.")
+    return Bop

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -17,7 +17,7 @@ from pylops.utils.typing import DTypeLike, NDArray
 
 
 class BlendingContinuous(LinearOperator):
-    """Continuous blending operator
+    r"""Continuous blending operator
 
     Blend seismic shot gathers in continuous mode based on pre-defined sequence of firing times.
     The size of input model vector must be :math:`n_s \times n_r \times n_t`, whilst the size of the data
@@ -34,7 +34,7 @@ class BlendingContinuous(LinearOperator):
     dt : :obj:`float`
         Time sampling in seconds
     times : :obj:`np.ndarray`
-        Dithering ignition times. This the firing time after the last shot.
+        Absolute ignition times for each source
     nproc : :obj:`int`, optional
         Number of processors used when applying operator
     dtype : :obj:`str`, optional
@@ -53,6 +53,9 @@ class BlendingContinuous(LinearOperator):
 
       .. math::
         \Phi = [\Phi_1, \Phi_2, ..., \Phi_N]
+
+    where each :math:`\Phi_i` operator applies a time-shift equal to the absolute ignition time provided in the
+    variable ``times``.
 
     """
 
@@ -145,7 +148,7 @@ def BlendingGroup(
     dtype: DTypeLike = "float64",
     name: str = "B",
 ) -> LinearOperator:
-    """Group blending operator
+    r"""Group blending operator
 
     Blend seismic shot gathers in group blending mode based on pre-defined
     sequence of firing times. In group blending a number of spatially closed
@@ -165,8 +168,9 @@ def BlendingGroup(
     dt : :obj:`float`
         Time sampling in seconds
     times : :obj:`np.ndarray`
-        Dithering ignition times. This should have dimensions :math`n_{groups} \times group_{size}`,
-        where each row contains the firing times for every group.
+        Absolute ignition times for each source. This should have dimensions
+        :math:`n_{groups} \times group_{size}`, where each row contains the
+        firing times for every group.
     group_size : :obj:`int`
         The number of sources per group
     n_groups : :obj:`int`
@@ -202,6 +206,9 @@ def BlendingGroup(
         \mathbf{0} & \mathbf{0}  & \mathbf{0} & \mathbf{0} & ... & \Phi_{N-1} & \Phi_{N}
         \end{bmatrix}
 
+    where each :math:`\Phi_i` operator applies a time-shift equal to the absolute ignition time provided in the
+    variable ``times``.
+
     """
     if times.shape[0] != group_size:
         raise ValueError("The first dimension of times must equal group_size")
@@ -233,7 +240,7 @@ def BlendingHalf(
     dtype: DTypeLike = "float64",
     name: str = "B",
 ) -> LinearOperator:
-    """Half blending operator
+    r"""Half blending operator
 
     Blend seismic shot gathers in half blending mode based on pre-defined
     sequence of firing times. This type of blending assumes that there are
@@ -253,8 +260,9 @@ def BlendingHalf(
     dt : :obj:`float`
         Time sampling in seconds
     times : :obj:`np.ndarray`
-        Dithering ignition times. This should have dimensions :math`n_{groups} \times group_{size}`,
-        where each row contains the firing times for every group.
+        Absolute ignition times for each source. This should have dimensions
+        :math`n_{groups} \times group_{size}`, where each row contains the firing
+        times for every group.
     group_size : :obj:`int`
         The number of sources per group
     n_groups : :obj:`int`
@@ -288,6 +296,9 @@ def BlendingHalf(
         ...        & ...          & ...           & ...          & ...         & ...          & ...  \\
         \mathbf{0} & \mathbf{0}   & \mathbf{0}    & \Phi_{N/2-1} & \mathbf{0}  & \mathbf{0}   & \Phi_{N} \\
         \end{bmatrix}
+
+    where each :math:`\Phi_i` operator applies a time-shift equal to the absolute ignition time provided in the
+    variable ``times``.
 
     """
     if times.shape[0] != group_size:

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -38,7 +38,16 @@ class _ContinuousBlending(LinearOperator):
 
     """
 
-    def __init__(self, nt, nr, ns, dt, times, dtype="float64", name: str = "B"):
+    def __init__(
+        self,
+        nt: int,
+        nr: int,
+        ns: int,
+        dt: float,
+        times: NDArray,
+        dtype: DTypeLike = "float64",
+        name: str = "B",
+    ) -> None:
         self.dtype = np.dtype(dtype)
         self.nt = nt
         self.nr = nr
@@ -78,7 +87,7 @@ class _ContinuousBlending(LinearOperator):
         )
 
     @reshaped()
-    def _matvec(self, x):
+    def _matvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         blended_data = ncp.zeros((self.nr, self.nttot), dtype=self.dtype)
         for i, shift_int in enumerate(self.shifts):
@@ -90,7 +99,7 @@ class _ContinuousBlending(LinearOperator):
         return blended_data
 
     @reshaped()
-    def _rmatvec(self, x):
+    def _rmatvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         deblended_data = ncp.zeros((self.ns, self.nr, self.nt), dtype=self.dtype)
         for i, shift_int in enumerate(self.shifts):
@@ -107,17 +116,17 @@ class _ContinuousBlending(LinearOperator):
 
 
 def _GroupBlending(
-    nt,
-    nr,
-    ns,
-    dt,
-    times,
-    group_size,
-    n_groups,
-    nproc=1,
-    dtype="float64",
+    nt: int,
+    nr: int,
+    ns: int,
+    dt: float,
+    times: NDArray,
+    group_size: int,
+    n_groups: int,
+    nproc: int = 1,
+    dtype: DTypeLike = "float64",
     name: str = "B",
-):
+) -> LinearOperator:
     """Group blending operator
 
     Blend seismic shot gathers in group blending mode based on pre-defined
@@ -167,8 +176,17 @@ def _GroupBlending(
 
 
 def _HalfBlending(
-    nt, nr, ns, dt, times, group_size, n_groups, nproc=1, dtype="float64", name="B"
-):
+    nt: int,
+    nr: int,
+    ns: int,
+    dt: float,
+    times: NDArray,
+    group_size: int,
+    n_groups: int,
+    nproc: int = 1,
+    dtype: DTypeLike = "float64",
+    name: str = "B",
+) -> LinearOperator:
     """Half blending operator
 
     Blend seismic shot gathers in half blending mode based on pre-defined

--- a/pytests/test_blending.py
+++ b/pytests/test_blending.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+
+from pylops.utils import dottest
+from pylops.waveeqprocessing import Blending
+
+par = {"nt": 101, "ns": 50, "nr": 20, "dtype": "float64"}
+
+d = np.random.normal(0, 1, (par["ns"], par["nr"], par["nt"]))
+dt = 0.004
+
+
+@pytest.mark.parametrize("par", [(par)])
+def test_Blending_continuous(par):
+    """Dot-test for continuous Blending operator"""
+    np.random.seed(0)
+    # ignition times
+    overlap = 0.5
+    ignition_times = 2.0 * np.random.rand(par["ns"]) - 1.0
+    ignition_times += (
+        np.arange(0, overlap * par["nt"] * par["ns"], overlap * par["nt"]) * dt
+    )
+    ignition_times[0] = 0.0
+    Bop = Blending(
+        par["nt"],
+        par["nr"],
+        par["ns"],
+        dt,
+        ignition_times,
+        kind="continuous",
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        Bop,
+        Bop.nttot * par["nr"],
+        par["nt"] * par["ns"] * par["nr"],
+    )
+
+
+@pytest.mark.parametrize("par", [(par)])
+def test_Blending_group(par):
+    """Dot-test for group Blending operator"""
+    np.random.seed(0)
+    group_size = 2
+    n_groups = par["ns"] // group_size
+    ignition_times = 0.8 * np.random.rand(par["ns"])
+
+    Bop = Blending(
+        par["nt"],
+        par["nr"],
+        par["ns"],
+        dt,
+        ignition_times.reshape(group_size, n_groups),
+        n_groups=n_groups,
+        group_size=group_size,
+        kind="group",
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        Bop,
+        par["nt"] * n_groups * par["nr"],
+        par["nt"] * par["ns"] * par["nr"],
+    )
+
+
+@pytest.mark.parametrize("par", [(par)])
+def test_Blending_half(par):
+    """Dot-test for half Blending operator"""
+    np.random.seed(0)
+    group_size = 2
+    n_groups = par["ns"] // group_size
+    ignition_times = 0.8 * np.random.rand(par["ns"])
+
+    Bop = Blending(
+        par["nt"],
+        par["nr"],
+        par["ns"],
+        dt,
+        ignition_times.reshape(group_size, n_groups),
+        n_groups=n_groups,
+        group_size=group_size,
+        kind="half",
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        Bop,
+        par["nt"] * n_groups * par["nr"],
+        par["nt"] * par["ns"] * par["nr"],
+    )

--- a/pytests/test_blending.py
+++ b/pytests/test_blending.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from pylops.utils import dottest
-from pylops.waveeqprocessing import Blending
+from pylops.waveeqprocessing import BlendingContinuous, BlendingGroup, BlendingHalf
 
 par = {"nt": 101, "ns": 50, "nr": 20, "dtype": "float64"}
 
@@ -21,13 +21,12 @@ def test_Blending_continuous(par):
         np.arange(0, overlap * par["nt"] * par["ns"], overlap * par["nt"]) * dt
     )
     ignition_times[0] = 0.0
-    Bop = Blending(
+    Bop = BlendingContinuous(
         par["nt"],
         par["nr"],
         par["ns"],
         dt,
         ignition_times,
-        kind="continuous",
         dtype=par["dtype"],
     )
     assert dottest(
@@ -45,7 +44,7 @@ def test_Blending_group(par):
     n_groups = par["ns"] // group_size
     ignition_times = 0.8 * np.random.rand(par["ns"])
 
-    Bop = Blending(
+    Bop = BlendingGroup(
         par["nt"],
         par["nr"],
         par["ns"],
@@ -53,7 +52,6 @@ def test_Blending_group(par):
         ignition_times.reshape(group_size, n_groups),
         n_groups=n_groups,
         group_size=group_size,
-        kind="group",
         dtype=par["dtype"],
     )
     assert dottest(
@@ -71,7 +69,7 @@ def test_Blending_half(par):
     n_groups = par["ns"] // group_size
     ignition_times = 0.8 * np.random.rand(par["ns"])
 
-    Bop = Blending(
+    Bop = BlendingHalf(
         par["nt"],
         par["nr"],
         par["ns"],
@@ -79,7 +77,6 @@ def test_Blending_half(par):
         ignition_times.reshape(group_size, n_groups),
         n_groups=n_groups,
         group_size=group_size,
-        kind="half",
         dtype=par["dtype"],
     )
     assert dottest(

--- a/tutorials/deblending.py
+++ b/tutorials/deblending.py
@@ -21,7 +21,7 @@ Here :math:`\mathbf{d} = [\mathbf{d}_1^T, \mathbf{d}_2^T,\ldots,
 \boldsymbol\Phi_N]` is the blending operator, :math:`\mathbf{d}^b` is the
 so-called supergather than contains all shots superimposed to each other.
 
-In order to successfully invert this severely underdetermined problem, two key
+In order to successfully invert this severely under-determined problem, two key
 ingredients must be introduced:
 
 - the firing time of each source (i.e., shifts of the blending operator) must be
@@ -86,7 +86,7 @@ ignition_times = 2.0 * np.random.rand(ns) - 1.0
 ignition_times = np.arange(0, overlap * nt * ns, overlap * nt) * dt + ignition_times
 ignition_times[0] = 0.0
 Bop = pylops.waveeqprocessing.Blending(
-    nt, 1, ns, dt, ignition_times, kind="continous", dtype="complex128"
+    nt, 1, ns, dt, ignition_times, kind="continuous", dtype="complex128"
 )
 
 data_blended = Bop * data[:, np.newaxis]

--- a/tutorials/deblending.py
+++ b/tutorials/deblending.py
@@ -85,8 +85,8 @@ overlap = 0.5
 ignition_times = 2.0 * np.random.rand(ns) - 1.0
 ignition_times = np.arange(0, overlap * nt * ns, overlap * nt) * dt + ignition_times
 ignition_times[0] = 0.0
-Bop = pylops.waveeqprocessing.Blending(
-    nt, 1, ns, dt, ignition_times, kind="continuous", dtype="complex128"
+Bop = pylops.waveeqprocessing.BlendingContinuous(
+    nt, 1, ns, dt, ignition_times, dtype="complex128"
 )
 
 data_blended = Bop * data[:, np.newaxis]

--- a/tutorials/deblending.py
+++ b/tutorials/deblending.py
@@ -53,7 +53,7 @@ plt.close("all")
 # We can now load and display a small portion of the MobilAVO dataset composed
 # of 60 shots and a single receiver. This data is unblended.
 
-data = np.load("../../pylops/testdata/deblending/mobil.npy")
+data = np.load("../testdata/deblending/mobil.npy")
 ns, nt = data.shape
 
 dt = 0.004

--- a/tutorials/deblending.py
+++ b/tutorials/deblending.py
@@ -5,9 +5,9 @@ The cocktail party problem arises when sounds from different sources mix before 
 (or any recording device), requiring the brain (or any hardware in the recording device) to estimate
 individual sources from the received mixture. In seismic acquisition, an analog problem is present
 when multiple sources are fired simultaneously. This family of acquisition methods is usually referred to as
-simultaneous shooting and the problem of separating the blendend shot gathers into their individual
+simultaneous shooting and the problem of separating the blended shot gathers into their individual
 components is called deblending. Whilst various firing strategies can be adopted, in this example
-we consider the continuos blending problem where a single source is fired sequentially at an interval
+we consider the continuous blending problem where a single source is fired sequentially at an interval
 shorter than the amount of time required for waves to travel into the Earth and come back.
 
 Simply stated the forward problem can be written as:
@@ -26,7 +26,7 @@ ingredients must be introduced:
 
 - the firing time of each source (i.e., shifts of the blending operator) must be
   chosen to be dithered around a nominal regular, periodic firing interval.
-  In our case, we consider shots of duration :math:`T=4s`, regular firing time of :math:`T_s=2s`
+  In our case, we consider shots of duration :math:`T=4\,\text{s}`, regular firing time of :math:`T_s=2\,\text{s}`
   and a dithering code as follows :math:`\Delta t = U(-1,1)`;
 - prior information about the data to reconstruct, either in the form of regularization
   or preconditioning must be introduced. In our case we will use a patch-FK transform

--- a/tutorials/deblending.py
+++ b/tutorials/deblending.py
@@ -49,27 +49,11 @@ import pylops
 np.random.seed(10)
 plt.close("all")
 
-
-###############################################################################
-# Let's start by defining a blending operator
-def Blending(nt, ns, dt, overlap, times, dtype="float64"):
-    """Blending operator"""
-    pad = int(overlap * nt)
-    OpShiftPad = []
-    for i in range(ns):
-        PadOp = pylops.Pad(nt, (pad * i, pad * (ns - 1 - i)), dtype=dtype)
-        ShiftOp = pylops.signalprocessing.Shift(
-            pad * (ns - 1) + nt, times[i], axis=0, sampling=dt, real=False, dtype=dtype
-        )
-        OpShiftPad.append(ShiftOp * PadOp)
-    return pylops.HStack(OpShiftPad)
-
-
 ###############################################################################
 # We can now load and display a small portion of the MobilAVO dataset composed
 # of 60 shots and a single receiver. This data is unblended.
 
-data = np.load("../testdata/deblending/mobil.npy")
+data = np.load("../../pylops/testdata/deblending/mobil.npy")
 ns, nt = data.shape
 
 dt = 0.004
@@ -98,11 +82,15 @@ plt.tight_layout()
 # some burst like noise in the data. Deblending can hopefully fix this.
 
 overlap = 0.5
-pad = int(overlap * nt)
 ignition_times = 2.0 * np.random.rand(ns) - 1.0
-Bop = Blending(nt, ns, dt, overlap, ignition_times, dtype="complex128")
-data_blended = Bop * data.ravel()
-data_pseudo = Bop.H * data_blended.ravel()
+ignition_times = np.arange(0, overlap * nt * ns, overlap * nt) * dt + ignition_times
+ignition_times[0] = 0.0
+Bop = pylops.waveeqprocessing.Blending(
+    nt, 1, ns, dt, ignition_times, kind="continous", dtype="complex128"
+)
+
+data_blended = Bop * data[:, np.newaxis]
+data_pseudo = Bop.H * data_blended
 data_pseudo = data_pseudo.reshape(ns, nt)
 
 fig, ax = plt.subplots(1, 1, figsize=(12, 8))
@@ -149,16 +137,15 @@ alpha = 1.0 / maxeig
 niter = 60
 decay = (np.exp(-0.05 * np.arange(niter)) + 0.2) / 1.2
 
-with pylops.disabled_ndarray_multiplication():
-    p_inv = pylops.optimization.sparsity.fista(
-        Op,
-        data_blended.ravel(),
-        niter=niter,
-        eps=5e0,
-        alpha=alpha,
-        decay=decay,
-        show=True,
-    )[0]
+p_inv = pylops.optimization.sparsity.fista(
+    Op,
+    data_blended.ravel(),
+    niter=niter,
+    eps=5e0,
+    alpha=alpha,
+    decay=decay,
+    show=True,
+)[0]
 data_inv = Sop * p_inv
 data_inv = data_inv.reshape(ns, nt)
 


### PR DESCRIPTION
This PR introduces a new operator, namely `pylops.waveeqprocessing.blending.Blending` which implements the blending of seismic data (or any acoustic data acquired in similar fashion) for simultaneous shooting applications. 

This is based on @NickLuiken work and refractored to be consistent with PyLopsv2 operators' layout. It comprises of 3 private functions/classes implementing the following blending strategies:

- Continouos
- Group
- Half

and a public class which exposes all of them in the same manner (same inputs and shapes of model/data).

Moreover, this PR modifies the Deblending tutorial to use now this operator instead of an operator defined within the example.