### PR TITLE
Improve #463

### DIFF
--- a/pylops/signalprocessing/_nonstatconvolve2d_cuda.py
+++ b/pylops/signalprocessing/_nonstatconvolve2d_cuda.py
@@ -3,7 +3,7 @@ from math import floor
 from numba import cuda
 
 
-@cuda.jit
+@cuda.jit(max_registers=40)
 def _matvec_rmatvec(x, y, hs, hshape, xdims, ohx, ohz, dhx, dhz, nhx, nhz, rmatvec):
     """Cuda kernels for NonStationaryConvolve2D operator
 

--- a/pylops/signalprocessing/nonstatconvolve1d.py
+++ b/pylops/signalprocessing/nonstatconvolve1d.py
@@ -23,12 +23,12 @@ class NonStationaryConvolve1D(LinearOperator):
     dims : :obj:`list` or :obj:`int`
         Number of samples for each dimension
     hs : :obj:`numpy.ndarray`
-        Bank of 1d compact filters of size :math:`n_{filts} \times n_h`.
+        Bank of 1d compact filters of size :math:`n_\text{filts} \times n_h`.
         Filters must have odd number of samples and are assumed to be
         centered in the middle of the filter support.
     ih : :obj:`tuple`
         Indices of the locations of the filters ``hs`` in the model (and data). Note
-        that the filters must be regularly sampled, i.e. :math:`dh=diff(ih)=const`
+        that the filters must be regularly sampled, i.e. :math:`dh=\text{diff}(ih)=\text{const.}`
     axis : :obj:`int`, optional
         Axis along which convolution is applied
     dtype : :obj:`str`, optional
@@ -64,18 +64,18 @@ class NonStationaryConvolve1D(LinearOperator):
         \begin{bmatrix}
            \hat{h}_{0,0} & h_{1,0} & \hat{h}_{2,0} & h_{3,0} & \hat{h}_{4,0} \\
            \hat{h}_{0,1} & h_{1,1} & \hat{h}_{2,1} & h_{3,1} & \hat{h}_{4,1} \\
-           ...           & ...     & ...           & ...     & ...           \\
+           \vdots        & \vdots  & \vdots        & \vdots  & \vdots        \\
            \hat{h}_{0,4} & h_{1,4} & \hat{h}_{2,4} & h_{3,4} & \hat{h}_{4,4} \\
         \end{bmatrix}
         \begin{bmatrix}
-           x_0 \\ x_1 \\ ... \\ x_4
+           x_0 \\ x_1 \\ \vdots \\ x_4
         \end{bmatrix}
 
-    where :math:`\mathbf{h}_1 = [h_{1,0}, h_{1,1}, ..., h_{1,N}]` and
-    :math:`\mathbf{h}_3 = [h_{3,0}, h_{3,1}, ..., h_{3,N}]` are the provided filter,
+    where :math:`\mathbf{h}_1 = [h_{1,0}, h_{1,1}, \ldots, h_{1,N}]` and
+    :math:`\mathbf{h}_3 = [h_{3,0}, h_{3,1}, \ldots, h_{3,N}]` are the provided filter,
     :math:`\hat{\mathbf{h}}_0 = \mathbf{h}_1` and :math:`\hat{\mathbf{h}}_4 = \mathbf{h}_3` are the
     filters outside the range of the provided filters (which are extrapolated to be the same as
-    the nearest provided filter) and :math:`\hat{\mathbf{h}}_2 = 0.5 * \mathbf{h}_1 + 0.5 * \mathbf{h}_3`
+    the nearest provided filter) and :math:`\hat{\mathbf{h}}_2 = 0.5 \mathbf{h}_1 + 0.5 \mathbf{h}_3`
     is the filter within the range of the provided filters (which is linearly interpolated from the two nearest
     provided filter on either side of its location).
 

--- a/pylops/signalprocessing/nonstatconvolve1d.py
+++ b/pylops/signalprocessing/nonstatconvolve1d.py
@@ -93,7 +93,7 @@ class NonStationaryConvolve1D(LinearOperator):
         axis: int = -1,
         dtype: DTypeLike = "float64",
         name: str = "C",
-    ) -> LinearOperator:
+    ) -> None:
         if hs.shape[1] % 2 == 0:
             raise ValueError("filters hs must have odd length")
         if len(np.unique(np.diff(ih))) > 1:
@@ -111,11 +111,13 @@ class NonStationaryConvolve1D(LinearOperator):
     @property
     def hsinterp(self):
         ncp = get_array_module(self.hs)
-        _hsinterp = ncp.empty((self.dims[self.axis], self.hsize), dtype=self.dtype)
+        self._hsinterp = ncp.empty((self.dims[self.axis], self.hsize), dtype=self.dtype)
 
         for ix in range(self.dims[self.axis]):
-            _hsinterp[ix] = self._interpolate_h(self.hs, ix, self.oh, self.dh, self.nh)
-        return _hsinterp
+            self._hsinterp[ix] = self._interpolate_h(
+                self.hs, ix, self.oh, self.dh, self.nh
+            )
+        return self._hsinterp
 
     @hsinterp.deleter
     def hsinterp(self):

--- a/pylops/signalprocessing/nonstatconvolve2d.py
+++ b/pylops/signalprocessing/nonstatconvolve2d.py
@@ -138,7 +138,7 @@ class NonStationaryConvolve2D(LinearOperator):
         self.ohx, self.dhx, self.nhx = ihx[0], ihx[1] - ihx[0], len(ihx)
         self.ohz, self.dhz, self.nhz = ihz[0], ihz[1] - ihz[0], len(ihz)
         self.ehx, self.ehz = ihx[-1], ihz[-1]
-        self.dims = dims
+        self.dims = _value_or_sized_to_tuple(dims)
         self.engine = engine
         super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dims, name=name)
 

--- a/pylops/signalprocessing/nonstatconvolve2d.py
+++ b/pylops/signalprocessing/nonstatconvolve2d.py
@@ -40,15 +40,15 @@ class NonStationaryConvolve2D(LinearOperator):
         Number of samples for each dimension
     hs : :obj:`numpy.ndarray`
         Bank of 2d compact filters of size
-        :math:`n_{filts,x} \times n_{filts,z} \times n_h \times n_{h,x} \times n_{h,z}`.
+        :math:`n_{\text{filts},x} \times n_{\text{filts},z} \times n_h \times n_{h,x} \times n_{h,z}`.
         Filters must have odd number of samples and are assumed to be
         centered in the middle of the filter support.
     ihx : :obj:`tuple`
         Indices of the x locations of the filters ``hs`` in the model (and data). Note
-        that the filters must be regularly sampled, i.e. :math:`dh_x=diff(ihx)=const`
+        that the filters must be regularly sampled, i.e. :math:`dh_x=\text{diff}(ihx)=\text{const.}`
     ihz : :obj:`tuple`
         Indices of the z locations of the filters ``hs`` in the model (and data). Note
-        that the filters must be regularly sampled, i.e. :math:`dh_z=diff(ihz)=const`
+        that the filters must be regularly sampled, i.e. :math:`dh_z=\text{diff}(ihz)=\text{const.}`
     engine : :obj:`str`, optional
         Engine used for spread computation (``numpy``, ``numba``, or ``cuda``)
     num_threads_per_blocks : :obj:`tuple`, optional
@@ -71,7 +71,7 @@ class NonStationaryConvolve2D(LinearOperator):
     ValueError
         If filters ``hs`` have even size
     ValueError
-        If ``ihx`` or `ihz`` is not regularly sampled
+        If ``ihx`` or ``ihz`` is not regularly sampled
     NotImplementedError
         If ``engine`` is neither ``numpy``, ``fftw``, nor ``scipy``.
 
@@ -87,22 +87,22 @@ class NonStationaryConvolve2D(LinearOperator):
     .. math::
         \mathbf{y} =
         \begin{bmatrix}
-           \hat{h}_{(0,0),(0,0)} & ... & h_{(1,1),(0,0)} & ... & \hat{h}_{(2,2),(0,0)} & ...  \\
-           \hat{h}_{(0,0),(0,1)} & ... & h_{(1,1),(0,1)} & ... & \hat{h}_{(2,2),(0,0)} & ...  \\
-           ...                   & ... &                 & ... & ...                   & ...  \\
-           \hat{h}_{(0,0),(4,3)} & ... & h_{(1,1),(4,3)} & ... & \hat{h}_{(2,2),(0,0)} & ...  \\
+           \hat{h}_{(0,0),(0,0)} & \cdots & h_{(1,1),(0,0)} & \cdots & \hat{h}_{(2,2),(0,0)} & \cdots  \\
+           \hat{h}_{(0,0),(0,1)} & \cdots & h_{(1,1),(0,1)} & \cdots & \hat{h}_{(2,2),(0,0)} & \cdots  \\
+           \vdots                & \ddots &                 & \ddots & \vdots                & \vdots  \\
+           \hat{h}_{(0,0),(4,3)} & \cdots & h_{(1,1),(4,3)} & \cdots & \hat{h}_{(2,2),(0,0)} & \cdots  \\
         \end{bmatrix}
         \begin{bmatrix}
-           x_{0,0} \\ ... \\ x_{0,N} \\ x_{1,0} \\ ... \\
-           x_{1,N} \\ x_{M,0} \\ ... \\ x_{M,N}
+           x_{0,0} \\ \vdots \\ x_{0,N} \\ x_{1,0} \\ \vdots \\
+           x_{1,N} \\ x_{M,0} \\ \vdots \\ x_{M,N}
         \end{bmatrix}
 
-    where :math:`\mathbf{h}_{(1,1)} = [h_{(1,1),(0,0)}, h_{(1,1),(0,1)}, ..., h_{(1,1),(4,3)}]`
+    where :math:`\mathbf{h}_{(1,1)} = [h_{(1,1),(0,0)}, h_{(1,1),(0,1)}, \ldots, h_{(1,1),(4,3)}]`
     (and :math:`\mathbf{h}_{(1,1)}`, :math:`\mathbf{h}_{(1,3)}`, :math:`\mathbf{h}_{(3,1)}`,
     :math:`\mathbf{h}_{(3,3)}`) are the provided filter, :math:`\hat{\mathbf{h}}_{(0,0)} =
     \mathbf{h}_{(1,1)}` and similar are the filters outside the range of the provided filters
     (which are extrapolated to be the same as the nearest provided filter) and
-    :math:`\hat{\mathbf{h}}_{(2,2)} = BiLinear(\mathbf{h}_{(1,1)}, \mathbf{h}_{(3,1)},
+    :math:`\hat{\mathbf{h}}_{(2,2)} = \text{bilinear}(\mathbf{h}_{(1,1)}, \mathbf{h}_{(3,1)},
     \mathbf{h}_{(1,3)},\mathbf{h}_{(3,3)})` is the filter within the range of the provided filters
     (which is bilinearly interpolated from the four nearest provided filter on either side
     of its location).

--- a/tutorials/ilsm.py
+++ b/tutorials/ilsm.py
@@ -153,11 +153,11 @@ kopdyn = pylops.waveeqprocessing.Kirchhoff(
     engine="numba",
 )
 
-d = kop * refl
-mmig = kopdyn.H * d
+d = kop @ refl
+mmig = kopdyn.H @ d
 
-dpsf = kop * psfrefl
-mmigpsf = kopdyn.H * dpsf
+dpsf = kop @ psfrefl
+mmigpsf = kopdyn.H @ dpsf
 
 fig, axs = plt.subplots(1, 2, figsize=(10, 6))
 axs[0].imshow(
@@ -215,8 +215,7 @@ Cop = pylops.signalprocessing.NonStationaryConvolve2D(
     hs=psfs, ihx=psfx, ihz=psfz, dims=(nx, nz), engine="numba"
 )
 
-mmigpsf = Cop * refl.ravel()
-mmigpsf = mmigpsf.reshape(nx, nz)
+mmigpsf = Cop @ refl
 
 fig, axs = plt.subplots(1, 2, figsize=(10, 5))
 axs[0].imshow(


### PR DESCRIPTION
This PR fixes some of the issues in #463. Importantly, it limits the number of registers used in the cuda version of `_matvec_rmatvec`. Not doing so causes [this bug](https://stackoverflow.com/questions/68658970/why-launching-a-numba-cuda-kernel-works-with-up-to-640-threads-but-fails-with-6) on my machine.

@mrava87 please check the comments in this PR for further improvements to the code.