### PR TITLE
Made LinearOperator independent of spLinearOperator

### DIFF
--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -1306,6 +1306,7 @@ class _TransposeLinearOperator(LinearOperator):
 
 
 class _ProductLinearOperator(LinearOperator):
+    """ Product of Linear Operators """
     def __init__(self, A: LinearOperator, B: LinearOperator):
         if not isinstance(A, LinearOperator) or not isinstance(B, LinearOperator):
             raise ValueError(f"both operands have to be a LinearOperator{type(A)} {type(B)}")


### PR DESCRIPTION
For issue #328 
- Added `_AdjointLinearOperator`, `_TransposeLinearOperator` and `_ProductLinearOperator`
- Added methods  `__matmul__`, `__rmatmul__` , `transpose` and `adjoint`
- Made all classes extend the `LinearOperator`

Still need to update the docs...