### PR TITLE
Made LinearOperator independent of spLinearOperator

### DIFF
--- a/docs/source/adding.rst
+++ b/docs/source/adding.rst
@@ -23,10 +23,6 @@ which will be used as *parent* class for any of our operators:
 
    from pylops import LinearOperator
 
-This class is a child of the
-:py:class:`scipy.sparse.linalg.LinearOperator` class itself which implements the same methods of its parent class
-as well as an additional method for quick inversion: such method can be easily accessed by using ``\`` between the
-operator and the data (e.g., ``A \ y``).
 
 After that we define our new object:
 

--- a/docs/source/adding.rst
+++ b/docs/source/adding.rst
@@ -23,6 +23,11 @@ which will be used as *parent* class for any of our operators:
 
    from pylops import LinearOperator
 
+This class was originally defined as a child of the :py:class:`scipy.sparse.linalg.LinearOperator`, implementing
+the same methods of its parent class as well as additional methods for quick inversion (e.g., ``A \ y``),
+eigenvalues computation, conversion to dense matrices, etc. From version ``v2.1`` onwards, our linear operator
+class has become stand-alone; however, by keeping the same naming structure of the original scipy class, we still
+allow inter-operability with scipy-native linear operators and solvers.
 
 After that we define our new object:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,19 +48,17 @@ such as `Basic Earth Imaging <http://sepwww.stanford.edu/sep/prof/bei11.2010.pdf
 
 Implementation
 --------------
-PyLops is build on top of the `scipy <http://www.scipy.org/scipylib/index.html>`_ class :py:class:`scipy.sparse.linalg.LinearOperator`.
+PyLops is build on top of the class :py:class:`pylops.linearoperator.LinearOperator`.
 
 This class allows in fact for the creation of objects (or interfaces) for matrix-vector and matrix-matrix products
 that can ultimately be used to solve any inverse problem of the form :math:`\mathbf{y}=\mathbf{A}\mathbf{x}`.
 
-As explained in the `scipy LinearOperator <https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html>`_
-official documentation, to construct a :py:class:`scipy.sparse.linalg.LinearOperator`, a user is required to pass appropriate callables
+To construct a :py:class:`pylops.linearoperator.LinearOperator`, a user is required to pass appropriate arguments
 to the constructor of this class, or subclass it. More specifically one of the methods ``_matvec`` and ``_matmat`` must be implemented for
 the *forward operator* and one of the methods ``_rmatvec`` or ``_adjoint`` may be implemented to apply the *Hermitian adjoint*.
-The attributes/properties ``shape`` (pair of integers) and ``dtype`` (may be None) must also be provided during ``__init__`` of this class.
 
 Any linear operator developed within the PyLops library follows this philosophy. As explained more in details in :ref:`addingoperator` section,
-a linear operator is created by subclassing the :py:class:`scipy.sparse.linalg.LinearOperator` class and ``_matvec`` and ``_rmatvec`` are implemented.
+a linear operator is created by subclassing the :py:class:`pylops.linearoperator.LinearOperator` class and ``_matvec`` and ``_rmatvec`` are implemented.
 
 
 History

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,6 @@ PyLops offers such solvers for many different types of problems, in particular l
 Get started by :ref:`installing PyLops <Installation>` and following our quick tour.
 
 
-
 Terminology
 -----------
 A common *terminology* is used within the entire documentation of PyLops. Every linear operator and its application to
@@ -48,17 +47,22 @@ such as `Basic Earth Imaging <http://sepwww.stanford.edu/sep/prof/bei11.2010.pdf
 
 Implementation
 --------------
-PyLops is build on top of the class :py:class:`pylops.linearoperator.LinearOperator`.
+PyLops was originally build on top of the `scipy <http://www.scipy.org/scipylib/index.html>`_ class
+:py:class:`scipy.sparse.linalg.LinearOperator`.  From version ``v2.1`` onwards, whilst still being heavily inspired
+by its scipy counterpart, PyLops's :py:class:`pylops.linearoperator.LinearOperator` has become a stand-alone class.
 
-This class allows in fact for the creation of objects (or interfaces) for matrix-vector and matrix-matrix products
+This class allows for the creation of objects (or interfaces) for matrix-vector and matrix-matrix products
 that can ultimately be used to solve any inverse problem of the form :math:`\mathbf{y}=\mathbf{A}\mathbf{x}`.
 
 To construct a :py:class:`pylops.linearoperator.LinearOperator`, a user is required to pass appropriate arguments
 to the constructor of this class, or subclass it. More specifically one of the methods ``_matvec`` and ``_matmat`` must be implemented for
 the *forward operator* and one of the methods ``_rmatvec`` or ``_adjoint`` may be implemented to apply the *Hermitian adjoint*.
+The attributes/properties ``dtype`` (may be None) and ``shape`` (pair of integers) -- or alternatively ``dims`` and ``dimsd`` --
+must also be provided during ``__init__`` of this class.
 
 Any linear operator developed within the PyLops library follows this philosophy. As explained more in details in :ref:`addingoperator` section,
-a linear operator is created by subclassing the :py:class:`pylops.linearoperator.LinearOperator` class and ``_matvec`` and ``_rmatvec`` are implemented.
+a linear operator is created by subclassing the :py:class:`pylops.linearoperator.LinearOperator` class and implementing the
+``_matvec`` and ``_rmatvec``.
 
 
 History

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -43,11 +43,11 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 class LinearOperator:
     """Common interface for performing matrix-vector products.
 
-    This class is an overload of the
-    :py:class:`scipy.sparse.linalg.LinearOperator` class. It adds
-    functionalities by overloading standard operators such as ``__truediv__``
-    as well as creating convenience methods such as ``eigs``, ``cond``, and
-    ``conj``.
+    This class provides various iterative vector solvers, to solve a
+    linear system A*x=b.
+
+    To construct a concrete LinearOperator, either pass appropriate
+    arguments to the constructor of this class, or subclass it.
 
     .. note:: End users of PyLops should not use this class directly but simply
       use operators that are already implemented. This class is meant for
@@ -57,7 +57,7 @@ class LinearOperator:
 
     Parameters
     ----------
-    Op : :obj:`scipy.sparse.linalg.LinearOperator` or :obj:`scipy.sparse.linalg._ProductLinearOperator` or :obj:`scipy.sparse.linalg._SumLinearOperator`
+    Op : :obj:`scipy.sparse.linalg.LinearOperator` or :obj:`pylops.linearoperator.LinearOperator`
         Operator. If other arguments are provided, they will overwrite those obtained from ``Op``.
     dtype : :obj:`str`, optional
         Type of elements in input array.

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -45,7 +45,9 @@ class LinearOperator:
 
     This class acts as an abstract interface between matrix-like
     objects and iterative solvers, providing methods to perform
-    matrix-vector and adjoint matrix-vector products.
+    matrix-vector and adjoint matrix-vector products as as
+    well as convenience methods such as ``eigs``, ``cond``, and
+    ``conj``.
 
     .. note:: End users of PyLops should not use this class directly but simply
       use operators that are already implemented. This class is meant for

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -290,10 +290,10 @@ class LinearOperator:
                 setattr(dest, attr, getattr(self, attr))
 
     def _matvec(self, x: NDArray) -> NDArray:
-        return self.Op._matvec(x)
+        return self.Op.matmat(x.reshape(-1, 1))
 
     def _rmatvec(self, x: NDArray) -> NDArray:
-        return self.Op._rmatvec(x)
+        return self.Op.H.matvec(x)
 
     def _matmat(self, X: NDArray) -> NDArray:
         """Matrix-matrix multiplication handler.

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -43,11 +43,9 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 class LinearOperator:
     """Common interface for performing matrix-vector products.
 
-    This class provides various iterative vector solvers, to solve a
-    linear system A*x=b.
-
-    To construct a concrete LinearOperator, either pass appropriate
-    arguments to the constructor of this class, or subclass it.
+    This class acts as an abstract interface between matrix-like
+    objects and iterative solvers, providing methods to perform
+    matrix-vector and adjoint matrix-vector products.
 
     .. note:: End users of PyLops should not use this class directly but simply
       use operators that are already implemented. This class is meant for

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -276,6 +276,7 @@ class LinearOperator:
                 Op,
                 exclude=[
                     "explicit",
+                    "name",
                 ],
             )
             Op.explicit = False
@@ -295,6 +296,7 @@ class LinearOperator:
                 Op,
                 exclude=[
                     "explicit",
+                    "name",
                 ],
             )
             Op.explicit = False
@@ -312,6 +314,7 @@ class LinearOperator:
                 Op,
                 exclude=[
                     "explicit",
+                    "name",
                 ],
             )
             Op.clinear = Op.clinear and Opx.clinear
@@ -331,6 +334,7 @@ class LinearOperator:
             Op,
             exclude=[
                 "explicit",
+                "name",
             ],
         )
         Op.explicit = False
@@ -407,7 +411,7 @@ class LinearOperator:
         return Op
 
     def _transpose(self) -> LinearOperator:
-        Op = _TransposeLinearOperator(self)
+        Op = _TransposedLinearOperator(self)
         self._copy_attributes(Op, exclude=["dims", "dimsd", "explicit", "name"])
         Op.explicit = False
         Op.dims = self.dimsd
@@ -573,9 +577,7 @@ class LinearOperator:
             Op = LinearOperator(Op=_ScaledLinearOperator(self, x))
             self._copy_attributes(
                 Op,
-                exclude=[
-                    "explicit",
-                ],
+                exclude=["explicit", "name"],
             )
             Op.explicit = False
             return Op
@@ -1292,12 +1294,12 @@ class _AdjointLinearOperator(LinearOperator):
         return self.A._matmat(X)
 
 
-class _TransposeLinearOperator(LinearOperator):
+class _TransposedLinearOperator(LinearOperator):
     """Transposition of Linear Operator"""
 
     def __init__(self, A: LinearOperator):
         shape = (A.shape[1], A.shape[0])
-        super(_TransposeLinearOperator, self).__init__(shape=shape, dtype=A.dtype)
+        super(_TransposedLinearOperator, self).__init__(shape=shape, dtype=A.dtype)
         self.A = A
         self.args = (A,)
 

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -1306,6 +1306,7 @@ class _TransposeLinearOperator(LinearOperator):
 
 
 class _ProductLinearOperator(LinearOperator):
+    """ Product of Linear Operators """
     def __init__(self, A: LinearOperator, B: LinearOperator):
         if not isinstance(A, LinearOperator) or not isinstance(B, LinearOperator):
             raise ValueError(f"both operands have to be a LinearOperator{type(A)} {type(B)}")

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -4,7 +4,9 @@ import logging
 import random
 import string
 
+"""
 import scipy as sp
+
 
 # need to check scipy version since the interface submodule changed into
 # _interface from scipy>=1.8.0
@@ -21,12 +23,19 @@ else:
         _ProductLinearOperator,
         _TransposedLinearOperator,
     )
+"""
 
 from typing import List, Set, Union
 
 from pylops import LinearOperator
 from pylops.basicoperators import BlockDiag, HStack, VStack
-from pylops.linearoperator import _ScaledLinearOperator, _SumLinearOperator
+from pylops.linearoperator import (
+    _AdjointLinearOperator,
+    _ProductLinearOperator,
+    _ScaledLinearOperator,
+    _SumLinearOperator,
+    _TransposedLinearOperator,
+)
 from pylops.utils import deps
 
 sympy_message = deps.sympy_import("the describe module")
@@ -299,7 +308,6 @@ def describe(Op) -> None:
     """
     if sympy_message is not None:
         raise NotImplementedError(sympy_message)
-
     # Describe the operator
     Ops = {}
     names = set()

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -4,27 +4,6 @@ import logging
 import random
 import string
 
-"""
-import scipy as sp
-
-
-# need to check scipy version since the interface submodule changed into
-# _interface from scipy>=1.8.0
-sp_version = sp.__version__.split(".")
-if int(sp_version[0]) <= 1 and int(sp_version[1]) < 8:
-    from scipy.sparse.linalg.interface import (
-        _AdjointLinearOperator,
-        _ProductLinearOperator,
-        _TransposedLinearOperator,
-    )
-else:
-    from scipy.sparse.linalg._interface import (
-        _AdjointLinearOperator,
-        _ProductLinearOperator,
-        _TransposedLinearOperator,
-    )
-"""
-
 from typing import List, Set, Union
 
 from pylops import LinearOperator

--- a/tutorials/linearoperator.py
+++ b/tutorials/linearoperator.py
@@ -1,6 +1,6 @@
 """
 01. The LinearOperator
-=====================
+======================
 This first tutorial is aimed at easing the use of the PyLops
 library for both new users and developers.
 
@@ -42,7 +42,7 @@ Dop = pylops.Diagonal(d)
 #   checks whether the input ``x`` is a vector or matrix and applies ``_matvec``
 #   or ``_matmul`` accordingly.
 # * ``@``: operator used to map the special method ``__mul__`` which
-#   performs like the ``*`` opetator
+#   performs like the ``*`` operator
 #
 # We will time these 4 different executions and see how using ``_matvec``
 # (or ``matvec``) will result in the faster computation. It is thus advised to
@@ -94,15 +94,15 @@ plt.tight_layout()
 # * ``_rmatvec``: directly applies the method implemented for adjoint mode
 # * ``rmatvec``: performs some checks before and after applying ``_rmatvec``
 # * ``.H*``: first applies the adjoint ``.H`` which creates a new
-#   `pylops.linearoperator.LinearOperator`` where ``_matvec``
+#   `pylops.linearoperator._AdjointLinearOperator`` where ``_matvec``
 #   and ``_rmatvec`` are swapped and then applies the new ``_matvec``.
 #
-# Once again, after timing these 3 different executions we can see
+# Once again, after timing these 3 different executions we can
 # see how using ``_rmatvec`` (or ``rmatvec``) will result in the faster
 # computation while ``.H*`` is very unefficient and slow. Note that if the
 # adjoint has to be applied multiple times it is at least advised to create
 # the adjoint operator by applying ``.H`` only once upfront.
-# Not surprisingly, the linear solvers in PyLops
+# Not surprisingly, the linear solvers in scipy and PyLops
 # actually use ``matvec`` and ``rmatvec`` when dealing with linear operators.
 
 # _rmatvec
@@ -138,7 +138,7 @@ plt.tight_layout()
 # teaching purposes.
 #
 # We now go through some other *methods* and *special methods* that
-# are implemented in :py:class:`pylops.LinearOperator`):
+# are implemented in :py:class:`pylops.LinearOperator`:
 #
 # * ``Op1+Op2``: maps the special method ``__add__`` and
 #   performs summation between two operators and
@@ -214,8 +214,9 @@ plt.tight_layout()
 ###############################################################################
 # At this point it is worth reiterating that if two linear operators are
 # combined by means of the algebraical operations shown above, the resulting
-# operator is still a :py:class:`pylops.LinearOperator` operator.
-# definition like ``/``
+# operator is still a :py:class:`pylops.LinearOperator` operator. This means
+# that we can still apply any of the methods implemented in our class
+# like ``*`` or ``/``.
 Dop1 = Dop - Dop.conj()
 
 y = Dop1 * x
@@ -254,5 +255,5 @@ print(f"Adjoint evaluations: {Dop.rmatvec_count}")
 ###############################################################################
 # This first tutorial is completed. You have seen the basic operations that
 # can be performed using :py:class:`pylops.LinearOperator` and you
-# should be able to get started combining various PyLops operators and
+# should now be able to get started combining various PyLops operators and
 # solving your own inverse problems.

--- a/tutorials/linearoperator.py
+++ b/tutorials/linearoperator.py
@@ -1,12 +1,10 @@
 """
-01. The LinearOpeator
+01. The LinearOperator
 =====================
 This first tutorial is aimed at easing the use of the PyLops
 library for both new users and developers.
 
-Since PyLops heavily relies  on the use of the
-:py:class:`scipy.sparse.linalg.LinearOperator` class of SciPy, we will start
-by looking at how to initialize a linear operator as well as
+We will start by looking at how to initialize a linear operator as well as
 different ways to apply the forward and adjoint operations. Finally we will
 investigate various *special methods*, also called *magic methods*
 (i.e., methods with the double underscores at the beginning and the end) that
@@ -96,7 +94,7 @@ plt.tight_layout()
 # * ``_rmatvec``: directly applies the method implemented for adjoint mode
 # * ``rmatvec``: performs some checks before and after applying ``_rmatvec``
 # * ``.H*``: first applies the adjoint ``.H`` which creates a new
-#   `scipy.sparse.linalg._CustomLinearOperator`` where ``_matvec``
+#   `pylops.linearoperator.LinearOperator`` where ``_matvec``
 #   and ``_rmatvec`` are swapped and then applies the new ``_matvec``.
 #
 # Once again, after timing these 3 different executions we can see
@@ -104,7 +102,7 @@ plt.tight_layout()
 # computation while ``.H*`` is very unefficient and slow. Note that if the
 # adjoint has to be applied multiple times it is at least advised to create
 # the adjoint operator by applying ``.H`` only once upfront.
-# Not surprisingly, the linear solvers in scipy as well as in PyLops
+# Not surprisingly, the linear solvers in PyLops
 # actually use ``matvec`` and ``rmatvec`` when dealing with linear operators.
 
 # _rmatvec
@@ -140,8 +138,7 @@ plt.tight_layout()
 # teaching purposes.
 #
 # We now go through some other *methods* and *special methods* that
-# are implemented in :py:class:`scipy.sparse.linalg.LinearOperator` (and
-# :py:class:`pylops.LinearOperator`):
+# are implemented in :py:class:`pylops.LinearOperator`):
 #
 # * ``Op1+Op2``: maps the special method ``__add__`` and
 #   performs summation between two operators and
@@ -217,9 +214,7 @@ plt.tight_layout()
 ###############################################################################
 # At this point it is worth reiterating that if two linear operators are
 # combined by means of the algebraical operations shown above, the resulting
-# operator is still a :py:class:`pylops.LinearOperator` operator. This means
-# that we can still apply any of the methods implemented in the original
-# scipy class definition like ``*``, as well as those in our class
+# operator is still a :py:class:`pylops.LinearOperator` operator.
 # definition like ``/``
 Dop1 = Dop - Dop.conj()
 
@@ -258,7 +253,6 @@ print(f"Adjoint evaluations: {Dop.rmatvec_count}")
 
 ###############################################################################
 # This first tutorial is completed. You have seen the basic operations that
-# can be performed using :py:class:`scipy.sparse.linalg.LinearOperator` and
-# our overload of such a class :py:class:`pylops.LinearOperator` and you
+# can be performed using :py:class:`pylops.LinearOperator` and you
 # should be able to get started combining various PyLops operators and
 # solving your own inverse problems.


### PR DESCRIPTION
For issue #328 
- Added `_AdjointLinearOperator`, `_TransposeLinearOperator` and `_ProductLinearOperator`
- Added methods `__matmul__`,`__rmatmul__` , `transpose` and `adjoint`
- Made all classes extend the `LinearOperator`

Still need to change/update the docs, if code seems fine...
