### PR TITLE
Fixed Figures size in Docs

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,5 @@
+@import 'theme.css'; 
+
+.sphx-glr-multi-img {
+    max-width: 100%;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,8 +107,8 @@ html_static_path = ["_static"]
 html_last_updated_fmt = "%b %d, %Y"
 html_title = "PyLops"
 html_short_title = "PyLops"
-html_logo = "pylops.png"
-html_favicon = "favicon.ico"
+html_logo = "_static/pylops.png"
+html_favicon = "_static/favicon.ico"
 html_extra_path = []
 pygments_style = "default"
 add_function_parentheses = False
@@ -122,10 +122,14 @@ html_theme_options = {
     "logo_only": True,
     "display_version": True,
     "logo": {
-      "image_light": "pylops_b.png",
-      "image_dark": "pylops.png",
+        "image_light": "pylops_b.png",
+        "image_dark": "pylops.png",
     }
 }
+html_css_files = [
+    'css/custom.css',
+]
+
 html_context = {
     "menu_links_name": "Repository",
     "menu_links": [


### PR DESCRIPTION
fixes issue: https://github.com/PyLops/pylops/issues/477

demo: 
https://dikwickley-pylops.readthedocs.io/en/latest/tutorials/lsm.html

before:
![image](https://user-images.githubusercontent.com/31622972/217201674-3fd8e6f7-7985-4be5-8068-ea7d256b6fe7.png)

after:
https://dikwickley-pylops.readthedocs.io/en/latest/tutorials/lsm.html
