### PR TITLE
bug: switch NonStationaryFilters2D to numpy in doc

### DIFF
--- a/examples/plot_nonstatfilter.py
+++ b/examples/plot_nonstatfilter.py
@@ -77,7 +77,7 @@ x[:, 21] = 1.0
 x[:, 41] = -1.0
 
 Cop = pylops.signalprocessing.NonStationaryFilters2D(
-    inp=x, hshape=wavsize, ihx=(21, 41), ihz=(21, 41), engine="numba"
+    inp=x, hshape=wavsize, ihx=(21, 41), ihz=(21, 41), engine="numpy"
 )
 
 y = Cop @ hs
@@ -116,7 +116,6 @@ axs[1, 1].imshow(hsinv[1, 1], cmap="gray", vmin=-1, vmax=1)
 axs[1, 1].axis("tight")
 axs[1, 1].set_title(r"$H_{2,2}$")
 plt.tight_layout()
-
 
 fig, axs = plt.subplots(2, 2, figsize=(10, 5))
 fig.suptitle("Estimation error")


### PR DESCRIPTION
We are currently experiencing an error in the build of our documentation which seems to come to the newly introduced example `plot_nonstatfilter` (https://readthedocs.org/api/v2/build/19515033.txt). 

I cannot reproduce this locally!

To get the documentation back up and running this PR changes the backend to numpy for the NonStationaryFilters2D operator in this example.