### PR TITLE
Feature: improve memory handling in Kirchhoff operator

### DIFF
--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -506,21 +506,21 @@ class Kirchhoff(LinearOperator):
 
         Returns
         -------
-        trav : :obj:`numpy.ndarray`
-            Total traveltime table of size :math:`\lbrack (n_y) n_x n_z
-            \times n_s n_r \rbrack`
         trav_srcs : :obj:`numpy.ndarray`
             Source-to-subsurface traveltime table of size
-            :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack` (or constant)
+            :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack`
         trav_recs : :obj:`numpy.ndarray`
             Receiver-to-subsurface traveltime table of size
             :math:`\lbrack (n_y) n_x n_z \times n_r \rbrack`
-        dist : :obj:`numpy.ndarray`
-            Total distance table of size
-            :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack` (or constant)
+        dist_srcs : :obj:`numpy.ndarray`
+            Source-to-subsurface distance table of size
+            :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack`
+        dist_recs : :obj:`numpy.ndarray`
+            Receiver-to-subsurface distance table of size
+            :math:`\lbrack (n_y) n_x n_z \times n_r \rbrack`
         trav_srcs_gradient : :obj:`numpy.ndarray`
             Source-to-subsurface traveltime gradient table of size
-            :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack` (or constant)
+            :math:`\lbrack (n_y*) n_x n_z \times n_s \rbrack`
         trav_recs_gradient : :obj:`numpy.ndarray`
             Receiver-to-subsurface traveltime gradient table of size
             :math:`\lbrack (n_y) n_x n_z \times n_r \rbrack`

--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -677,11 +677,11 @@ class Kirchhoff(LinearOperator):
             itravisrcrec = itrav[:, isrcrec]
             travdisrcrec = travd[:, isrcrec]
             for ii in range(ni):
-                index = itravisrcrec[ii]
-                dindex = travdisrcrec[ii]
-                if 0 <= index < nt - 1:
-                    y[isrcrec, index] += x[ii] * (1 - dindex)
-                    y[isrcrec, index + 1] += x[ii] * dindex
+                itravii = itravisrcrec[ii]
+                travdii = travdisrcrec[ii]
+                if 0 <= itravii < nt - 1:
+                    y[isrcrec, itravii] += x[ii] * (1 - travdii)
+                    y[isrcrec, itravii + 1] += x[ii] * travdii
         return y
 
     @staticmethod
@@ -698,10 +698,12 @@ class Kirchhoff(LinearOperator):
             itravii = itrav[ii]
             travdii = travd[ii]
             for isrcrec in range(nsnr):
-                if 0 <= itravii[isrcrec] < nt - 1:
+                itravisrcrecii = itravii[isrcrec]
+                travdisrcrecii = travdii[isrcrec]
+                if 0 <= itravisrcrecii < nt - 1:
                     y[ii] += (
-                        x[isrcrec, itravii[isrcrec]] * (1 - travdii[isrcrec])
-                        + x[isrcrec, itravii[isrcrec] + 1] * travdii[isrcrec]
+                        x[isrcrec, itravisrcrecii] * (1 - travdisrcrecii)
+                        + x[isrcrec, itravisrcrecii + 1] * travdisrcrecii
                     )
         return y
 
@@ -725,11 +727,11 @@ class Kirchhoff(LinearOperator):
                 itrav = (trav / dt).astype("int32")
                 travd = trav / dt - itrav
                 for ii in range(ni):
-                    index = itrav[ii]
-                    dindex = travd[ii]
-                    if 0 <= index < nt - 1:
-                        y[isrc * nr + irec, index] += x[ii] * (1 - dindex)
-                        y[isrc * nr + irec, index + 1] += x[ii] * dindex
+                    itravii = itrav[ii]
+                    travdii = travd[ii]
+                    if 0 <= itravii < nt - 1:
+                        y[isrc * nr + irec, itravii] += x[ii] * (1 - travdii)
+                        y[isrc * nr + irec, itravii + 1] += x[ii] * travdii
         return y
 
     @staticmethod
@@ -800,8 +802,8 @@ class Kirchhoff(LinearOperator):
             angles_rec = angles_recs[:, isrcrec % nr]
             for ii in range(ni):
                 # extract traveltime, amplitude at given image point
-                index = itravisrcrec[ii]
-                dindex = travdisrcrec[ii]
+                itravii = itravisrcrec[ii]
+                travdii = travdisrcrec[ii]
                 damp = ampisrcrec[ii]
                 # extract source and receiver angle
                 angle_src = angles_src[ii]
@@ -863,10 +865,10 @@ class Kirchhoff(LinearOperator):
                                 ]
                             )
                         # time limit check
-                        if 0 <= index < nt - 1:
+                        if 0 <= itravii < nt - 1:
                             # assign values
-                            y[isrcrec, index] += x[ii] * (1 - dindex) * damp * aptap
-                            y[isrcrec, index + 1] += x[ii] * dindex * damp * aptap
+                            y[isrcrec, itravii] += x[ii] * (1 - travdii) * damp * aptap
+                            y[isrcrec, itravii + 1] += x[ii] * travdii * damp * aptap
         return y
 
     @staticmethod
@@ -906,8 +908,8 @@ class Kirchhoff(LinearOperator):
             # identify x-index of image point
             iz = ii % nz
             for isrcrec in range(nsnr):
-                index = itravii[isrcrec]
-                dindex = travdii[isrcrec]
+                itravisrcrecii = itravii[isrcrec]
+                travdisrcrecii = travdii[isrcrec]
                 sixisrcrec = six[isrcrec]
                 rixisrcrec = rix[isrcrec]
                 # extract source and receiver angle
@@ -968,12 +970,12 @@ class Kirchhoff(LinearOperator):
                                 ]
                             )
                         # time limit check
-                        if 0 <= index < nt - 1:
+                        if 0 <= itravisrcrecii < nt - 1:
                             # assign values
                             y[ii] += (
                                 (
-                                    x[isrcrec, index] * (1 - dindex)
-                                    + x[isrcrec, index + 1] * dindex
+                                    x[isrcrec, itravisrcrecii] * (1 - travdisrcrecii)
+                                    + x[isrcrec, itravisrcrecii + 1] * travdisrcrecii
                                 )
                                 * ampii[isrcrec]
                                 * aptap
@@ -1027,8 +1029,8 @@ class Kirchhoff(LinearOperator):
                 sixisrcrec = six[isrc * nr + irec]
                 rixisrcrec = rix[isrc * nr + irec]
                 for ii in range(ni):
-                    index = itrav[ii]
-                    dindex = travd[ii]
+                    itravii = itrav[ii]
+                    travdii = travd[ii]
                     damp = amp[ii] / vel[ii]
                     # extract source and receiver angle at given image point
                     angle_src = angleisrc[ii]
@@ -1092,12 +1094,12 @@ class Kirchhoff(LinearOperator):
                                     ]
                                 )
                             # time limit check
-                            if 0 <= index < nt - 1:
-                                y[isrc * nr + irec, index] += (
-                                    x[ii] * (1 - dindex) * damp * aptap
+                            if 0 <= itravii < nt - 1:
+                                y[isrc * nr + irec, itravii] += (
+                                    x[ii] * (1 - travdii) * damp * aptap
                                 )
-                                y[isrc * nr + irec, index + 1] += (
-                                    x[ii] * dindex * damp * aptap
+                                y[isrc * nr + irec, itravii + 1] += (
+                                    x[ii] * travdii * damp * aptap
                                 )
         return y
 
@@ -1371,6 +1373,29 @@ class Kirchhoff(LinearOperator):
                 self.snell[0],
                 self.snell[1],
                 self.maxdist,
+            )
+        elif self.dynamic and not self.travsrcrec:
+            inputs = (
+                x,
+                y,
+                self.nsnr,
+                self.nt,
+                self.ni,
+                self.itrav,
+                self.travd,
+                self.amp,
+                self.aperture[0],
+                self.aperture[1],
+                self.aperturetap,
+                self.nz,
+                self.six,
+                self.rix,
+                self.angleaperture[0],
+                self.angleaperture[1],
+                self.angle_srcs,
+                self.angle_recs,
+                self.snell[0],
+                self.snell[1],
             )
         elif not self.dynamic and self.travsrcrec:
             inputs = (

--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -10,39 +10,26 @@ import numpy as np
 
 from pylops import LinearOperator
 from pylops.signalprocessing import Convolve1D
+from pylops.utils import deps
 from pylops.utils._internal import _value_or_sized_to_array
 from pylops.utils.decorators import reshaped
 from pylops.utils.tapers import taper
 from pylops.utils.typing import DTypeLike, NDArray
 
-try:
-    import skfmm
-except ModuleNotFoundError:
-    skfmm = None
-    skfmm_message = (
-        "Skfmm package not installed. Choose method=analytical "
-        "if using constant velocity or run "
-        '"pip install scikit-fmm" or '
-        '"conda install -c conda-forge scikit-fmm".'
-    )
-except Exception as e:
-    skfmm = None
-    skfmm_message = f"Failed to import skfmm (error:{e})."
+skfmm_message = deps.skfmm_import("the kirchhoff module")
+jit_message = deps.numba_import("the kirchhoff module")
 
-try:
+if skfmm_message is None:
+    import skfmm
+
+if jit_message is None:
     from numba import jit, prange
 
     # detect whether to use parallel or not
     numba_threads = int(os.getenv("NUMBA_NUM_THREADS", "1"))
     parallel = True if numba_threads != 1 else False
-except ModuleNotFoundError:
-    jit = None
+else:
     prange = range
-    jit_message = "Numba not available, reverting to numpy."
-except Exception as e:
-    jit = None
-    jit_message = "Failed to import numba (error:%s), use numpy." % e
-
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 

--- a/pylops/waveeqprocessing/lsm.py
+++ b/pylops/waveeqprocessing/lsm.py
@@ -10,20 +10,6 @@ from pylops.utils.typing import NDArray
 from pylops.waveeqprocessing.kirchhoff import Kirchhoff
 from pylops.waveeqprocessing.twoway import AcousticWave2D
 
-try:
-    import skfmm
-except ModuleNotFoundError:
-    skfmm = None
-    skfmm_message = (
-        "Skfmm package not installed. Choose method=analytical "
-        "if using constant velocity or run "
-        '"pip install scikit-fmm" or '
-        '"conda install -c conda-forge scikit-fmm".'
-    )
-except Exception as e:
-    skfmm = None
-    skfmm_message = f"Failed to import skfmm (error:{e})."
-
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 


### PR DESCRIPTION
# Motivation
This PR is mainly aimed at improving the memory efficiency of the `Kirchhoff` operator. 

In the current implementation, we create an overall `trav` table (similar for `amp` in `dynamic=True` mode) of size `nynxnz x nsnr`. Assuming `ns=nr` this scales quadratically with the `ns`. 

In the new implementation, we handle source and receiver tables independently (`trav_srcs` and `trav_recs`) and not merge them into a unique table. Assuming `ns=nr` this scales linearly with the `ns`. 

# Changes
The following changes are introduced:

- 4 new methods are created: `_travsrcrec_kirch_matvec`, `_travsrcrec_kirch_rmatvec`, `_amp_kirch_matvec`, and `_amp_kirch_rmatvec`, which are the counterparts of `_trav_kirch_matvec`, `_trav_kirch_rmatvec`, `_ampsrcrec_kirch_matvec`, and `_ampsrcrec_kirch_rmatvec` which used full tables
- `trav` and `amp` can now be provided as nd.arrays or tuples of 2 nd.arrays. In the second case, these Arte the src and rec tables. Internally the `__init__` operator handles both cases to ensure backward compatibility.
- the order and number of outputs in `_traveltime_table` is changed. However, being this a private method we should not expect users to use it (aka users should not expect us not to make changes), so I believe this is fine.
- handled https://github.com/PyLops/pylops/issues/430

# Performance tests

I run the following two performance tests using this code:

```python
#!/usr/bin/env python
# coding: utf-8

import numpy as np
import matplotlib.pyplot as plt
import scipy as sp

from pylops.utils.wavelets import *
from pylops.waveeqprocessing.kirchhoff import Kirchhoff

## 2D layered in homogenous velocity

# Velocity Model
nx, nz = 301, 100
dx, dz = 4, 4
x, z = np.arange(nx)*dx, np.arange(nz)*dz
v0 = 1000 # initial velocity
kv = 0. # gradient
vel = np.outer(np.ones(nx), v0 +kv*z) 

# Reflectivity Model
refl = np.zeros((nx, nz))
#refl[nx//2, 50] = -1
refl[:, 10] = -1
refl[:, -10] = 0.5

# Receivers
nr = 101
rx = np.linspace(10*dx, (nx-10)*dx, nr)
rz = 20*np.ones(nr)
recs = np.vstack((rx, rz))
dr = recs[0,1]-recs[0,0]

# Sources
ns = 30
sx = np.linspace(dx*10, (nx-10)*dx, ns)
sz = 10*np.ones(ns)
sources = np.vstack((sx, sz))

# Model data and invert it
nt = 651
dt = 0.004
t = np.arange(nt)*dt
wav, wavt, wavc = ricker(t[:41], f0=20)

kop = Kirchhoff(z, x, t, sources, recs, v0, wav, wavc, mode='analytic', engine='numba')

d = kop * refl.ravel()
d = d.reshape(ns, nr, nt)

madj = kop.H * d.ravel()
madj = madj.reshape(nx, nz)

print('Done')
```
and equivalent code with old version of Kirchoff.


- `dynamic=False`
![plot_memorynew](https://user-images.githubusercontent.com/22675848/220715731-78b19db5-5b27-4de1-8353-8a5c63edd7da.png)
![plot_memoryold](https://user-images.githubusercontent.com/22675848/220715743-528c0188-7db3-4a67-8c36-52026b7748c1.png)

- `dynamic=True`
![plot_memorynew](https://user-images.githubusercontent.com/22675848/220716275-e6d0b525-9c6c-4282-9128-323ef0effe41.png)
![plot_memoryold](https://user-images.githubusercontent.com/22675848/220716280-96f2a18e-5127-426c-a641-126b26c8a79a.png)
