### PR TITLE
Feature: forceflat property

### DIFF
--- a/MIGRATION_V1_V2.md
+++ b/MIGRATION_V1_V2.md
@@ -10,7 +10,7 @@ should be used as a checklist when converting a piece of code using PyLops from 
   for every operator by default. While the change is mostly backwards compatible, there are some operators (e.g. the ``Bilinear``
   transpose/conjugate) which can output reshaped arrays instead of 1d-arrays. To ensure no breakage, you can entirely disable this
   feature either globally by setting ``pylops.set_ndarray_multiplication(False)``, or locally with the context manager
-  ``pylops.disabled_ndarray_multiplication()``. Both will revert to v1.x behavior. At this time, PyLops sparse solvers do
+  ``pylops.disabled_ndarray_multiplication()``. Both will revert to v1.x behavior. At this time, PyLops solvers do
   *not* support N-D array multiplication.
 
   See the table at the end of this document for support ndarray operations.

--- a/pylops/basicoperators/blockdiag.py
+++ b/pylops/basicoperators/blockdiag.py
@@ -44,6 +44,10 @@ class BlockDiag(LinearOperator):
     nproc : :obj:`int`, optional
         Number of processes used to evaluate the N operators in parallel using
         ``multiprocessing``. If ``nproc=1``, work in serial mode.
+    forceflat : :obj:`bool`, optional
+        .. versionadded:: 2.2.0
+
+        Force an array to be flattened after matvec and rmatvec.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -108,6 +112,7 @@ class BlockDiag(LinearOperator):
         self,
         ops: Sequence[LinearOperator],
         nproc: int = 1,
+        forceflat: bool = None,
         dtype: Optional[DTypeLike] = None,
     ) -> None:
         self.ops = ops
@@ -130,7 +135,12 @@ class BlockDiag(LinearOperator):
 
         dtype = _get_dtype(ops) if dtype is None else np.dtype(dtype)
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
-        super().__init__(dtype=dtype, shape=(self.nops, self.mops), clinear=clinear)
+        super().__init__(
+            dtype=dtype,
+            shape=(self.nops, self.mops),
+            clinear=clinear,
+            forceflat=forceflat,
+        )
 
     @property
     def nproc(self) -> int:

--- a/pylops/basicoperators/blockdiag.py
+++ b/pylops/basicoperators/blockdiag.py
@@ -127,6 +127,22 @@ class BlockDiag(LinearOperator):
         self.mops = int(mops.sum())
         self.nnops = np.insert(np.cumsum(nops), 0, 0)
         self.mmops = np.insert(np.cumsum(mops), 0, 0)
+        # define dims (check if all operators have the same,
+        # otherwise make same as self.mops and forceflat=True)
+        dims = [op.dims for op in self.ops]
+        if len(set(dims)) == 1:
+            dims = (len(ops), *dims[0])
+        else:
+            dims = (self.mops,)
+            forceflat = True
+        # define dimsd (check if all operators have the same,
+        # otherwise make same as self.nops and forceflat=True)
+        dimsd = [op.dimsd for op in self.ops]
+        if len(set(dimsd)) == 1:
+            dimsd = (len(ops), *dimsd[0])
+        else:
+            dimsd = (self.nops,)
+            forceflat = True
         # create pool for multiprocessing
         self._nproc = nproc
         self.pool: Optional[mp.pool.Pool] = None
@@ -137,10 +153,12 @@ class BlockDiag(LinearOperator):
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
         super().__init__(
             dtype=dtype,
-            shape=(self.nops, self.mops),
+            dims=dims,
+            dimsd=dimsd,
             clinear=clinear,
             forceflat=forceflat,
         )
+        print(dims, dimsd)
 
     @property
     def nproc(self) -> int:

--- a/pylops/basicoperators/blockdiag.py
+++ b/pylops/basicoperators/blockdiag.py
@@ -158,7 +158,6 @@ class BlockDiag(LinearOperator):
             clinear=clinear,
             forceflat=forceflat,
         )
-        print(dims, dimsd)
 
     @property
     def nproc(self) -> int:

--- a/pylops/basicoperators/hstack.py
+++ b/pylops/basicoperators/hstack.py
@@ -44,6 +44,10 @@ class HStack(LinearOperator):
     nproc : :obj:`int`, optional
         Number of processes used to evaluate the N operators in parallel
         using ``multiprocessing``. If ``nproc=1``, work in serial mode.
+    forceflat : :obj:`bool`, optional
+        .. versionadded:: 2.2.0
+
+        Force an array to be flattened after matvec.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -107,6 +111,7 @@ class HStack(LinearOperator):
         self,
         ops: Sequence[LinearOperator],
         nproc: int = 1,
+        forceflat: bool = None,
         dtype: Optional[str] = None,
     ) -> None:
         self.ops = ops
@@ -129,7 +134,13 @@ class HStack(LinearOperator):
 
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
-        super().__init__(dtype=dtype, shape=(self.nops, self.mops), clinear=clinear)
+        super().__init__(
+            dtype=dtype,
+            shape=(self.nops, self.mops),
+            dimsd=ops[0].dimsd,
+            clinear=clinear,
+            forceflat=forceflat,
+        )
 
     @property
     def nproc(self) -> int:

--- a/pylops/basicoperators/hstack.py
+++ b/pylops/basicoperators/hstack.py
@@ -126,18 +126,25 @@ class HStack(LinearOperator):
             raise ValueError("operators have different number of rows")
         self.nops = int(nops[0])
         self.mmops = np.insert(np.cumsum(mops), 0, 0)
+        # define dimsd (check if all operators have the same,
+        # otherwise make same as self.nops and forceflat=True)
+        dimsd = [op.dimsd for op in self.ops]
+        if len(set(dimsd)) == 1:
+            dimsd = dimsd[0]
+        else:
+            dimsd = (self.nops,)
+            forceflat = True
         # create pool for multiprocessing
         self._nproc = nproc
         self.pool = None
         if self.nproc > 1:
             self.pool = mp.Pool(processes=nproc)
-
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
         super().__init__(
             dtype=dtype,
             shape=(self.nops, self.mops),
-            dimsd=ops[0].dimsd,
+            dimsd=dimsd,
             clinear=clinear,
             forceflat=forceflat,
         )

--- a/pylops/basicoperators/identity.py
+++ b/pylops/basicoperators/identity.py
@@ -1,13 +1,14 @@
 __all__ = ["Identity"]
 
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils.backend import get_array_module
-from pylops.utils.typing import DTypeLike, NDArray
+from pylops.utils.decorators import reshaped
+from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
 
 
 class Identity(LinearOperator):
@@ -19,16 +20,29 @@ class Identity(LinearOperator):
     removes last :math:`N - M` elements from data in adjoint and pads with
     :math:`0` in forward.
 
+    Note that the identity operator can handle both 1d and nd arrays; in the
+    case of nd arrays, all elements of N must be larger or equal than those of M
+    (or all elements of M must be larger or equal than those of N).
+
     Parameters
     ----------
-    N : :obj:`int`
+    N : :obj:`int` or :obj:`tuple`
         Number of samples in data (and model, if ``M`` is not provided).
-    M : :obj:`int`, optional
-        Number of samples in model.
+        If a tuple is provided, this is interpreted as the data (and model)
+        are nd-arrays.
+    M : :obj:`int` or :obj:`tuple`, optional
+        Number of samples in model. If a tuple is provided, this is interpreted
+        as the model is an nd-array. Note that when `M` is a tuple, `N` must be
+        also a tuple with the same number of elements.
     inplace : :obj:`bool`, optional
         Work inplace (``True``) or make a new copy (``False``). By default,
         data is a reference to the model (in forward) and model is a reference
         to the data (in adjoint).
+    forceflat : :obj:`bool`, optional
+         .. versionadded:: 2.2.0
+
+         Force an array to be flattened after matvec and rmatvec. Note that this is only
+         required when `N` and `M` are tuples (input and output arrays are nd-arrays.
     dtype : :obj:`str`, optional
         Type of elements in input array.
     name : :obj:`str`, optional
@@ -43,6 +57,15 @@ class Identity(LinearOperator):
     explicit : :obj:`bool`
         Operator contains a matrix that can be solved explicitly (``True``) or
         not (``False``)
+
+    Raises
+    ------
+    ValueError
+        - If ``M`` is a tuple with different number of elements of ``N``
+        - If ``N`` ``M`` are non-identical tuples and some values are largers
+          in ``N`` and some in ``M``
+    NotImplemented
+        If ``N`` or ``M`` have type different from int or tuple/list
 
     Notes
     -----
@@ -87,38 +110,90 @@ class Identity(LinearOperator):
 
     def __init__(
         self,
-        N: int,
-        M: Optional[int] = None,
+        N: Union[int, InputDimsLike],
+        M: Optional[Union[int, InputDimsLike]] = None,
         inplace: bool = True,
+        forceflat: bool = None,
         dtype: DTypeLike = "float64",
         name: str = "I",
     ) -> None:
         M = N if M is None else M
-        super().__init__(dtype=np.dtype(dtype), shape=(N, M), name=name)
+        if isinstance(N, int) and isinstance(M, int):
+            # N and M are scalars (1d-arrays)
+            super().__init__(
+                dtype=np.dtype(dtype),
+                dims=(M,),
+                dimsd=(N,),
+                forceflat=forceflat,
+                name=name,
+            )
+            # identify behaviour for matvec/rmatvec: 'same' for N=M,
+            # 'data' for N>M, and 'model' for M>N
+            if N == M:
+                self.mode = "same"
+            elif N < M:
+                self.mode = "model"
+                self.sliceN = slice(0, N)
+                self.sliceM = slice(0, M)
+            else:
+                self.mode = "data"
+                self.sliceN = slice(0, N)
+                self.sliceM = slice(0, M)
+        elif isinstance(N, (tuple, list)) and isinstance(M, (tuple, list)):
+            # N and M are tuples (nd-arrays)
+            # First check that all elements in N and M are the same or that
+            # all elements of either N or M are bigger than the other one and
+            # raise error is not the case
+            if np.array_equal(N, M):
+                self.mode = "same"
+            elif np.array_equal(M, np.maximum(N, M)):
+                self.mode = "model"
+                self.sliceN = tuple([slice(0, n) for n in N])
+                self.sliceM = tuple([slice(0, m) for m in M])
+            elif np.array_equal(N, np.maximum(N, M)):
+                self.mode = "data"
+                self.sliceN = tuple([slice(0, n) for n in N])
+                self.sliceM = tuple([slice(0, m) for m in M])
+            else:
+                raise ValueError(
+                    "N and M are not identical, "
+                    "and some values are larger in N and some in M"
+                )
+            super().__init__(
+                dtype=np.dtype(dtype), dims=M, dimsd=N, forceflat=forceflat, name=name
+            )
+        else:
+            raise NotImplemented(
+                f"N and M must have same type and equal to "
+                f"int, tuple, or list, instead their types"
+                f" are type(N)={type(N)} and type(M)={type(M)}"
+            )
         self.inplace = inplace
 
+    @reshaped
     def _matvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         if not self.inplace:
             x = x.copy()
-        if self.shape[0] == self.shape[1]:
+        if self.mode == "same":
             y = x
-        elif self.shape[0] < self.shape[1]:
-            y = x[: self.shape[0]]
+        elif self.mode == "model":
+            y = x[self.sliceN]
         else:
-            y = ncp.zeros(self.shape[0], dtype=self.dtype)
-            y[: self.shape[1]] = x
+            y = ncp.zeros(self.dimsd, dtype=self.dtype)
+            y[self.sliceM] = x
         return y
 
+    @reshaped
     def _rmatvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         if not self.inplace:
             x = x.copy()
-        if self.shape[0] == self.shape[1]:
+        if self.mode == "same":
             y = x
-        elif self.shape[0] < self.shape[1]:
-            y = ncp.zeros(self.shape[1], dtype=self.dtype)
-            y[: self.shape[0]] = x
+        elif self.mode == "model":
+            y = ncp.zeros(self.dims, dtype=self.dtype)
+            y[self.sliceN] = x
         else:
-            y = x[: self.shape[1]]
+            y = x[self.sliceM]
         return y

--- a/pylops/basicoperators/identity.py
+++ b/pylops/basicoperators/identity.py
@@ -64,7 +64,7 @@ class Identity(LinearOperator):
         - If ``M`` is a tuple with different number of elements of ``N``
         - If ``N`` ``M`` are non-identical tuples and some values are largers
           in ``N`` and some in ``M``
-    NotImplemented
+    NotImplementedError
         If ``N`` or ``M`` have type different from int or tuple/list
 
     Notes
@@ -163,7 +163,7 @@ class Identity(LinearOperator):
                 dtype=np.dtype(dtype), dims=M, dimsd=N, forceflat=forceflat, name=name
             )
         else:
-            raise NotImplemented(
+            raise NotImplementedError(
                 f"N and M must have same type and equal to "
                 f"int, tuple, or list, instead their types"
                 f" are type(N)={type(N)} and type(M)={type(M)}"

--- a/pylops/basicoperators/identity.py
+++ b/pylops/basicoperators/identity.py
@@ -42,7 +42,7 @@ class Identity(LinearOperator):
          .. versionadded:: 2.2.0
 
          Force an array to be flattened after matvec and rmatvec. Note that this is only
-         required when `N` and `M` are tuples (input and output arrays are nd-arrays.
+         required when `N` and `M` are tuples (input and output arrays are nd-arrays).
     dtype : :obj:`str`, optional
         Type of elements in input array.
     name : :obj:`str`, optional

--- a/pylops/basicoperators/matrixmult.py
+++ b/pylops/basicoperators/matrixmult.py
@@ -91,10 +91,10 @@ class MatrixMult(LinearOperator):
         # Check if forceflat is needed and set it back to None otherwise
         if otherdims is not None and forceflat is not None:
             logging.warning(
-                f"setting forceflat=None since otherdims!=None. "
-                f"PyLops will automatically detect whether to return "
-                f"a 1d or nd array based on the shape of the input"
-                f"array."
+                "setting forceflat=None since otherdims!=None. "
+                "PyLops will automatically detect whether to return "
+                "a 1d or nd array based on the shape of the input "
+                "array."
             )
             forceflat = None
         # Check dtype for correctness (upcast to complex when A is complex)

--- a/pylops/basicoperators/sum.py
+++ b/pylops/basicoperators/sum.py
@@ -83,15 +83,14 @@ class Sum(LinearOperator):
         dimsd = list(dims).copy()
         dimsd.pop(self.axis)
         # check if forceflat is needed and set it back to None otherwise
-        if len(dims) > 2:
-            if forceflat is not None:
-                logging.warning(
-                    f"setting forceflat=None since len(dims)={len(dims)}>2. "
-                    f"PyLops will automatically detect whether to return "
-                    f"a 1d or nd array based on the shape of the input"
-                    f"array."
-                )
-                forceflat = None
+        if len(dims) > 2 and forceflat is not None:
+            logging.warning(
+                f"setting forceflat=None since len(dims)={len(dims)}>2. "
+                f"PyLops will automatically detect whether to return "
+                f"a 1d or nd array based on the shape of the input"
+                f"array."
+            )
+            forceflat = None
         super().__init__(
             dtype=np.dtype(dtype),
             dims=dims,

--- a/pylops/basicoperators/sum.py
+++ b/pylops/basicoperators/sum.py
@@ -1,5 +1,7 @@
 __all__ = ["Sum"]
 
+import logging
+
 import numpy as np
 
 from pylops import LinearOperator
@@ -7,6 +9,8 @@ from pylops.utils._internal import _value_or_sized_to_tuple
 from pylops.utils.backend import get_array_module
 from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
+
+logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class Sum(LinearOperator):
@@ -27,7 +31,9 @@ class Sum(LinearOperator):
     forceflat : :obj:`bool`, optional
         .. versionadded:: 2.2.0
 
-        Force an array to be flattened after rmatvec.
+        Force an array to be flattened after rmatvec. Note that this is only
+        required when `len(dims)=2`, otherwise pylops will detect whether to
+        return a 1d or nd array.
     dtype : :obj:`str`, optional
         Type of elements in input array.
     name : :obj:`str`, optional
@@ -65,7 +71,7 @@ class Sum(LinearOperator):
         self,
         dims: InputDimsLike,
         axis: int = -1,
-        forceflat: bool = False,
+        forceflat: bool = None,
         dtype: DTypeLike = "float64",
         name: str = "S",
     ) -> None:
@@ -76,6 +82,16 @@ class Sum(LinearOperator):
         # data dimensions
         dimsd = list(dims).copy()
         dimsd.pop(self.axis)
+        # check if forceflat is needed and set it back to None otherwise
+        if len(dims) > 2:
+            if forceflat is not None:
+                logging.warning(
+                    f"setting forceflat=None since len(dims)={len(dims)}>2. "
+                    f"PyLops will automatically detect whether to return "
+                    f"a 1d or nd array based on the shape of the input"
+                    f"array."
+                )
+                forceflat = None
         super().__init__(
             dtype=np.dtype(dtype),
             dims=dims,

--- a/pylops/basicoperators/sum.py
+++ b/pylops/basicoperators/sum.py
@@ -24,6 +24,10 @@ class Sum(LinearOperator):
         .. versionadded:: 2.0.0
 
         Axis along which model is summed.
+    forceflat : :obj:`bool`, optional
+        .. versionadded:: 2.2.0
+
+        Force an array to be flattened after rmatvec.
     dtype : :obj:`str`, optional
         Type of elements in input array.
     name : :obj:`str`, optional
@@ -61,6 +65,7 @@ class Sum(LinearOperator):
         self,
         dims: InputDimsLike,
         axis: int = -1,
+        forceflat: bool = False,
         dtype: DTypeLike = "float64",
         name: str = "S",
     ) -> None:
@@ -71,7 +76,13 @@ class Sum(LinearOperator):
         # data dimensions
         dimsd = list(dims).copy()
         dimsd.pop(self.axis)
-        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=dims,
+            dimsd=dimsd,
+            forceflat=forceflat,
+            name=name,
+        )
 
         # array of ones with dims of model in self.axis for np.tile in adjoint mode
         self.tile = np.ones(len(self.dims), dtype=int)

--- a/pylops/basicoperators/vstack.py
+++ b/pylops/basicoperators/vstack.py
@@ -126,6 +126,14 @@ class VStack(LinearOperator):
             raise ValueError("operators have different number of columns")
         self.mops = int(mops[0])
         self.nnops = np.insert(np.cumsum(nops), 0, 0)
+        # define dims (check if all operators have the same,
+        # otherwise make same as self.mops and forceflat=True)
+        dims = [op.dims for op in self.ops]
+        if len(set(dims)) == 1:
+            dims = dims[0]
+        else:
+            dims = (self.mops,)
+            forceflat = True
         # create pool for multiprocessing
         self._nproc = nproc
         self.pool = None
@@ -136,7 +144,7 @@ class VStack(LinearOperator):
         super().__init__(
             dtype=dtype,
             shape=(self.nops, self.mops),
-            dims=ops[0].dims,
+            dims=dims,
             clinear=clinear,
             forceflat=forceflat,
         )

--- a/pylops/basicoperators/vstack.py
+++ b/pylops/basicoperators/vstack.py
@@ -44,6 +44,10 @@ class VStack(LinearOperator):
     nproc : :obj:`int`, optional
         Number of processes used to evaluate the N operators in parallel using
         ``multiprocessing``. If ``nproc=1``, work in serial mode.
+    forceflat : :obj:`bool`, optional
+        .. versionadded:: 2.2.0
+
+        Force an array to be flattened after rmatvec.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -107,6 +111,7 @@ class VStack(LinearOperator):
         self,
         ops: Sequence[LinearOperator],
         nproc: int = 1,
+        forceflat: bool = None,
         dtype: Optional[DTypeLike] = None,
     ) -> None:
         self.ops = ops
@@ -126,10 +131,15 @@ class VStack(LinearOperator):
         self.pool = None
         if self.nproc > 1:
             self.pool = mp.Pool(processes=nproc)
-
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
-        super().__init__(dtype=dtype, shape=(self.nops, self.mops), clinear=clinear)
+        super().__init__(
+            dtype=dtype,
+            shape=(self.nops, self.mops),
+            dims=ops[0].dims,
+            clinear=clinear,
+            forceflat=forceflat,
+        )
 
     @property
     def nproc(self) -> int:

--- a/pylops/basicoperators/zero.py
+++ b/pylops/basicoperators/zero.py
@@ -1,12 +1,12 @@
 __all__ = ["Zero"]
 
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
 from pylops import LinearOperator
 from pylops.utils.backend import get_array_module
-from pylops.utils.typing import DTypeLike, NDArray
+from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
 
 
 class Zero(LinearOperator):
@@ -17,10 +17,14 @@ class Zero(LinearOperator):
 
     Parameters
     ----------
-    N : :obj:`int`
-       Number of samples in data (and model in M is not provided).
-    M : :obj:`int`, optional
-       Number of samples in model.
+    N : :obj:`int` or :obj:`tuple`
+        Number of samples in data (and model, if ``M`` is not provided).
+        If a tuple is provided, this is interpreted as the data (and model)
+        are nd-arrays.
+    M : :obj:`int` or :obj:`tuple`, optional
+        Number of samples in model. If a tuple is provided, this is interpreted
+        as the model is an nd-array. Note that when `M` is a tuple, `N` must be
+        also a tuple with the same number of elements.
     dtype : :obj:`str`, optional
        Type of elements in input array.
     name : :obj:`str`, optional
@@ -55,13 +59,33 @@ class Zero(LinearOperator):
 
     def __init__(
         self,
-        N: int,
-        M: Optional[int] = None,
+        N: Union[int, InputDimsLike],
+        M: Optional[Union[int, InputDimsLike]] = None,
+        forceflat: bool = None,
         dtype: DTypeLike = "float64",
         name: str = "Z",
     ) -> None:
         M = N if M is None else M
-        super().__init__(dtype=np.dtype(dtype), shape=(N, M), name=name)
+        if isinstance(N, int) and isinstance(M, int):
+            # N and M are scalars (1d-arrays)
+            super().__init__(
+                dtype=np.dtype(dtype),
+                dims=(M,),
+                dimsd=(N,),
+                forceflat=forceflat,
+                name=name,
+            )
+        elif isinstance(N, (tuple, list)) and isinstance(M, (tuple, list)):
+            # N and M are tuples (nd-arrays)
+            super().__init__(
+                dtype=np.dtype(dtype), dims=M, dimsd=N, forceflat=forceflat, name=name
+            )
+        else:
+            raise NotImplementedError(
+                f"N and M must have same type and equal to "
+                f"int, tuple, or list, instead their types"
+                f" are type(N)={type(N)} and type(M)={type(M)}"
+            )
 
     def _matvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)

--- a/pylops/basicoperators/zero.py
+++ b/pylops/basicoperators/zero.py
@@ -68,24 +68,23 @@ class Zero(LinearOperator):
         M = N if M is None else M
         if isinstance(N, int) and isinstance(M, int):
             # N and M are scalars (1d-arrays)
-            super().__init__(
-                dtype=np.dtype(dtype),
-                dims=(M,),
-                dimsd=(N,),
-                forceflat=forceflat,
-                name=name,
-            )
+            dims, dimsd = (M,), (N,)
         elif isinstance(N, (tuple, list)) and isinstance(M, (tuple, list)):
             # N and M are tuples (nd-arrays)
-            super().__init__(
-                dtype=np.dtype(dtype), dims=M, dimsd=N, forceflat=forceflat, name=name
-            )
+            dims, dimsd = M, N
         else:
             raise NotImplementedError(
                 f"N and M must have same type and equal to "
                 f"int, tuple, or list, instead their types"
                 f" are type(N)={type(N)} and type(M)={type(M)}"
             )
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=dims,
+            dimsd=dimsd,
+            forceflat=forceflat,
+            name=name,
+        )
 
     def _matvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)

--- a/pylops/basicoperators/zero.py
+++ b/pylops/basicoperators/zero.py
@@ -25,6 +25,11 @@ class Zero(LinearOperator):
         Number of samples in model. If a tuple is provided, this is interpreted
         as the model is an nd-array. Note that when `M` is a tuple, `N` must be
         also a tuple with the same number of elements.
+    forceflat : :obj:`bool`, optional
+         .. versionadded:: 2.2.0
+
+         Force an array to be flattened after matvec and rmatvec. Note that this is only
+         required when `N` and `M` are tuples (input and output arrays are nd-arrays).
     dtype : :obj:`str`, optional
        Type of elements in input array.
     name : :obj:`str`, optional

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -362,7 +362,7 @@ class LinearOperator(_LinearOperator):
             if isinstance(self.forceflat, bool) and isinstance(Opx.forceflat, bool):
                 if self.forceflat != Opx.forceflat:
                     raise ValueError(
-                        f"the two operators have contrasting forceflat {Op.forceflat}-{Opx.forceflatx}"
+                        f"the two operators have contrasting forceflat {Op.forceflat}-{Opx.forceflat}"
                     )
                 else:
                     Op.forceflat = self.forceflat
@@ -628,7 +628,7 @@ class LinearOperator(_LinearOperator):
             if isinstance(self.forceflat, bool) and isinstance(Opx.forceflat, bool):
                 if self.forceflat != Opx.forceflat:
                     raise ValueError(
-                        f"the two operators have contrasting forceflat {Op.forceflat}-{Opx.forceflatx}"
+                        f"the two operators have contrasting forceflat {Op.forceflat}-{Opx.forceflat}"
                     )
                 else:
                     Op.forceflat = self.forceflat

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -281,7 +281,10 @@ class LinearOperator(_LinearOperator):
 
     @forceflat.setter
     def forceflat(self, new_forceflat: bool) -> None:
-        self._forceflat = bool(new_forceflat)
+        # note that this can also be None so we check before forcing bool
+        self._forceflat = (
+            new_forceflat if new_forceflat is None else bool(new_forceflat)
+        )
 
     @forceflat.deleter
     def forceflat(self):

--- a/pylops/signalprocessing/bilinear.py
+++ b/pylops/signalprocessing/bilinear.py
@@ -37,6 +37,10 @@ class Bilinear(LinearOperator):
          for interpolation.
     dims : :obj:`list`
         Number of samples for each dimension
+    forceflat : :obj:`bool`, optional
+        .. versionadded:: 2.2.0
+
+        Force an array to be flattened after rmatvec.
     dtype : :obj:`str`, optional
         Type of elements in input array.
     name : :obj:`str`, optional
@@ -90,13 +94,20 @@ class Bilinear(LinearOperator):
         self,
         iava: IntNDArray,
         dims: InputDimsLike,
+        forceflat: bool = False,
         dtype: DTypeLike = "float64",
         name: str = "B",
     ) -> None:
         # define dimension of data
         ndims = len(dims)
         dimsd = [len(iava[1])] + list(dims[2:])
-        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=dims,
+            dimsd=dimsd,
+            forceflat=forceflat,
+            name=name,
+        )
 
         ncp = get_array_module(iava)
         # check non-unique pairs (works only with numpy arrays)

--- a/pylops/signalprocessing/bilinear.py
+++ b/pylops/signalprocessing/bilinear.py
@@ -40,7 +40,9 @@ class Bilinear(LinearOperator):
     forceflat : :obj:`bool`, optional
         .. versionadded:: 2.2.0
 
-        Force an array to be flattened after rmatvec.
+        Force an array to be flattened after rmatvec. Note that this is only
+        required when `len(dims)=2`, otherwise pylops will detect whether to
+        return a 1d or nd array.
     dtype : :obj:`str`, optional
         Type of elements in input array.
     name : :obj:`str`, optional
@@ -94,13 +96,23 @@ class Bilinear(LinearOperator):
         self,
         iava: IntNDArray,
         dims: InputDimsLike,
-        forceflat: bool = False,
+        forceflat: bool = None,
         dtype: DTypeLike = "float64",
         name: str = "B",
     ) -> None:
         # define dimension of data
         ndims = len(dims)
         dimsd = [len(iava[1])] + list(dims[2:])
+        # check if forceflat is needed and set it back to None otherwise
+        if ndims > 2:
+            if forceflat is not None:
+                logging.warning(
+                    f"setting forceflat=None since len(dims)={len(dims)}>2. "
+                    f"PyLops will automatically detect whether to return "
+                    f"a 1d or nd array based on the shape of the input"
+                    f"array."
+                )
+                forceflat = None
         super().__init__(
             dtype=np.dtype(dtype),
             dims=dims,

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -63,7 +63,9 @@ def test_LinearRegression(par):
     assert dottest(LRop, par["ny"], 2)
 
     x = np.array([1.0, 2.0], dtype=np.float32)
-    xlsqr = lsqr(LRop, LRop * x, damp=1e-10, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[0]
+    xlsqr = lsqr(
+        LRop, LRop * x, damp=1e-10, iter_lim=300, atol=1e-8, btol=1e-8, show=0
+    )[0]
     assert_array_almost_equal(x, xlsqr, decimal=3)
 
     y = LRop * x
@@ -82,7 +84,9 @@ def test_MatrixMult(par):
     assert dottest(Gop, par["ny"], par["nx"], complexflag=0 if par["imag"] == 0 else 3)
 
     x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
-    xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[0]
+    xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[
+        0
+    ]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
 
@@ -100,7 +104,9 @@ def test_MatrixMult_sparse(par):
     assert dottest(Gop, par["ny"], par["nx"], complexflag=0 if par["imag"] == 1 else 3)
 
     x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
-    xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[0]
+    xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[
+        0
+    ]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
 
@@ -133,7 +139,9 @@ def test_MatrixMult_repeated(par):
     )
 
     x = (np.ones((par["nx"], 5)) + par["imag"] * np.ones((par["nx"], 5))).ravel()
-    xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[0]
+    xlsqr = lsqr(Gop, Gop * x, damp=1e-20, iter_lim=300, atol=1e-8, btol=1e-8, show=0)[
+        0
+    ]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
 
@@ -458,6 +466,44 @@ def test_Roll3D(par):
 
         xinv = Rop.H * y
         assert_array_almost_equal(x[str(axis)].ravel(), xinv, decimal=3)
+
+
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+def test_Sum2D_forceflat(par):
+    np.random.seed(10)
+    flat_dimsd = par["ny"]
+    flat_dims = par["ny"] * par["nx"]
+    x = np.random.randn(flat_dims) + par["imag"] * np.random.randn(flat_dims)
+
+    Sop_True = Sum((par["ny"], par["nx"]), axis=-1, forceflat=True)
+    y = Sop_True @ x
+    xadj = Sop_True.H @ y
+    assert y.shape == (flat_dimsd,)
+    assert xadj.shape == (flat_dims,)
+
+    Sop_None = Sum((par["ny"], par["nx"]), axis=-1)
+    y = Sop_None @ x
+    xadj = Sop_None.H @ y
+    assert y.shape == (par["ny"],)
+    assert xadj.shape == (par["ny"], par["nx"])
+
+    Sop_False = Sum((par["ny"], par["nx"]), axis=-1, forceflat=False)
+    y = Sop_False @ x
+    xadj = Sop_False.H @ y
+    assert y.shape == (par["ny"],)
+    assert xadj.shape == (par["ny"], par["nx"])
+
+    with pytest.raises(ValueError):
+        Sop_True * Sop_False.H
+
+    Sop = Sop_True * Sop_None.H
+    assert Sop.forceflat is True
+
+    Sop = Sop_False * Sop_None.H
+    assert Sop.forceflat is False
+
+    Sop = Sop_None * Sop_None.H
+    assert Sop.forceflat is None
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -469,7 +469,18 @@ def test_Roll3D(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+def test_Sum2D(par):
+    """Dot-test for Sum operator on 2d signal"""
+    for axis in [0, 1]:
+        dim_d = [par["ny"], par["nx"]]
+        dim_d.pop(axis)
+        Sop = Sum(dims=(par["ny"], par["nx"]), axis=axis, dtype=par["dtype"])
+        assert dottest(Sop, np.prod(dim_d), par["ny"] * par["nx"])
+
+
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
 def test_Sum2D_forceflat(par):
+    """Dot-test for Sum operator on 2d signal with forceflat"""
     np.random.seed(10)
     flat_dimsd = par["ny"]
     flat_dims = par["ny"] * par["nx"]
@@ -504,16 +515,6 @@ def test_Sum2D_forceflat(par):
 
     Sop = Sop_None * Sop_None.H
     assert Sop.forceflat is None
-
-
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
-def test_Sum2D(par):
-    """Dot-test for Sum operator on 2d signal"""
-    for axis in [0, 1]:
-        dim_d = [par["ny"], par["nx"]]
-        dim_d.pop(axis)
-        Sop = Sum(dims=(par["ny"], par["nx"]), axis=axis, dtype=par["dtype"])
-        assert dottest(Sop, np.prod(dim_d), par["ny"] * par["nx"])
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])

--- a/pytests/test_interpolation.py
+++ b/pytests/test_interpolation.py
@@ -406,6 +406,30 @@ def test_Bilinear_2dsignal(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
+def test_Bilinear_2dsignal_flatten(par):
+    """Dot-test and forward for Interp operator for 2d signal with forceflat"""
+    np.random.seed(1)
+    flat_dimsd = par["ny"]
+    flat_dims = par["nx"] * par["nt"]
+    dims = (par["nx"], par["nt"])
+
+    x = np.random.normal(0, 1, dims) + par["imag"] * np.random.normal(0, 1, dims)
+
+    iava = np.vstack((np.arange(0, 10), np.arange(0, 10)))
+    Iop_True = Bilinear(iava, dims=dims, dtype=par["dtype"], forceflat=True)
+    y = Iop_True @ x
+    xadj = Iop_True.H @ y
+    assert y.shape == (flat_dimsd,)
+    assert xadj.shape == (flat_dims,)
+
+    Iop_None = Bilinear(iava, dims=dims, dtype=par["dtype"])
+    y = Iop_None @ x
+    xadj = Iop_None.H @ y
+    assert y.shape == (par["ny"],)
+    assert xadj.shape == dims
+
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Bilinear_3dsignal(par):
     """Dot-test and forward for Interp operator for 3d signal"""
     np.random.seed(1)

--- a/pytests/test_interpolation.py
+++ b/pytests/test_interpolation.py
@@ -409,23 +409,23 @@ def test_Bilinear_2dsignal(par):
 def test_Bilinear_2dsignal_flatten(par):
     """Dot-test and forward for Interp operator for 2d signal with forceflat"""
     np.random.seed(1)
-    flat_dimsd = par["ny"]
-    flat_dims = par["nx"] * par["nt"]
     dims = (par["nx"], par["nt"])
+    flat_dims = par["nx"] * par["nt"]
+    dimsd = 10
 
     x = np.random.normal(0, 1, dims) + par["imag"] * np.random.normal(0, 1, dims)
 
-    iava = np.vstack((np.arange(0, 10), np.arange(0, 10)))
+    iava = np.vstack((np.arange(0, dimsd), np.arange(0, dimsd)))
     Iop_True = Bilinear(iava, dims=dims, dtype=par["dtype"], forceflat=True)
     y = Iop_True @ x
     xadj = Iop_True.H @ y
-    assert y.shape == (flat_dimsd,)
+    assert y.shape == (dimsd,)
     assert xadj.shape == (flat_dims,)
 
     Iop_None = Bilinear(iava, dims=dims, dtype=par["dtype"])
     y = Iop_None @ x
     xadj = Iop_None.H @ y
-    assert y.shape == (par["ny"],)
+    assert y.shape == (dimsd,)
     assert xadj.shape == dims
 
 


### PR DESCRIPTION
This PR tackles issue https://github.com/PyLops/pylops/issues/500 and aims to provide an easy way for users to drive the behavior of so called ambiguous operators* via keyword arguments, therefore avoid to use global settings or context manager provided by `pylops.config.disabled_ndarray_multiplication`

* An operator is defined ambiguous is the output of either matvec or rmatvec is a 1d array (aka if `dims` or `dimsd` have len=1) . In this case pylops cannot tell whether a user would like a nd array or a 1d array when either rmatvec or matvec is performed on the 1d array from the other method.

## Background 
A couple of remarks based on the discussion in the issue, before introducing the changes:

-  `Now if that is not possible, I don't like breaking the matrix-like functionality. The operations are called .matvec and .rmatvec,`: just to be clear `matvec` and `rmatvec` have always taken 1d arrays and returned 1d arrays. This was the case in v1 and this is still the case in v2. What changed now is that if you use `dot` (or the overloads `@` and `*` some internal checks happen such that one can provide ndarrays to an operator `Op` of shape `Op.dims` (for matvec) or of shape `Op.dimsd` (for rmatvec) and obtain ndarrays of shape `Op.dimsd` (for matvec) or of shape `Op.dims` (for rmatvec); alternatively, as in pylops v1, one can provide 1darrays of size `np.prod(Op.dims)`  (for matvec) and get 1darrays of size `np.prod(Op.dimsd)` - similar for rmatvec. Apart from the ambiguous operators that we are going to tackle here in a special way, all other operators should follow this pattern, if not it means there is a bug (which it may be the case for some operators - we already identified `Identity` for example.
- All pylops solvers that call `matvec` and `rmatvec` instead of `@` and `.H @` do not experience any problem even with the ambiguous operators. We will see in a minute that some still call `@` and `.H @` and explain why

## Changes
This PR introduces the following 3 major changes:

- All pylops solvers are modified to use `matvec` and `rmatvec` instead of `@` and `.H @`. This is good as it makes them run faster (see https://pylops.readthedocs.io/en/stable/tutorials/linearoperator.html) as well as prevents issues with ambiguous operators as they were up until now. For `ISTA` and `FISTA`, we need a special treatment since they allow multiple right-hand sides (https://github.com/PyLops/pylops/pull/266.).
- A new property called `forceflat` is added to `LinearOperator`. This property is always set to `None` other than for the ambiguous operators. In that case, users can choose to set it to `True` such that the output of matvec and/or rmatvec will be always forced to be flat - if instead set to `False`, which is the original behavior, the output  of matvec and/or rmatvec will be reshaped in the shape of `Op.dimsd` or `Op.dims` even when the input was a 1d array. 
- The `__add__` and `dot` methods of `LinearOperator` have been modified to check for inconsistencies in the `forceflat` property of the operators to be combined. Basically, if both of them have `forceflat` set to a boolean and they are inconsistent, an error will be raised.
- The `dot` method is modified such that when the input is a numpy array, the `forceflat` parameters is also used to check whether the input and output arrays should be reshaped into ndarrays or kept as 1darrays
-`Bilinear`, `Identity`,`MatrixMult`,  `Sum`, and composition operators `HStack`, `VStack`, and `BlockDiag` are ambiguous operators. As such we introduce`forceflat` as an additional input parameter. By choosing `forceflat=True` we ensure that the output of matvec/rmatvec is always a 1darray when the input is 1darray. 
- For `HStack` and `VStack`, there may be scenarios where Ndarrays are not a meaningful option (e.g., where `dims` of the two operators differ), in this case we internally force `forceflat=True` (not sure whether we should return a warning or not?)
- For `BlockDiag`, we check if dims/dimsd of all operators are the same and stack over a new zero axis (e.g., [nops, *dims]). However we also want to make sure that if we add an operator to the left or right the output can be either Ndarray or 1darray and chosen by the user via `forceflat` in `BlockDiag`.
- For `Block`, I wasn't able to identify any scenario where `forceflat` would be needed. To be on the safe side, I added it anyways*.
- `Identity` has been modified to accommodate for nd-arrays. For backward compatibiilty, `N` and `M` are kept, but they allow now also passing tuples (effectively becoming as if they were `dimsd` and `dims`).

* See Discussion

## Operators with missing dims/dimsd
- `Kronecker`: not sure how dims/dimsd would apply to this operator
 
## Discussion
I have identified a possibility for `VStack`, `HStack`, and `Block`,  which I think ideally makes sense but it becomes a breaking change. Basically, the idea is that we could have `dimsd` in VStack equal `nops x *dims(op)` and similar for HStack with `dims`. However to be backward compatible we would need to have `forceflat=True` as default. This would however force flat inputs and outputs also when VStack/HStack is chained with other operators, which is not the case... unless someone has any smart idea, we may need to accept this new behavior cannot be added :(
