### PR TITLE
patch: allow psnr to use range instead of max

### DIFF
--- a/pylops/utils/metrics.py
+++ b/pylops/utils/metrics.py
@@ -75,10 +75,10 @@ def snr(xref, xcmp):
     return snr
 
 
-def psnr(xref, xcmp, xmax=None):
+def psnr(xref, xcmp, xmax=None, xmin=0.0):
     """Peak Signal to Noise Ratio (PSNR)
 
-    Compute Peak Signal to Noise Ratio between two vectors.
+    Compute Peak Signal to Noise Ratio between two vectors
 
     Parameters
     ----------
@@ -89,6 +89,10 @@ def psnr(xref, xcmp, xmax=None):
     xmax : :obj:`float`, optional
       Maximum value to use. If ``None``, the actual maximum of
       the reference vector is used
+    xmin : :obj:`float`, optional
+      Minimum value to use. If ``None``, the actual minimum of
+      the reference vector is used (``0`` is default for
+      backward compatibility)
 
     Returns
     -------
@@ -98,5 +102,8 @@ def psnr(xref, xcmp, xmax=None):
     """
     if xmax is None:
         xmax = xref.max()
-    psrn = 10.0 * np.log10(xmax**2 / mse(xref, xcmp))
-    return psrn
+    if xmin is None:
+        xmin = xref.min()
+    xrange = xmax - xmin
+    psnr = 10.0 * np.log10(xrange**2 / mse(xref, xcmp))
+    return psnr

--- a/pytests/test_metrics.py
+++ b/pytests/test_metrics.py
@@ -49,7 +49,7 @@ def test_psnr(par):
     xref = np.ones(par["nx"])
     xcmp = np.zeros(par["nx"])
 
-    psnrsame = psnr(xref, xref, xmax=1.0)
-    psnrcmp = psnr(xref, xcmp, xmax=1.0)
+    psnrsame = psnr(xref, xref, xmax=1.0, xmin=0.0)
+    psnrcmp = psnr(xref, xcmp, xmax=1.0, xmin=0.0)
     assert psnrsame == np.inf
     assert psnrcmp == 0.0


### PR DESCRIPTION
This PR handles https://github.com/PyLops/pylops/issues/508 allowing to use the range of `xref` instead of just the maximum (required for non-strictly positive signals - signals with negative values). 

By adding `xmin=0` still ensure backward compatibility, but allows for using effective range by choosing the appropriate xmin