### PR TITLE
feature: restyling of Kirchhoff operator

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -8,8 +8,8 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
-        python-version: ["3.8", "3.9", "3.10"]
+        platform: [ ubuntu-latest, ]
+        python-version: ["3.8", ]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
           - --line-length=88
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -133,7 +133,7 @@ class Kirchhoff(LinearOperator):
     -----
     The Kirchhoff demigration operator synthesizes seismic data given a
     propagation velocity model :math:`v(\mathbf{x})` and a
-    reflectivity model :math:`m(\mathbf{x})`. In forward mode [1]_, [2]_:
+    reflectivity model :math:`m(\mathbf{x})`. In forward mode [1]_, [2]_, [3]_:
 
     .. math::
         d(\mathbf{x_r}, \mathbf{x_s}, t) =
@@ -175,7 +175,7 @@ class Kirchhoff(LinearOperator):
     :math:`\text{dist}(\mathbf{x}, \mathbf{y})=\|\mathbf{x} - \mathbf{y}\|`, whilst for
     ``mode=eikonal``, this is computed internally by the Eikonal solver.
 
-    The wavelet filtering is applied as follows [3]_:
+    The wavelet filtering is applied as follows [4]_:
 
     * ``2D``: :math:`\tilde{W}(f)=\sqrt{j\omega} \cdot W(f)`
     * ``3D``: :math:`\tilde{W}(f)=j\omega \cdot W(f)`
@@ -209,14 +209,18 @@ class Kirchhoff(LinearOperator):
     projects data in the model domain creating an image of the subsurface
     reflectivity.
 
-    .. [1] Bleistein, N., Cohen, J.K., and Stockwell, J.W..
+    .. [1] Bleistein, N., Cohen, J.K., and Stockwell, J.W.
        "Mathematics of Multidimensional Seismic Imaging, Migration and
        Inversion", 2000.
 
     .. [2] Santos, L.T., Schleicher, J., Tygel, M., and Hubral, P.
        "Seismic modeling by demigration", Geophysics, 65(4), pp. 1281-1289, 2000.
 
-    .. [3] Safron, L. "Multicomponent least-squares Kirchhoff depth migration",
+    .. [3] Yang, K., and Zhang, J. "Comparison between Born and Kirchhoff operators for
+       least-squares reverse time migration and the constraint of the propagation of the
+       background wavefield", Geophysics, 84(5), pp. R725-R739, 2019.
+
+    .. [4] Safron, L. "Multicomponent least-squares Kirchhoff depth migration",
        MSc Thesis, 2018.
 
     """
@@ -302,7 +306,7 @@ class Kirchhoff(LinearOperator):
                 ) = Kirchhoff._traveltime_table(z, x, srcs, recs, vel, y=y, mode=mode)
                 if self.dynamic:
                     # need to add a scalar in the denominator of amplitude term to avoid
-                    # division by 0, currently set to 1e-4 of max distance to avoid having
+                    # division by 0, currently set to 1e-2 of max distance to avoid having
                     # too large scaling around the source. This number may change in future
                     # or left to the user to define
                     epsdist = 1e-2
@@ -639,7 +643,7 @@ class Kirchhoff(LinearOperator):
             raise NotImplementedError("2.D wavelet currently not available")
         elif dimsrc == 3 and dimrec == 3 and dimv == 3:
             # 3D
-            Wfilt = W * (1j * 2 * np.pi * f)
+            Wfilt = W * (-1j * 2 * np.pi * f)
         wavfilt = np.fft.irfft(Wfilt, n=len(wav))
         return wavfilt
 

--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -137,18 +137,18 @@ class Kirchhoff(LinearOperator):
 
     .. math::
         d(\mathbf{x_r}, \mathbf{x_s}, t) =
-        \widetilde{w}(t) * \int_V \frac{2 cos(\theta)} {v(\mathbf{x})}
+        \widetilde{w}(t) * \int_V \frac{2 \cos\theta} {v(\mathbf{x})}
         G(\mathbf{x_r}, \mathbf{x}, t) G(\mathbf{x}, \mathbf{x_s}, t)
         m(\mathbf{x})  \,\mathrm{d}\mathbf{x}
 
     where :math:`G(\mathbf{x}, \mathbf{x_s}, t)` and :math:`G(\mathbf{x_r}, \mathbf{x}, t)`
     are the Green's functions from source-to-subsurface-to-receiver and finally
-    :math:`\widetilde{w}(t)` is a filtered version of the wavelet :math:`w(t)`
-    as explained below (or the wavelet itself when ``wavfilter=False``).
+    :math:`\widetilde{w}(t)` is either a filtered version of the wavelet :math:`w(t)`
+    as explained below (``wavfilter=True``) or the wavelet itself when (``wavfilter=False``).
     Moreover, an angle scaling is included in the modelling operator,
-    where :math:`\theta=(\theta_s-\theta_r)/2` is half of the opening angle,
-    where :math:`\theta_s` and :math:`\theta_r` are the angles between the source-side
-    and receiver-side rays and the vertical at the image point.
+    where the reflection angle :math:`\theta=(\theta_s-\theta_r)/2` is half of the opening angle,
+    with :math:`\theta_s` and :math:`\theta_r` representing the angles between the source-side
+    and receiver-side rays and the vertical at the image point, respectively.
 
     In our implementation, the following high-frequency approximation of the
     Green's functions is adopted:
@@ -168,14 +168,14 @@ class Kirchhoff(LinearOperator):
 
     On the  other hand, when ``dynamic=True``, the amplitude scaling is defined as
 
-    * ``2D``: :math:`a(\mathbf{x}, \mathbf{y})=\frac{1}{\sqrt{dist(\mathbf{x}, \mathbf{y})}}`
-    * ``3D``: :math:`a(\mathbf{x}, \mathbf{y})=\frac{1}{dist(\mathbf{x}, \mathbf{y})}`
+    * ``2D``: :math:`a(\mathbf{x}, \mathbf{y})=\frac{1}{\sqrt{\text{dist}(\mathbf{x}, \mathbf{y})}}`
+    * ``3D``: :math:`a(\mathbf{x}, \mathbf{y})=\frac{1}{\text{dist}(\mathbf{x}, \mathbf{y})}`
 
     approximating the geometrical spreading of the wavefront. For ``mode=analytic``,
-    :math:`dist(\mathbf{x}, \mathbf{y})=\|\mathbf{x} - \mathbf{y}\|`, whilst for
-    ``mode=eikonal``, this is instead computed internally by the eikonal solver.
+    :math:`\text{dist}(\mathbf{x}, \mathbf{y})=\|\mathbf{x} - \mathbf{y}\|`, whilst for
+    ``mode=eikonal``, this is computed internally by the Eikonal solver.
 
-    The wavelet filtering is applied as follows:
+    The wavelet filtering is applied as follows [3]_:
 
     * ``2D``: :math:`\tilde{W}(f)=\sqrt{j\omega} \cdot W(f)`
     * ``3D``: :math:`\tilde{W}(f)=j\omega \cdot W(f)`

--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -178,7 +178,7 @@ class Kirchhoff(LinearOperator):
     The wavelet filtering is applied as follows [4]_:
 
     * ``2D``: :math:`\tilde{W}(f)=\sqrt{j\omega} \cdot W(f)`
-    * ``3D``: :math:`\tilde{W}(f)=j\omega \cdot W(f)`
+    * ``3D``: :math:`\tilde{W}(f)=-j\omega \cdot W(f)`
 
     Depending on the choice of ``mode`` the traveltime and amplitude of the Green's
     function will be also computed differently:

--- a/pytests/test_kirchhoff.py
+++ b/pytests/test_kirchhoff.py
@@ -287,7 +287,7 @@ def test_kirchhoff3d(par):
 )
 def test_kirchhoff2d_trav_vs_travsrcrec(par):
     """Compare 2D Kirchhoff operator forward and adjoint when using trav (original behavior)
-    or trav_src and trav_rec (new reccomended behaviour)"""
+    or trav_src and trav_rec (new reccommended behaviour)"""
 
     # new behaviour
     Dop = Kirchhoff(
@@ -311,21 +311,7 @@ def test_kirchhoff2d_trav_vs_travsrcrec(par):
     ) + Dop.trav_recs.reshape(PAR["nx"] * PAR["nz"], 1, PAR["nrx"])
     trav = trav.reshape(PAR["nx"] * PAR["nz"], PAR["nsx"] * PAR["nrx"])
     if par["dynamic"]:
-        dist = Dop.dist_srcs.reshape(
-            PAR["nx"] * PAR["nz"], PAR["nsx"], 1
-        ) + Dop.dist_recs.reshape(PAR["nx"] * PAR["nz"], 1, PAR["nrx"])
-        dist = dist.reshape(PAR["nx"] * PAR["nz"], PAR["nsx"] * PAR["nrx"])
-
-        cosangle = np.cos(Dop.angle_srcs).reshape(
-            PAR["nx"] * PAR["nz"], PAR["nsx"], 1
-        ) + np.cos(Dop.angle_recs).reshape(PAR["nx"] * PAR["nz"], 1, PAR["nrx"])
-        cosangle = cosangle.reshape(PAR["nx"] * PAR["nz"], PAR["nsx"] * PAR["nrx"])
-
-        epsdist = 1e-2
-        amp = 1 / (dist + epsdist * np.max(dist))
-
-        amp *= np.abs(cosangle)
-        amp /= v0
+        amp = (Dop.amp_srcs, Dop.amp_recs)
 
     D1op = Kirchhoff(
         z,

--- a/pytests/test_kirchhoff.py
+++ b/pytests/test_kirchhoff.py
@@ -347,7 +347,7 @@ def test_kirchhoff2d_trav_vs_travsrcrec(par):
 )
 def test_kirchhoff3d_trav_vs_travsrcrec(par):
     """Compare 3D Kirchhoff operator forward and adjoint when using trav (original behavior)
-    or trav_src and trav_rec (new reccomended behaviour)"""
+    or trav_src and trav_rec (new recommended behaviour)"""
 
     # new behaviour
     Dop = Kirchhoff(

--- a/pytests/test_kirchhoff.py
+++ b/pytests/test_kirchhoff.py
@@ -287,7 +287,7 @@ def test_kirchhoff3d(par):
 )
 def test_kirchhoff2d_trav_vs_travsrcrec(par):
     """Compare 2D Kirchhoff operator forward and adjoint when using trav (original behavior)
-    or trav_src and trav_rec (new reccommended behaviour)"""
+    or trav_src and trav_rec (new recommended behaviour)"""
 
     # new behaviour
     Dop = Kirchhoff(


### PR DESCRIPTION
This PR introduces a number of changes to the Kirchhoff operator in an attempt to improve the amplitude fidelity of this modelling process with respect to finite-difference full wavefield modelling. Also follows from https://github.com/PyLops/pylops/issues/439.

Major changes:

- Remove `anglerefl` as the angle `theta` can be computed directly from the incident and reflection angles with normal
- Remove `snell` limitations, this is naturally handled by stationary-phase when summing along all possible image points and src-rec pairs
- Force `amp` to be provided as pair of tables like `trav`
- When `amp` is not provided, compute it as `1/sqrt(dist)` for both source and receiver side in 2D (and `1/dist` in 3D)
- Correct computation of `cos(\theta)`
- Documentation polished and fully consistent with code
