### PR TITLE
fix: change make rule for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dev-install_conda:
 
 tests:
 	make pythoncheck
-	$(PYTHON) setup.py test
+	pytest
 
 doc:
 	cd docs  && rm -rf source/api/generated && rm -rf source/gallery &&\


### PR DESCRIPTION
This PR fixes the `tests` rule as `setup.py` is not available anymore, instead `pytest` is used as the command to start tests.