### PR TITLE
Changing how optional dependencies are import state are checked 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,4 @@ A list of video tutorials to learn more about PyLops:
 * Rohan Babbar, rohanbabbar04
 * Wei Zhang, ZhangWeiGeo
 * Fedor Goncharov, fedor-goncharov
+* Alex Rakowski, alex-rakowski

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -21,3 +21,4 @@ Contributors
 *  `Rohan Babbar <https://github.com/rohanbabbar04>`_, rohanbabbar04
 *  `Wei Zhang <https://github.com/ZhangWeiGeo>`_, ZhangWeiGeo
 *  `Fedor Goncharov <https://github.com/fedor-goncharov>`_, fedor-goncharov
+*  `Alex Rakowski <https://github.com/alex-rakowski>`_, alex-rakowski

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -12,7 +12,7 @@ __all__ = [
 ]
 
 import os
-from importlib import util
+from importlib import import_module, util
 from typing import Optional
 
 
@@ -152,14 +152,14 @@ def cupy_import(message: Optional[str] = None):
     if cupy_test:
         # try importing it
         try:
-            import cupy  # noqa: F401
+            import_module("cupy")  # noqa: F401
 
             # if successful set the message to None.
             cupy_message = None
         # if unable to import but it is installed
         except (ImportError, ModuleNotFoundError) as e:
             cupy_message = (
-                f"Failed to import cupy. Falling back to CPU (error: {e}). "
+                f"Failed to import cupy, Falling back to CPU (error: {e}). "
                 f""
                 "Please ensure your CUDA envrionment is set up correctly "
                 "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
@@ -188,7 +188,7 @@ def cusignal_import(message: Optional[str] = None):
     if cusignal_test:
         # try importing it
         try:
-            import cusignal  # noqa: F401
+            import_module("cusignal")  # noqa: F401
 
             # if successful set the message to None.
             cusignal_message = None

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -22,17 +22,22 @@ def check_module_enabled(
     envrionment_val: Optional[int] = 1,
 ) -> bool:
     """
-    Checks whether a specific module can be imported in the current Python environment.
+    Check whether a specific module can be imported in the current Python environment.
 
-    Args:
-        module (str): The name of the module to check import state for.
-        envrionment_str (Optional[str]): An optional environment variable name to check for. If provided,
-            the function will return True only if the environment variable is set to the specified value.
-            Defaults to None.
-        envrionment_val (Optional[str]): The value to compare the environment variable against. Defaults to "1".
+    Parameters
+    ----------
+    module : str
+        The name of the module to check import state for.
+    environment_str : str, optional
+        An optional environment variable name to check for. If provided, the function will return True
+        only if the environment variable is set to the specified value. Defaults to None.
+    environment_val : str, optional
+        The value to compare the environment variable against. Defaults to "1".
 
-    Returns:
-        bool: True if the module is available, False otherwise.
+    Returns
+    -------
+    bool
+        True if the module is available, False otherwise.
     """
     # try to import the module
     try:

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -12,61 +12,52 @@ __all__ = [
 ]
 
 import os
-from importlib import import_module
-from typing import Optional
+
+# from importlib import import_module
+from importlib import util
+
+# from typing import Optional
 
 
-def check_module_enabled(
-    module: str,
-    envrionment_str: Optional[str] = None,
-    envrionment_val: Optional[int] = 1,
-) -> bool:
-    """
-    Check whether a specific module can be imported in the current Python environment.
+# def check_module_enabled(
+#     module: str,
+#     envrionment_str: Optional[str] = None,
+#     envrionment_val: Optional[int] = 1,
+# ) -> bool:
+#     """
+#     Check whether a specific module can be imported in the current Python environment.
 
-    Parameters
-    ----------
-    module : str
-        The name of the module to check import state for.
-    environment_str : str, optional
-        An optional environment variable name to check for. If provided, the function will return True
-        only if the environment variable is set to the specified value. Defaults to None.
-    environment_val : str, optional
-        The value to compare the environment variable against. Defaults to "1".
+#     Parameters
+#     ----------
+#     module : str
+#         The name of the module to check import state for.
+#     environment_str : str, optional
+#         An optional environment variable name to check for. If provided, the function will return True
+#         only if the environment variable is set to the specified value. Defaults to None.
+#     environment_val : str, optional
+#         The value to compare the environment variable against. Defaults to "1".
 
-    Returns
-    -------
-    bool
-        True if the module is available, False otherwise.
-    """
-    # try to import the module
-    try:
-        _ = import_module(module)  # noqa: F401
-        # run envrionment check if needed
-        if envrionment_str is not None:
-            # return True if the value matches expected value
-            return int(os.getenv(envrionment_str, envrionment_val)) == envrionment_val
-        # if no environment check return True as import_module worked
-        else:
-            return True
-    # if cannot import and provides expected Exceptions, return False
-    except (ImportError, ModuleNotFoundError):
-        return False
-    # raise warning if anyother exception raised in import
-    except Exception as e:
-        raise UserWarning(f"Unexpceted Exception when importing {module}") from e
-
-
-cupy_enabled = check_module_enabled("cupy", "CUPY_PYLOPS")
-cusignal_enabled = check_module_enabled("cusignal", "CUSIGNAL_PYLOPS")
-devito_enabled = check_module_enabled("devito")
-numba_enabled = check_module_enabled("numba")
-pyfftw_enabled = check_module_enabled("pyfftw")
-pywt_enabled = check_module_enabled("pywt")
-skfmm_enabled = check_module_enabled("skfmm")
-spgl1_enabled = check_module_enabled("spgl1")
-sympy_enabled = check_module_enabled("sympy")
-torch_enabled = check_module_enabled("torch")
+#     Returns
+#     -------
+#     bool
+#         True if the module is available, False otherwise.
+#     """
+#     # try to import the module
+#     try:
+#         _ = import_module(module)  # noqa: F401
+#         # run envrionment check if needed
+#         if envrionment_str is not None:
+#             # return True if the value matches expected value
+#             return int(os.getenv(envrionment_str, envrionment_val)) == envrionment_val
+#         # if no environment check return True as import_module worked
+#         else:
+#             return True
+#     # if cannot import and provides expected Exceptions, return False
+#     except (ImportError, ModuleNotFoundError):
+#         return False
+#     # raise warning if anyother exception raised in import
+#     except Exception as e:
+#         raise UserWarning(f"Unexpceted Exception when importing {module}") from e
 
 
 # error message at import of available package
@@ -194,3 +185,93 @@ def sympy_import(message):
             f'"pip install sympy".'
         )
     return sympy_message
+
+
+def cupy_import(message):
+    # detect if cupy should be importable
+    cupy_test = (
+        util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
+    )
+    # if cupy should be importable
+    if cupy_test:
+        # try importing it
+        try:
+            import cupy  # noqa: F401
+
+            # if successful set the message to None.
+            cupy_message = None
+        # if unable to import but it is installed
+        except (ImportError, ModuleNotFoundError) as e:
+            cupy_message = (
+                f"Failed to import cupy. Falling back to CPU (error: {e}) ."
+                f"{message} run"
+                "Please ensure your CUDA envrionment is set up correctly"
+                "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
+            )
+    # if cupy_test is False it means not installed or envrionment variable set to 0
+    else:
+        cupy_message = (
+            f"cupy package not installed or os.getenv('CUPY_PYLOPS') == 0. In order to be able to use "
+            f"{message} "
+            "os.getenv('CUPY_PYLOPS') == 1  and run"
+            "'pip install cupy'."
+            "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
+        )
+
+    return cupy_message
+
+
+def cusignal_import(message):
+    # detect if cupy should be importable
+    cusignal_test = (
+        util.find_spec("cusignal") is not None
+        and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
+    )
+    # if cupy should be importable
+    if cusignal_test:
+        # try importing it
+        try:
+            import cusignal  # noqa: F401
+
+            # if successful set the message to None.
+            cusignal_message = None
+        # if unable to import but it is installed
+        except (ImportError, ModuleNotFoundError) as e:
+            cusignal_message = (
+                f"Failed to import cusignal. Falling back to CPU (error: {e}) ."
+                f"{message} run"
+                "Please ensure your CUDA envrionment is set up correctly"
+                "for more details visit 'https://github.com/rapidsai/cusignal#installation'"
+            )
+    # if cupy_test is False it means not installed or envrionment variable set to 0
+    else:
+        cusignal_message = (
+            f"cusignal package not installed or os.getenv('CUSIGNAL_PYLOPS') == 0. In order to be able to use "
+            f"{message} "
+            "os.getenv('CUSIGNAL_PYLOPS') == 1  and run"
+            "'pip install cupy'."
+            "for more details visit ''https://github.com/rapidsai/cusignal#installation''"
+        )
+
+    return cusignal_message
+
+
+cupy_enabled = (
+    True
+    if (cupy_import() is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1)
+    else False  # noqa:F821,E501
+)
+cusignal_enabled = (
+    True
+    if (cusignal_import() is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1)
+    else False  # noqa:F821,E501
+)
+# cusignal_enabled = check_module_enabled("cusignal", "CUSIGNAL_PYLOPS")
+devito_enabled = util.find_spec("devito") is not None
+numba_enabled = util.find_spec("numba") is not None
+pyfftw_enabled = util.find_spec("pyfftw") is not None
+pywt_enabled = util.find_spec("pywt") is not None
+skfmm_enabled = util.find_spec("skfmm") is not None
+spgl1_enabled = util.find_spec("spgl1") is not None
+sympy_enabled = util.find_spec("sympy") is not None
+torch_enabled = util.find_spec("torch") is not None

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -15,9 +15,7 @@ import os
 
 # from importlib import import_module
 from importlib import util
-
-# from typing import Optional
-
+from typing import Optional
 
 # def check_module_enabled(
 #     module: str,
@@ -187,7 +185,7 @@ def sympy_import(message):
     return sympy_message
 
 
-def cupy_import(message):
+def cupy_import(message: Optional[str] = None):
     # detect if cupy should be importable
     cupy_test = (
         util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
@@ -221,7 +219,7 @@ def cupy_import(message):
     return cupy_message
 
 
-def cusignal_import(message):
+def cusignal_import(message: Optional[str] = None):
     # detect if cupy should be importable
     cusignal_test = (
         util.find_spec("cusignal") is not None

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -12,12 +12,23 @@ __all__ = [
 ]
 
 import os
-from importlib import util
+from importlib import import_module, util
 
 # check package availability
-cupy_enabled = (
-    util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
-)
+# cupy_enabled = (
+#     util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
+# )
+
+try:
+    import_module("cupy")
+    # if can succesfully import cupy, check envrionment
+    cupy_enabled = int(os.getenv("CUPY_PYLOPS", 1)) == 1
+except (ImportError, ModuleNotFoundError):
+    cupy_enabled = False
+except Exception as e:
+    raise UserWarning("Unexpceted Exception when importing cupy") from e
+
+
 cusignal_enabled = (
     util.find_spec("cusignal") is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
 )

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -255,14 +255,12 @@ def cusignal_import(message: Optional[str] = None):
 
 
 cupy_enabled = (
-    True
-    if (cupy_import() is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1)
-    else False  # noqa:F821,E501
+    True if (cupy_import() is None and int(os.getenv("CUPY_PYLOPS", 1)) == 1) else False
 )
 cusignal_enabled = (
     True
-    if (cusignal_import() is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1)
-    else False  # noqa:F821,E501
+    if (cusignal_import() is None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1)
+    else False
 )
 # cusignal_enabled = check_module_enabled("cusignal", "CUSIGNAL_PYLOPS")
 devito_enabled = util.find_spec("devito") is not None

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -17,10 +17,73 @@ from typing import Optional
 
 
 # error message at import of available package
-def devito_import(message):
+def cupy_import(message: Optional[str] = None) -> str:
+    # detect if cupy is available and the user is expecting to be used
+    cupy_test = (
+        util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
+    )
+    # if cupy should be importable
+    if cupy_test:
+        # try importing it
+        try:
+            import_module("cupy")  # noqa: F401
+
+            # if successful set the message to None.
+            cupy_message = None
+        # if unable to import but the package is installed
+        except (ImportError, ModuleNotFoundError) as e:
+            cupy_message = (
+                f"Failed to import cupy, Falling back to CPU (error: {e}). "
+                "Please ensure your CUDA environment is set up correctly "
+                "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
+            )
+            print(UserWarning(cupy_message))
+    # if cupy_test is False, it means not installed or environment variable set to 0
+    else:
+        cupy_message = (
+            "Cupy package not installed or os.getenv('CUPY_PYLOPS') == 0. "
+            f"In order to be able to use {message} "
+            "ensure 'os.getenv('CUPY_PYLOPS') == 1' and run "
+            "'pip install cupy'; "
+            "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
+        )
+
+    return cupy_message
+
+
+def cusignal_import(message: Optional[str] = None) -> str:
+    cusignal_test = (
+        util.find_spec("cusignal") is not None
+        and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
+    )
+    if cusignal_test:
+        try:
+            import_module("cusignal")  # noqa: F401
+
+            cusignal_message = None
+        except (ImportError, ModuleNotFoundError) as e:
+            cusignal_message = (
+                f"Failed to import cusignal. Falling back to CPU (error: {e}) . "
+                "Please ensure your CUDA environment is set up correctly; "
+                "for more details visit 'https://github.com/rapidsai/cusignal#installation'"
+            )
+            print(UserWarning(cusignal_message))
+    else:
+        cusignal_message = (
+            "Cusignal not installed or os.getenv('CUSIGNAL_PYLOPS') == 0. "
+            f"In order to be able to use {message} "
+            "ensure 'os.getenv('CUSIGNAL_PYLOPS') == 1' and run "
+            "'conda install cusignal'; "
+            "for more details visit ''https://github.com/rapidsai/cusignal#installation''"
+        )
+
+    return cusignal_message
+
+
+def devito_import(message: Optional[str] = None) -> str:
     if devito_enabled:
         try:
-            import devito  # noqa: F401
+            import_module("devito")  # noqa: F401
 
             devito_message = None
         except Exception as e:
@@ -34,10 +97,10 @@ def devito_import(message):
     return devito_message
 
 
-def numba_import(message):
+def numba_import(message: Optional[str] = None) -> str:
     if numba_enabled:
         try:
-            import numba  # noqa: F401
+            import_module("numba")  # noqa: F401
 
             numba_message = None
         except Exception as e:
@@ -53,10 +116,10 @@ def numba_import(message):
     return numba_message
 
 
-def pyfftw_import(message):
+def pyfftw_import(message: Optional[str] = None) -> str:
     if pyfftw_enabled:
         try:
-            import pyfftw  # noqa: F401
+            import_module("pyfftw")  # noqa: F401
 
             pyfftw_message = None
         except Exception as e:
@@ -72,10 +135,10 @@ def pyfftw_import(message):
     return pyfftw_message
 
 
-def pywt_import(message):
+def pywt_import(message: Optional[str] = None) -> str:
     if pywt_enabled:
         try:
-            import pywt  # noqa: F401
+            import_module("pywt")  # noqa: F401
 
             pywt_message = None
         except Exception as e:
@@ -91,10 +154,10 @@ def pywt_import(message):
     return pywt_message
 
 
-def skfmm_import(message):
+def skfmm_import(message: Optional[str] = None) -> str:
     if skfmm_enabled:
         try:
-            import skfmm  # noqa: F401
+            import_module("skfmm")  # noqa: F401
 
             skfmm_message = None
         except Exception as e:
@@ -109,10 +172,10 @@ def skfmm_import(message):
     return skfmm_message
 
 
-def spgl1_import(message):
+def spgl1_import(message: Optional[str] = None) -> str:
     if spgl1_enabled:
         try:
-            import spgl1  # noqa: F401
+            import_module("spgl1")  # noqa: F401
 
             spgl1_message = None
         except Exception as e:
@@ -126,10 +189,10 @@ def spgl1_import(message):
     return spgl1_message
 
 
-def sympy_import(message):
+def sympy_import(message: Optional[str] = None) -> str:
     if sympy_enabled:
         try:
-            import sympy  # noqa: F401
+            import_module("sympy")  # noqa: F401
 
             sympy_message = None
         except Exception as e:
@@ -143,78 +206,13 @@ def sympy_import(message):
     return sympy_message
 
 
-def cupy_import(message: Optional[str] = None):
-    # detect if cupy should be importable
-    cupy_test = (
-        util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
-    )
-    # if cupy should be importable
-    if cupy_test:
-        # try importing it
-        try:
-            import_module("cupy")  # noqa: F401
-
-            # if successful set the message to None.
-            cupy_message = None
-        # if unable to import but it is installed
-        except (ImportError, ModuleNotFoundError) as e:
-            cupy_message = (
-                f"Failed to import cupy, Falling back to CPU (error: {e}). "
-                f""
-                "Please ensure your CUDA envrionment is set up correctly "
-                "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
-            )
-            print(UserWarning(cupy_message))
-    # if cupy_test is False it means not installed or envrionment variable set to 0
-    else:
-        cupy_message = (
-            f"cupy package not installed or os.getenv('CUPY_PYLOPS') == 0. In order to be able to use "
-            f"{message} "
-            "ensure 'os.getenv('CUPY_PYLOPS') == 1' and run "
-            "'pip install cupy'. "
-            "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
-        )
-
-    return cupy_message
-
-
-def cusignal_import(message: Optional[str] = None):
-    # detect if cupy should be importable
-    cusignal_test = (
-        util.find_spec("cusignal") is not None
-        and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
-    )
-    # if cupy should be importable
-    if cusignal_test:
-        # try importing it
-        try:
-            import_module("cusignal")  # noqa: F401
-
-            # if successful set the message to None.
-            cusignal_message = None
-        # if unable to import but it is installed
-        except (ImportError, ModuleNotFoundError) as e:
-            cusignal_message = (
-                f"Failed to import cusignal. Falling back to CPU (error: {e}) . "
-                f""
-                "Please ensure your CUDA envrionment is set up correctly "
-                "for more details visit 'https://github.com/rapidsai/cusignal#installation'"
-            )
-            print(UserWarning(cusignal_message))
-    # if cupy_test is False it means not installed or envrionment variable set to 0
-    else:
-        cusignal_message = (
-            f"cusignal package not installed or os.getenv('CUSIGNAL_PYLOPS') == 0. In order to be able to use "
-            f"{message} "
-            "ensure 'os.getenv('CUSIGNAL_PYLOPS') == 1' and run "
-            "'conda install cusignal'. "
-            "for more details visit ''https://github.com/rapidsai/cusignal#installation''"
-        )
-
-    return cusignal_message
-
-
-# Set package avlaiblity booleans
+# Set package availability booleans
+# cupy and cusignal: the package is imported to check everything is working correctly,
+# if not the package is disabled. We do this here as both libraries are used as drop-in
+# replacement for many numpy and scipy routines when cupy arrays are provided.
+# all other libraries: we simply check if the package is available and postpone its import
+# to check everything is working correctly when a user tries to create an operator that requires
+# such a package
 cupy_enabled: bool = (
     True if (cupy_import() is None and int(os.getenv("CUPY_PYLOPS", 1)) == 1) else False
 )

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -12,32 +12,8 @@ __all__ = [
 ]
 
 import os
-from importlib import import_module  # , util
+from importlib import import_module
 from typing import Optional
-
-# check package availability
-# cupy_enabled = (
-#     util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
-# )
-# cusignal_enabled = (
-#     util.find_spec("cusignal") is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
-# )
-# try:
-#     import_module("cupy")
-#     # if can succesfully import cupy, check envrionment
-#     cupy_enabled = int(os.getenv("CUPY_PYLOPS", 1)) == 1
-# except (ImportError, ModuleNotFoundError):
-#     cupy_enabled = False
-# except Exception as e:
-#     raise UserWarning("Unexpceted Exception when importing cupy") from e
-# devito_enabled = util.find_spec("devito") is not None
-# numba_enabled = util.find_spec("numba") is not None
-# pyfftw_enabled = util.find_spec("pyfftw") is not None
-# pywt_enabled = util.find_spec("pywt") is not None
-# skfmm_enabled = util.find_spec("skfmm") is not None
-# spgl1_enabled = util.find_spec("spgl1") is not None
-# sympy_enabled = util.find_spec("sympy") is not None
-# torch_enabled = util.find_spec("torch") is not None
 
 
 def check_module_enabled(
@@ -60,7 +36,7 @@ def check_module_enabled(
     """
     # try to import the module
     try:
-        import_module(module)
+        _ = import_module(module)  # noqa: F401
         # run envrionment check if needed
         if envrionment_str is not None:
             # return True if the value matches expected value

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -12,50 +12,8 @@ __all__ = [
 ]
 
 import os
-
-# from importlib import import_module
 from importlib import util
 from typing import Optional
-
-# def check_module_enabled(
-#     module: str,
-#     envrionment_str: Optional[str] = None,
-#     envrionment_val: Optional[int] = 1,
-# ) -> bool:
-#     """
-#     Check whether a specific module can be imported in the current Python environment.
-
-#     Parameters
-#     ----------
-#     module : str
-#         The name of the module to check import state for.
-#     environment_str : str, optional
-#         An optional environment variable name to check for. If provided, the function will return True
-#         only if the environment variable is set to the specified value. Defaults to None.
-#     environment_val : str, optional
-#         The value to compare the environment variable against. Defaults to "1".
-
-#     Returns
-#     -------
-#     bool
-#         True if the module is available, False otherwise.
-#     """
-#     # try to import the module
-#     try:
-#         _ = import_module(module)  # noqa: F401
-#         # run envrionment check if needed
-#         if envrionment_str is not None:
-#             # return True if the value matches expected value
-#             return int(os.getenv(envrionment_str, envrionment_val)) == envrionment_val
-#         # if no environment check return True as import_module worked
-#         else:
-#             return True
-#     # if cannot import and provides expected Exceptions, return False
-#     except (ImportError, ModuleNotFoundError):
-#         return False
-#     # raise warning if anyother exception raised in import
-#     except Exception as e:
-#         raise UserWarning(f"Unexpceted Exception when importing {module}") from e
 
 
 # error message at import of available package
@@ -211,7 +169,7 @@ def cupy_import(message: Optional[str] = None):
         cupy_message = (
             f"cupy package not installed or os.getenv('CUPY_PYLOPS') == 0. In order to be able to use "
             f"{message} "
-            "os.getenv('CUPY_PYLOPS') == 1  and run"
+            "ensure 'os.getenv('CUPY_PYLOPS') == 1' and run"
             "'pip install cupy'."
             "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
         )
@@ -246,23 +204,23 @@ def cusignal_import(message: Optional[str] = None):
         cusignal_message = (
             f"cusignal package not installed or os.getenv('CUSIGNAL_PYLOPS') == 0. In order to be able to use "
             f"{message} "
-            "os.getenv('CUSIGNAL_PYLOPS') == 1  and run"
-            "'pip install cupy'."
+            "ensure 'os.getenv('CUSIGNAL_PYLOPS') == 1' and run"
+            "'conda install cusignal'."
             "for more details visit ''https://github.com/rapidsai/cusignal#installation''"
         )
 
     return cusignal_message
 
 
-cupy_enabled = (
+# Set package avlaiblity booleans
+cupy_enabled: bool = (
     True if (cupy_import() is None and int(os.getenv("CUPY_PYLOPS", 1)) == 1) else False
 )
-cusignal_enabled = (
+cusignal_enabled: bool = (
     True
     if (cusignal_import() is None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1)
     else False
 )
-# cusignal_enabled = check_module_enabled("cusignal", "CUSIGNAL_PYLOPS")
 devito_enabled = util.find_spec("devito") is not None
 numba_enabled = util.find_spec("numba") is not None
 pyfftw_enabled = util.find_spec("pyfftw") is not None

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -12,14 +12,16 @@ __all__ = [
 ]
 
 import os
-from importlib import import_module, util
+from importlib import import_module  # , util
 from typing import Optional
 
 # check package availability
 # cupy_enabled = (
 #     util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
 # )
-
+# cusignal_enabled = (
+#     util.find_spec("cusignal") is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
+# )
 # try:
 #     import_module("cupy")
 #     # if can succesfully import cupy, check envrionment
@@ -28,40 +30,62 @@ from typing import Optional
 #     cupy_enabled = False
 # except Exception as e:
 #     raise UserWarning("Unexpceted Exception when importing cupy") from e
+# devito_enabled = util.find_spec("devito") is not None
+# numba_enabled = util.find_spec("numba") is not None
+# pyfftw_enabled = util.find_spec("pyfftw") is not None
+# pywt_enabled = util.find_spec("pywt") is not None
+# skfmm_enabled = util.find_spec("skfmm") is not None
+# spgl1_enabled = util.find_spec("spgl1") is not None
+# sympy_enabled = util.find_spec("sympy") is not None
+# torch_enabled = util.find_spec("torch") is not None
 
 
 def check_module_enabled(
     module: str,
     envrionment_str: Optional[str] = None,
-    envrionment_val: Optional[str] = "1",
+    envrionment_val: Optional[int] = 1,
 ) -> bool:
+    """
+    Checks whether a specific module can be imported in the current Python environment.
 
+    Args:
+        module (str): The name of the module to check import state for.
+        envrionment_str (Optional[str]): An optional environment variable name to check for. If provided,
+            the function will return True only if the environment variable is set to the specified value.
+            Defaults to None.
+        envrionment_val (Optional[str]): The value to compare the environment variable against. Defaults to "1".
+
+    Returns:
+        bool: True if the module is available, False otherwise.
+    """
+    # try to import the module
     try:
         import_module(module)
-
+        # run envrionment check if needed
         if envrionment_str is not None:
-            return os.environ[envrionment_str] == envrionment_val
+            # return True if the value matches expected value
+            return int(os.getenv(envrionment_str, envrionment_val)) == envrionment_val
+        # if no environment check return True as import_module worked
         else:
             return True
+    # if cannot import and provides expected Exceptions, return False
     except (ImportError, ModuleNotFoundError):
         return False
+    # raise warning if anyother exception raised in import
     except Exception as e:
-        raise UserWarning("Unexpceted Exception when importing cupy") from e
+        raise UserWarning(f"Unexpceted Exception when importing {module}") from e
 
 
 cupy_enabled = check_module_enabled("cupy", "CUPY_PYLOPS")
-
-cusignal_enabled = (
-    util.find_spec("cusignal") is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1
-)
-devito_enabled = util.find_spec("devito") is not None
-numba_enabled = util.find_spec("numba") is not None
-pyfftw_enabled = util.find_spec("pyfftw") is not None
-pywt_enabled = util.find_spec("pywt") is not None
-skfmm_enabled = util.find_spec("skfmm") is not None
-spgl1_enabled = util.find_spec("spgl1") is not None
-sympy_enabled = util.find_spec("sympy") is not None
-torch_enabled = util.find_spec("torch") is not None
+cusignal_enabled = check_module_enabled("cusignal", "CUSIGNAL_PYLOPS")
+devito_enabled = check_module_enabled("devito")
+numba_enabled = check_module_enabled("numba")
+pyfftw_enabled = check_module_enabled("pyfftw")
+pywt_enabled = check_module_enabled("pywt")
+skfmm_enabled = check_module_enabled("skfmm")
+spgl1_enabled = check_module_enabled("spgl1")
+sympy_enabled = check_module_enabled("sympy")
+torch_enabled = check_module_enabled("torch")
 
 
 # error message at import of available package

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -159,18 +159,19 @@ def cupy_import(message: Optional[str] = None):
         # if unable to import but it is installed
         except (ImportError, ModuleNotFoundError) as e:
             cupy_message = (
-                f"Failed to import cupy. Falling back to CPU (error: {e}) ."
-                f"{message} run"
-                "Please ensure your CUDA envrionment is set up correctly"
+                f"Failed to import cupy. Falling back to CPU (error: {e}). "
+                f"{message} run "
+                "Please ensure your CUDA envrionment is set up correctly "
                 "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
             )
+            print(cupy_message)
     # if cupy_test is False it means not installed or envrionment variable set to 0
     else:
         cupy_message = (
             f"cupy package not installed or os.getenv('CUPY_PYLOPS') == 0. In order to be able to use "
             f"{message} "
-            "ensure 'os.getenv('CUPY_PYLOPS') == 1' and run"
-            "'pip install cupy'."
+            "ensure 'os.getenv('CUPY_PYLOPS') == 1' and run "
+            "'pip install cupy'. "
             "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
         )
 
@@ -194,18 +195,19 @@ def cusignal_import(message: Optional[str] = None):
         # if unable to import but it is installed
         except (ImportError, ModuleNotFoundError) as e:
             cusignal_message = (
-                f"Failed to import cusignal. Falling back to CPU (error: {e}) ."
-                f"{message} run"
-                "Please ensure your CUDA envrionment is set up correctly"
+                f"Failed to import cusignal. Falling back to CPU (error: {e}) . "
+                f"{message} run "
+                "Please ensure your CUDA envrionment is set up correctly "
                 "for more details visit 'https://github.com/rapidsai/cusignal#installation'"
             )
+            print(cusignal_message)
     # if cupy_test is False it means not installed or envrionment variable set to 0
     else:
         cusignal_message = (
             f"cusignal package not installed or os.getenv('CUSIGNAL_PYLOPS') == 0. In order to be able to use "
             f"{message} "
-            "ensure 'os.getenv('CUSIGNAL_PYLOPS') == 1' and run"
-            "'conda install cusignal'."
+            "ensure 'os.getenv('CUSIGNAL_PYLOPS') == 1' and run "
+            "'conda install cusignal'. "
             "for more details visit ''https://github.com/rapidsai/cusignal#installation''"
         )
 

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -37,7 +37,7 @@ def check_module_enabled(
 ) -> bool:
 
     try:
-        import_module("module")
+        import_module(module)
 
         if envrionment_str is not None:
             return os.environ[envrionment_str] == envrionment_val

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -13,21 +13,43 @@ __all__ = [
 
 import os
 from importlib import import_module, util
+from typing import Optional
 
 # check package availability
 # cupy_enabled = (
 #     util.find_spec("cupy") is not None and int(os.getenv("CUPY_PYLOPS", 1)) == 1
 # )
 
-try:
-    import_module("cupy")
-    # if can succesfully import cupy, check envrionment
-    cupy_enabled = int(os.getenv("CUPY_PYLOPS", 1)) == 1
-except (ImportError, ModuleNotFoundError):
-    cupy_enabled = False
-except Exception as e:
-    raise UserWarning("Unexpceted Exception when importing cupy") from e
+# try:
+#     import_module("cupy")
+#     # if can succesfully import cupy, check envrionment
+#     cupy_enabled = int(os.getenv("CUPY_PYLOPS", 1)) == 1
+# except (ImportError, ModuleNotFoundError):
+#     cupy_enabled = False
+# except Exception as e:
+#     raise UserWarning("Unexpceted Exception when importing cupy") from e
 
+
+def check_module_enabled(
+    module: str,
+    envrionment_str: Optional[str] = None,
+    envrionment_val: Optional[str] = "1",
+) -> bool:
+
+    try:
+        import_module("module")
+
+        if envrionment_str is not None:
+            return os.environ[envrionment_str] == envrionment_val
+        else:
+            return True
+    except (ImportError, ModuleNotFoundError):
+        return False
+    except Exception as e:
+        raise UserWarning("Unexpceted Exception when importing cupy") from e
+
+
+cupy_enabled = check_module_enabled("cupy", "CUPY_PYLOPS")
 
 cusignal_enabled = (
     util.find_spec("cusignal") is not None and int(os.getenv("CUSIGNAL_PYLOPS", 1)) == 1

--- a/pylops/utils/deps.py
+++ b/pylops/utils/deps.py
@@ -160,11 +160,11 @@ def cupy_import(message: Optional[str] = None):
         except (ImportError, ModuleNotFoundError) as e:
             cupy_message = (
                 f"Failed to import cupy. Falling back to CPU (error: {e}). "
-                f"{message} run "
+                f""
                 "Please ensure your CUDA envrionment is set up correctly "
                 "for more details visit 'https://docs.cupy.dev/en/stable/install.html'"
             )
-            print(cupy_message)
+            print(UserWarning(cupy_message))
     # if cupy_test is False it means not installed or envrionment variable set to 0
     else:
         cupy_message = (
@@ -196,11 +196,11 @@ def cusignal_import(message: Optional[str] = None):
         except (ImportError, ModuleNotFoundError) as e:
             cusignal_message = (
                 f"Failed to import cusignal. Falling back to CPU (error: {e}) . "
-                f"{message} run "
+                f""
                 "Please ensure your CUDA envrionment is set up correctly "
                 "for more details visit 'https://github.com/rapidsai/cusignal#installation'"
             )
-            print(cusignal_message)
+            print(UserWarning(cusignal_message))
     # if cupy_test is False it means not installed or envrionment variable set to 0
     else:
         cusignal_message = (

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -162,7 +162,7 @@ par_lists_fft_small_real = dict(
         (np.float16, 1),
         (np.float32, 4),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
     ],
     norm=["ortho", "none", "1/n"],
     ifftshift_before=[False, True],
@@ -234,7 +234,7 @@ par_lists_fft_random_real = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
     ],
     ifftshift_before=[False, True],
     engine=["numpy", "fftw", "scipy"],
@@ -280,7 +280,7 @@ def test_FFT_random_real(par):
 
 
 par_lists_fft_small_cpx = dict(
-    dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.clongdouble, 11)],
+    dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.complex256, 11)],
     norm=["ortho", "none", "1/n"],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
@@ -344,10 +344,10 @@ par_lists_fft_random_cpx = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
         (np.complex64, 3),
         (np.complex128, 11),
-        (np.clongdouble, 11),
+        (np.complex256, 11),
     ],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
@@ -426,7 +426,7 @@ par_lists_fft2d_random_real = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
     ],
     ifftshift_before=[False, True],
     engine=["numpy", "scipy"],
@@ -484,10 +484,10 @@ par_lists_fft2d_random_cpx = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
         (np.complex64, 3),
         (np.complex128, 11),
-        (np.clongdouble, 11),
+        (np.complex256, 11),
     ],
     ifftshift_before=itertools.product([False, True], [False, True]),
     fftshift_after=itertools.product([False, True], [False, True]),
@@ -566,7 +566,7 @@ par_lists_fftnd_random_real = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
     ],
     engine=["numpy", "scipy"],
 )
@@ -625,10 +625,10 @@ par_lists_fftnd_random_cpx = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.longdouble, 11),
+        (np.float128, 11),
         (np.complex64, 3),
         (np.complex128, 11),
-        (np.clongdouble, 11),
+        (np.complex256, 11),
     ],
     engine=["numpy", "scipy"],
 )
@@ -700,7 +700,7 @@ def test_FFTND_random_complex(par):
 
 
 par_lists_fft2dnd_small_cpx = dict(
-    dtype_precision=[(np.complex64, 5), (np.complex128, 11), (np.clongdouble, 11)],
+    dtype_precision=[(np.complex64, 5), (np.complex128, 11), (np.complex256, 11)],
     norm=["ortho", "none", "1/n"],
     engine=["numpy", "scipy"],
 )
@@ -874,15 +874,7 @@ def test_FFT_1dsignal(par):
         assert_array_almost_equal(y_fftshift, np.fft.fftshift(y))
 
         xadj = FFTop_fftshift.H * y_fftshift  # adjoint is same as inverse for fft
-        xinv = lsqr(
-            FFTop_fftshift,
-            y_fftshift,
-            damp=1e-10,
-            iter_lim=10,
-            atol=1e-8,
-            btol=1e-8,
-            show=0,
-        )[0]
+        xinv = lsqr(FFTop_fftshift, y_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
         assert_array_almost_equal(x[:imax], xadj[:imax], decimal=decimal)
         assert_array_almost_equal(x[:imax], xinv[:imax], decimal=decimal)
 
@@ -966,15 +958,7 @@ def test_FFT_2dsignal(par):
         assert_array_almost_equal(D_fftshift, D2)
 
         dadj = FFTop_fftshift.H * D_fftshift  # adjoint is same as inverse for fft
-        dinv = lsqr(
-            FFTop_fftshift,
-            D_fftshift,
-            damp=1e-10,
-            iter_lim=10,
-            atol=1e-8,
-            btol=1e-8,
-            show=0,
-        )[0]
+        dinv = lsqr(FFTop_fftshift, D_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
 
         dadj = np.real(dadj.reshape(nt, nx))
         dinv = np.real(dinv.reshape(nt, nx))
@@ -1032,15 +1016,7 @@ def test_FFT_2dsignal(par):
         assert_array_almost_equal(D_fftshift, D2)
 
         dadj = FFTop_fftshift.H * D_fftshift  # adjoint is same as inverse for fft
-        dinv = lsqr(
-            FFTop_fftshift,
-            D_fftshift,
-            damp=1e-10,
-            iter_lim=10,
-            atol=1e-8,
-            btol=1e-8,
-            show=0,
-        )[0]
+        dinv = lsqr(FFTop_fftshift, D_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
 
         dadj = np.real(dadj.reshape(nt, nx))
         dinv = np.real(dinv.reshape(nt, nx))
@@ -1217,15 +1193,7 @@ def test_FFT_3dsignal(par):
         assert_array_almost_equal(D_fftshift, D2)
 
         dadj = FFTop_fftshift.H * D_fftshift  # adjoint is same as inverse for fft
-        dinv = lsqr(
-            FFTop_fftshift,
-            D_fftshift,
-            damp=1e-10,
-            iter_lim=10,
-            atol=1e-8,
-            btol=1e-8,
-            show=0,
-        )[0]
+        dinv = lsqr(FFTop_fftshift, D_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
 
         dadj = np.real(dadj.reshape(nt, nx, ny))
         dinv = np.real(dinv.reshape(nt, nx, ny))

--- a/pytests/test_ffts.py
+++ b/pytests/test_ffts.py
@@ -162,7 +162,7 @@ par_lists_fft_small_real = dict(
         (np.float16, 1),
         (np.float32, 4),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
     ],
     norm=["ortho", "none", "1/n"],
     ifftshift_before=[False, True],
@@ -234,7 +234,7 @@ par_lists_fft_random_real = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
     ],
     ifftshift_before=[False, True],
     engine=["numpy", "fftw", "scipy"],
@@ -280,7 +280,7 @@ def test_FFT_random_real(par):
 
 
 par_lists_fft_small_cpx = dict(
-    dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.complex256, 11)],
+    dtype_precision=[(np.complex64, 4), (np.complex128, 11), (np.clongdouble, 11)],
     norm=["ortho", "none", "1/n"],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
@@ -344,10 +344,10 @@ par_lists_fft_random_cpx = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
         (np.complex64, 3),
         (np.complex128, 11),
-        (np.complex256, 11),
+        (np.clongdouble, 11),
     ],
     ifftshift_before=[False, True],
     fftshift_after=[False, True],
@@ -426,7 +426,7 @@ par_lists_fft2d_random_real = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
     ],
     ifftshift_before=[False, True],
     engine=["numpy", "scipy"],
@@ -484,10 +484,10 @@ par_lists_fft2d_random_cpx = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
         (np.complex64, 3),
         (np.complex128, 11),
-        (np.complex256, 11),
+        (np.clongdouble, 11),
     ],
     ifftshift_before=itertools.product([False, True], [False, True]),
     fftshift_after=itertools.product([False, True], [False, True]),
@@ -566,7 +566,7 @@ par_lists_fftnd_random_real = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
     ],
     engine=["numpy", "scipy"],
 )
@@ -625,10 +625,10 @@ par_lists_fftnd_random_cpx = dict(
         (np.float16, 1),
         (np.float32, 3),
         (np.float64, 11),
-        (np.float128, 11),
+        (np.longdouble, 11),
         (np.complex64, 3),
         (np.complex128, 11),
-        (np.complex256, 11),
+        (np.clongdouble, 11),
     ],
     engine=["numpy", "scipy"],
 )
@@ -700,7 +700,7 @@ def test_FFTND_random_complex(par):
 
 
 par_lists_fft2dnd_small_cpx = dict(
-    dtype_precision=[(np.complex64, 5), (np.complex128, 11), (np.complex256, 11)],
+    dtype_precision=[(np.complex64, 5), (np.complex128, 11), (np.clongdouble, 11)],
     norm=["ortho", "none", "1/n"],
     engine=["numpy", "scipy"],
 )
@@ -874,7 +874,15 @@ def test_FFT_1dsignal(par):
         assert_array_almost_equal(y_fftshift, np.fft.fftshift(y))
 
         xadj = FFTop_fftshift.H * y_fftshift  # adjoint is same as inverse for fft
-        xinv = lsqr(FFTop_fftshift, y_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        xinv = lsqr(
+            FFTop_fftshift,
+            y_fftshift,
+            damp=1e-10,
+            iter_lim=10,
+            atol=1e-8,
+            btol=1e-8,
+            show=0,
+        )[0]
         assert_array_almost_equal(x[:imax], xadj[:imax], decimal=decimal)
         assert_array_almost_equal(x[:imax], xinv[:imax], decimal=decimal)
 
@@ -958,7 +966,15 @@ def test_FFT_2dsignal(par):
         assert_array_almost_equal(D_fftshift, D2)
 
         dadj = FFTop_fftshift.H * D_fftshift  # adjoint is same as inverse for fft
-        dinv = lsqr(FFTop_fftshift, D_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        dinv = lsqr(
+            FFTop_fftshift,
+            D_fftshift,
+            damp=1e-10,
+            iter_lim=10,
+            atol=1e-8,
+            btol=1e-8,
+            show=0,
+        )[0]
 
         dadj = np.real(dadj.reshape(nt, nx))
         dinv = np.real(dinv.reshape(nt, nx))
@@ -1016,7 +1032,15 @@ def test_FFT_2dsignal(par):
         assert_array_almost_equal(D_fftshift, D2)
 
         dadj = FFTop_fftshift.H * D_fftshift  # adjoint is same as inverse for fft
-        dinv = lsqr(FFTop_fftshift, D_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        dinv = lsqr(
+            FFTop_fftshift,
+            D_fftshift,
+            damp=1e-10,
+            iter_lim=10,
+            atol=1e-8,
+            btol=1e-8,
+            show=0,
+        )[0]
 
         dadj = np.real(dadj.reshape(nt, nx))
         dinv = np.real(dinv.reshape(nt, nx))
@@ -1193,7 +1217,15 @@ def test_FFT_3dsignal(par):
         assert_array_almost_equal(D_fftshift, D2)
 
         dadj = FFTop_fftshift.H * D_fftshift  # adjoint is same as inverse for fft
-        dinv = lsqr(FFTop_fftshift, D_fftshift, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        dinv = lsqr(
+            FFTop_fftshift,
+            D_fftshift,
+            damp=1e-10,
+            iter_lim=10,
+            atol=1e-8,
+            btol=1e-8,
+            show=0,
+        )[0]
 
         dadj = np.real(dadj.reshape(nt, nx, ny))
         dinv = np.real(dinv.reshape(nt, nx, ny))


### PR DESCRIPTION
This PR changes how optional dependencies import states are checked, to address #548. Importing on Colab now works without requiring adding `os.envion["CUPY_PYLOPS] = "0"`. Instead of using `importlib.util.find_spec` to get state,  this uses `importlib.import_module` in a `try/except` block.

```python
!pip install git+https://github.com/alex-rakowski/pylops.git@optional-depends-checker > /dev/null
import pylops
states_to_check = [
    "cupy_enabled",
    "cusignal_enabled",
    "devito_enabled",
    "numba_enabled",
    "pyfftw_enabled",
    "pywt_enabled",
    "skfmm_enabled",
    "spgl1_enabled",
    "sympy_enabled",
    "torch_enabled",
]
for state in states_to_check:
  s = getattr(pylops.utils, state)
  print(f"{state}: {s}")
  
cupy_enabled: False
cusignal_enabled: False
devito_enabled: False
numba_enabled: True
pyfftw_enabled: False
pywt_enabled: True
skfmm_enabled: False
spgl1_enabled: False
sympy_enabled: True
torch_enabled: True
  ```

I changed `np.float128` and `np.complex256` to `np.longdouble` and `np.clongdouble` in `test_fft.py` to run tests on my local mac. Tests are passing on linux machine, and on mac (with the exception of the 7 mentioned in #550). I can revert these changes if desired. 