### PR TITLE
adding make dev-install_conda_arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ install_conda:
 dev-install_conda:
 	conda env create -f environment-dev.yml && conda activate pylops && pip install -e .
 
+dev-intsall_conda_arm:
+	conda env create -f environment-dev-arm.yml && conda activate pylops && pip install -e .
+
 tests:
 	make pythoncheck
 	pytest

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install_conda:
 dev-install_conda:
 	conda env create -f environment-dev.yml && conda activate pylops && pip install -e .
 
-dev-intsall_conda_arm:
+dev-install_conda_arm:
 	conda env create -f environment-dev-arm.yml && conda activate pylops && pip install -e .
 
 tests:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -99,7 +99,8 @@ For a ``conda`` environment, run
 
 .. code-block:: bash
 
-   >> make dev-install_conda
+   >> make dev-install_conda # for x86 (Intel or AMD CPUs)
+   >> make dev-install_conda_arm # for arm (M-series macbook)
 
 This will create and activate an environment called ``pylops``, with all required and optional dependencies.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -100,7 +100,7 @@ For a ``conda`` environment, run
 .. code-block:: bash
 
    >> make dev-install_conda # for x86 (Intel or AMD CPUs)
-   >> make dev-install_conda_arm # for arm (M-series macbook)
+   >> make dev-install_conda_arm # for arm (M-series Mac)
 
 This will create and activate an environment called ``pylops``, with all required and optional dependencies.
 

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -1,0 +1,37 @@
+name: pylops_new
+channels:
+  - defaults
+  - conda-forge
+  - numba
+  - pytorch
+dependencies:
+  - python>=3.6.4
+  - pip
+  - numpy>=1.21.0
+  - scipy>=1.4.0
+  - pytorch>=1.2.0
+  - pyfftw
+  - pywavelets
+  - sympy
+  - matplotlib
+  - ipython
+  - pytest
+  - Sphinx
+  - numpydoc
+  - numba
+  - pre-commit
+  - autopep8
+  - isort
+  - black
+  - pip:
+    - devito
+    - scikit-fmm
+    - spgl1
+    - pytest-runner
+    - setuptools_scm
+    - pydata-sphinx-theme
+    - sphinx-gallery
+    - nbsphinx
+    - image
+    - flake8
+    - mypy

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -1,4 +1,4 @@
-name: pylops_new
+name: pylops
 channels:
   - defaults
   - conda-forge


### PR DESCRIPTION
This PR adds a dev install conda envrionment for arm CPUs. 
Currently `make dev-install_conda` fails on M-series macs as `icc_rt` only works on x86. 

- adds `dev-install_conda_arm` to the make file
- adds `environment-dev-arm.yml` to repo which is the same as `envionment-dev.yml` without `icc_rt` dependency.
- updates `installation.rst` to add `make install dev-install_conda_arm` option to the docs. 