### PR TITLE
fix: better handling of nttot in BlendingContinuous

### DIFF
--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -76,7 +76,12 @@ class BlendingContinuous(LinearOperator):
         self.dt = dt
         self.times = times
         self.shiftall = shiftall
-        self.nttot = int(np.max(self.times) / self.dt + self.nt + 1)
+        if np.max(self.times) // dt == np.max(self.times) / dt:
+            # do not add extra sample as no shift will be applied
+            self.nttot = int(np.max(self.times) / self.dt + self.nt)
+        else:
+            # add 1 extra sample at the end
+            self.nttot = int(np.max(self.times) / self.dt + self.nt + 1)
         if not self.shiftall:
             # original implementation, where each source is shifted indipendently
             self.PadOp = Pad((self.nr, self.nt), ((0, 0), (0, 1)), dtype=self.dtype)


### PR DESCRIPTION
This PR adds some extra logic to nttot in BlendingContinuous which ensures that the minimum length is chosen based on whether the last firing shot requires decimal shift or not.