### PR TITLE
build: force torch cpuonly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PIP := $(shell command -v pip3 2> /dev/null || command which pip 2> /dev/null)
 PYTHON := $(shell command -v python3 2> /dev/null || command which python 2> /dev/null)
 
-.PHONY: install dev-install install_conda dev-install_conda tests doc docupdate
+.PHONY: install dev-install install_conda dev-install_conda tests doc docupdate servedoc lint typeannot coverage
 
 pipcheck:
 ifndef PIP

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy>=1.21.0
   - scipy>=1.4.0
   - pytorch>=1.2.0
+  - cpuonly
   - pyfftw
   - pywavelets
   - sympy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy>=1.21.0
   - scipy>=1.4.0
   - pytorch>=1.2.0
+  - cpuonly
   - pyfftw
   - pywavelets
   - sympy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 numpy>=1.21.0
 scipy>=1.4.0
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch>=1.2.0
 numba
 pyfftw


### PR DESCRIPTION
This PR fixes all requirements/environment files to ensure that the CPU version torch is installed even if a GPU is detected