### PR TITLE
Patch: scipy v1.11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-13 ]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-13 ]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
 #   steps:
 #   - task: UsePythonVersion@0
 #     inputs:
-#       versionSpec: '3.7'
+#       versionSpec: '3.9'
 #       architecture: 'x64'
 #
 #   - script: |
@@ -55,7 +55,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.9'
       architecture: 'x64'
 
   - script: |
@@ -84,7 +84,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.8'
+      versionSpec: '3.9'
       architecture: 'x64'
 
   - script: |

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,7 +9,7 @@ The PyLops project strives to create a library that is easy to install in
 any environment and has a very limited number of dependencies.
 Required dependencies are limited to:
 
-* Python 3.8 or greater
+* Python 3.9 or greater
 * `NumPy <http://www.numpy.org>`_
 * `SciPy <http://www.scipy.org/scipylib/index.html>`_
 

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -8,7 +8,7 @@ dependencies:
   - python>=3.6.4
   - pip
   - numpy>=1.21.0,<2.0.0
-  - scipy>=1.14.0
+  - scipy>=1.11.0
   - pytorch>=1.2.0
   - cpuonly
   - pyfftw

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -8,7 +8,7 @@ dependencies:
   - python>=3.6.4
   - pip
   - numpy>=1.21.0,<2.0.0
-  - scipy>=1.4.0,<=1.13.0
+  - scipy>=1.14.0
   - pytorch>=1.2.0
   - cpuonly
   - pyfftw

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - python>=3.6.4
   - pip
   - numpy>=1.21.0,<2.0.0
-  - scipy>=1.14.0
+  - scipy>=1.11.0
   - pytorch>=1.2.0
   - cpuonly
   - pyfftw

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,7 +8,7 @@ dependencies:
   - python>=3.6.4
   - pip
   - numpy>=1.21.0,<2.0.0
-  - scipy>=1.4.0,<=1.13.0
+  - scipy>=1.14.0
   - pytorch>=1.2.0
   - cpuonly
   - pyfftw

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - python>=3.6.4
   - numpy>=1.21.0,<2.0.0
-  - scipy>=1.4.0,<=1.13.0
+  - scipy>=1.14.0

--- a/pylops/optimization/cls_leastsquares.py
+++ b/pylops/optimization/cls_leastsquares.py
@@ -219,7 +219,7 @@ class NormalEquationsInversion(Solver):
             and cupy `data`, respectively)
 
             .. note::
-                When user does not supply ``atol``, it is set to "legacy".
+                When user supplies ``tol`` this is set to ``atol``.
 
         Returns
         -------
@@ -238,8 +238,9 @@ class NormalEquationsInversion(Solver):
         if x is not None:
             self.y_normal = self.y_normal - self.Op_normal.matvec(x)
         if engine == "scipy" and self.ncp == np:
-            if "atol" not in kwargs_solver:
-                kwargs_solver["atol"] = "legacy"
+            if "tol" in kwargs_solver:
+                kwargs_solver["atol"] = kwargs_solver["tol"]
+                kwargs_solver.pop("tol")
             xinv, istop = sp_cg(self.Op_normal, self.y_normal, **kwargs_solver)
         elif engine == "pylops" or self.ncp != np:
             if show:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy >= 1.21.0 , < 2.0.0",
-    "scipy >= 1.14.0",
+    "scipy >= 1.11.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy >= 1.21.0 , < 2.0.0",
-    "scipy >= 1.4.0 , <= 1.13.0",
+    "scipy >= 1.14.0",
 ]
 dynamic = ["version"]
 

--- a/pytests/test_leastsquares.py
+++ b/pytests/test_leastsquares.py
@@ -93,12 +93,12 @@ def test_NormalEquationsInversion(par):
 
     # normal equations with regularization
     xinv = normal_equations_inversion(
-        Gop, y, [Reg], epsI=1e-5, epsRs=[1e-8], x0=x0, **dict(maxiter=200, tol=1e-10)
+        Gop, y, [Reg], epsI=1e-5, epsRs=[1e-8], x0=x0, **dict(maxiter=200, atol=1e-10)
     )[0]
     assert_array_almost_equal(x, xinv, decimal=3)
     # normal equations with weight
     xinv = normal_equations_inversion(
-        Gop, y, None, Weight=Weigth, epsI=1e-5, x0=x0, **dict(maxiter=200, tol=1e-10)
+        Gop, y, None, Weight=Weigth, epsI=1e-5, x0=x0, **dict(maxiter=200, atol=1e-10)
     )[0]
     assert_array_almost_equal(x, xinv, decimal=3)
     # normal equations with weight and small regularization
@@ -110,7 +110,7 @@ def test_NormalEquationsInversion(par):
         epsI=1e-5,
         epsRs=[1e-8],
         x0=x0,
-        **dict(maxiter=200, tol=1e-10)
+        **dict(maxiter=200, atol=1e-10)
     )[0]
     assert_array_almost_equal(x, xinv, decimal=3)
     # normal equations with weight and small normal regularization
@@ -123,7 +123,7 @@ def test_NormalEquationsInversion(par):
         epsI=1e-5,
         epsNRs=[1e-8],
         x0=x0,
-        **dict(maxiter=200, tol=1e-10)
+        **dict(maxiter=200, atol=1e-10)
     )[0]
     assert_array_almost_equal(x, xinv, decimal=3)
 
@@ -192,7 +192,7 @@ def test_WeightedInversion(par):
     y = Gop * x
 
     xne = normal_equations_inversion(
-        Gop, y, None, Weight=Weigth, **dict(maxiter=5, tol=1e-10)
+        Gop, y, None, Weight=Weigth, **dict(maxiter=5, atol=1e-10)
     )[0]
     xreg = regularized_inversion(
         Gop, y, None, Weight=Weigth1, **dict(damp=0, iter_lim=5, show=0)

--- a/pytests/test_linearoperator.py
+++ b/pytests/test_linearoperator.py
@@ -122,7 +122,7 @@ def test_sparse(par):
     D = np.diag(diag)
     Dop = Diagonal(diag, dtype=par["dtype"])
     S = Dop.tosparse()
-    assert_array_equal(S.A, D)
+    assert_array_equal(S.toarray(), D)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j)])

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -86,7 +86,7 @@ def test_cg(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=par["nx"], atol=1e-5, show=True)[0]
+    xinv = cg(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
     assert_array_almost_equal(x, xinv, decimal=4)
 
 
@@ -114,7 +114,7 @@ def test_cg_ndarray(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, atol=1e-5, show=True)[0]
+    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=1e-5, show=True)[0]
     assert xinv.shape == x.shape
     assert_array_almost_equal(x, xinv, decimal=4)
 
@@ -143,7 +143,7 @@ def test_cg_forceflat(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, atol=1e-5, show=True)[0]
+    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=1e-5, show=True)[0]
     assert xinv.shape == x.ravel().shape
     assert_array_almost_equal(x.ravel(), xinv, decimal=4)
 
@@ -169,7 +169,7 @@ def test_cgls(par):
         x0 = None
 
     y = Aop * x
-    xinv = cgls(Aop, y, x0=x0, niter=par["nx"], atol=1e-5, show=True)[0]
+    xinv = cgls(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
     assert_array_almost_equal(x, xinv, decimal=4)
 
 

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -86,7 +86,7 @@ def test_cg(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
+    xinv = cg(Aop, y, x0=x0, niter=par["nx"], atol=1e-5, show=True)[0]
     assert_array_almost_equal(x, xinv, decimal=4)
 
 
@@ -114,7 +114,7 @@ def test_cg_ndarray(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=1e-5, show=True)[0]
+    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, atol=1e-5, show=True)[0]
     assert xinv.shape == x.shape
     assert_array_almost_equal(x, xinv, decimal=4)
 
@@ -143,7 +143,7 @@ def test_cg_forceflat(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=1e-5, show=True)[0]
+    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, atol=1e-5, show=True)[0]
     assert xinv.shape == x.ravel().shape
     assert_array_almost_equal(x.ravel(), xinv, decimal=4)
 
@@ -169,7 +169,7 @@ def test_cgls(par):
         x0 = None
 
     y = Aop * x
-    xinv = cgls(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
+    xinv = cgls(Aop, y, x0=x0, niter=par["nx"], atol=1e-5, show=True)[0]
     assert_array_almost_equal(x, xinv, decimal=4)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.21.0,<2.0.0
-scipy>=1.14.0
+scipy>=1.11.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=1.2.0
 numba

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.21.0,<2.0.0
-scipy>=1.4.0,<=1.13.0
+scipy>=1.14.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=1.2.0
 numba


### PR DESCRIPTION
This PR is aimed at solving some of the issues arising in our test suite when scipy v1.14 is used. This is mostly related to an (announced) breaking change in the new version for the `scipy.sparse.linalg.cg` solver, namely:

```
The tol argument of scipy.sparse.linalg.{bcg,bicstab,cg,cgs,gcrotmk, mres,lgmres,minres,qmr,tfqmr} 
has been removed in favour of rtol. Furthermore, the default value of atol for these 
functions has changed to 0.0.
```

See https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html

As a result of this change, we decided to:

- Bump the minimal python requirement to 3.9
- Bump the minimal scipy requirement to 1.13
- Change `tol` into `atol` when passed to the scipy cg solver in `NormalEquationsInversion`
