### PR TITLE
Feature: add edge and edgeside to NonStationaryConvolve2D

### DIFF
--- a/pylops/signalprocessing/nonstatconvolve2d.py
+++ b/pylops/signalprocessing/nonstatconvolve2d.py
@@ -586,6 +586,8 @@ class NonStationaryFilters2D(LinearOperator):
             self.dhz,
             self.nhx,
             self.nhz,
+            None,
+            None,
             **self.kwargs_cuda
         )
         return y


### PR DESCRIPTION
This PR introduces a new feature to the NonStationaryConvolve2D operator via the `edge` and `edgeside` optional parameters, which control whether the edge filters are extended with or without tapering to the edge of the input model.

Currently the new feature is only present in the CPU implementation, whilst is missing in the GPU implementation (to be added before merging this PR).