### PR TITLE
Feature: migrate to numpy v2.0.0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,6 @@ sphinx:
 # Declare the Python requirements required to build your docs
 python:
   install:
-    - requirements: requirements-dev.txt
+    - requirements: requirements-doc.txt
     - method: pip
       path: .

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -321,6 +321,11 @@ In alphabetic order:
 
 dtcwt
 -----
+
+.. warning::
+
+   ``dtcwt`` is not yet supported with Numpy 2.
+
 `dtcwt <https://dtcwt.readthedocs.io/en/0.12.0/>`_ is a library used to implement the DT-CWT operators.
 
 Install it via ``pip`` with:
@@ -328,6 +333,7 @@ Install it via ``pip`` with:
 .. code-block:: bash
 
    >> pip install dtcwt
+
 
 
 Devito
@@ -468,6 +474,11 @@ or with ``pip`` via
 
 SPGL1
 -----
+
+.. warning::
+   
+   ``SPGL1`` is not yet supported with Numpy 2.
+
 `SPGL1 <https://spgl1.readthedocs.io/en/latest/>`_ is used to solve sparsity-promoting
 basis pursuit, basis pursuit denoise, and Lasso problems
 in :py:func:`pylops.optimization.sparsity.SPGL1` solver.

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python>=3.6.4
   - pip
-  - numpy>=1.21.0,<2.0.0
+  - numpy>=1.21.0
   - scipy>=1.11.0
   - pytorch>=1.2.0
   - cpuonly

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python>=3.6.4
   - pip
-  - numpy>=1.21.0,<2.0.0
+  - numpy>=1.21.0
   - scipy>=1.11.0
   - pytorch>=1.2.0
   - cpuonly

--- a/environment.yml
+++ b/environment.yml
@@ -3,5 +3,5 @@ channels:
   - defaults
 dependencies:
   - python>=3.6.4
-  - numpy>=1.21.0,<2.0.0
+  - numpy>=1.21.0
   - scipy>=1.14.0

--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -1,12 +1,11 @@
 __all__ = ["Restriction"]
 
 import logging
-
 from typing import Sequence, Union
 
 import numpy as np
 import numpy.ma as np_ma
-from numpy.core.multiarray import normalize_axis_index
+from numpy.lib.array_utils import normalize_axis_index
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_sized_to_tuple
@@ -128,8 +127,13 @@ class Restriction(LinearOperator):
                 )
                 forceflat = None
 
-        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd,
-                         forceflat=forceflat, name=name)
+        super().__init__(
+            dtype=np.dtype(dtype),
+            dims=dims,
+            dimsd=dimsd,
+            forceflat=forceflat,
+            name=name,
+        )
 
         iavareshape = np.ones(len(self.dims), dtype=int)
         iavareshape[axis] = len(iava)

--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -5,7 +5,14 @@ from typing import Sequence, Union
 
 import numpy as np
 import numpy.ma as np_ma
-from numpy.lib.array_utils import normalize_axis_index
+
+# need to check numpy version since normalize_axis_index will be
+# soon moved from numpy.core.multiarray to from numpy.lib.array_utils
+np_version = np.__version__.split(".")
+if int(np_version[0]) < 2:
+    from numpy.core.multiarray import normalize_axis_index
+else:
+    from numpy.lib.array_utils import normalize_axis_index
 
 from pylops import LinearOperator
 from pylops.utils._internal import _value_or_sized_to_tuple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 dependencies = [
-    "numpy >= 1.21.0 , < 2.0.0",
+    "numpy >= 1.21.0",
     "scipy >= 1.11.0",
 ]
 dynamic = ["version"]

--- a/pytests/test_dtcwt.py
+++ b/pytests/test_dtcwt.py
@@ -3,6 +3,9 @@ import pytest
 
 from pylops.signalprocessing import DTCWT
 
+# currently test only if numpy<2.0.0 is installed...
+np_version = np.__version__.split(".")
+
 par1 = {"ny": 10, "nx": 10, "dtype": "float64"}
 par2 = {"ny": 50, "nx": 50, "dtype": "float64"}
 
@@ -17,66 +20,67 @@ def sequential_array(shape):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input1D(par):
     """Test for DTCWT with 1D input"""
+    if int(np_version[0]) < 2:
+        t = sequential_array((par["ny"],))
 
-    t = sequential_array((par["ny"],))
+        for level in range(1, 10):
+            Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
+            x = Dtcwt @ t
+            y = Dtcwt.H @ x
 
-    for level in range(1, 10):
-        Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
-        x = Dtcwt @ t
-        y = Dtcwt.H @ x
-
-        np.testing.assert_allclose(t, y)
+            np.testing.assert_allclose(t, y)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input2D(par):
     """Test for DTCWT with 2D input (forward-inverse pair)"""
-
-    t = sequential_array(
-        (
-            par["ny"],
-            par["ny"],
+    if int(np_version[0]) < 2:
+        t = sequential_array(
+            (
+                par["ny"],
+                par["ny"],
+            )
         )
-    )
 
-    for level in range(1, 10):
-        Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
-        x = Dtcwt @ t
-        y = Dtcwt.H @ x
+        for level in range(1, 10):
+            Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
+            x = Dtcwt @ t
+            y = Dtcwt.H @ x
 
-        np.testing.assert_allclose(t, y)
+            np.testing.assert_allclose(t, y)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input3D(par):
     """Test for DTCWT with 3D input (forward-inverse pair)"""
+    if int(np_version[0]) < 2:
+        t = sequential_array((par["ny"], par["ny"], par["ny"]))
 
-    t = sequential_array((par["ny"], par["ny"], par["ny"]))
+        for level in range(1, 10):
+            Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
+            x = Dtcwt @ t
+            y = Dtcwt.H @ x
 
-    for level in range(1, 10):
-        Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
-        x = Dtcwt @ t
-        y = Dtcwt.H @ x
-
-        np.testing.assert_allclose(t, y)
+            np.testing.assert_allclose(t, y)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_birot(par):
     """Test for DTCWT birot (forward-inverse pair)"""
-    birots = ["antonini", "legall", "near_sym_a", "near_sym_b"]
+    if int(np_version[0]) < 2:
+        birots = ["antonini", "legall", "near_sym_a", "near_sym_b"]
 
-    t = sequential_array(
-        (
-            par["ny"],
-            par["ny"],
+        t = sequential_array(
+            (
+                par["ny"],
+                par["ny"],
+            )
         )
-    )
 
-    for _b in birots:
-        print(f"birot {_b}")
-        Dtcwt = DTCWT(dims=t.shape, biort=_b, dtype=par["dtype"])
-        x = Dtcwt @ t
-        y = Dtcwt.H @ x
+        for _b in birots:
+            print(f"birot {_b}")
+            Dtcwt = DTCWT(dims=t.shape, biort=_b, dtype=par["dtype"])
+            x = Dtcwt @ t
+            y = Dtcwt.H @ x
 
-        np.testing.assert_allclose(t, y)
+            np.testing.assert_allclose(t, y)

--- a/pytests/test_dtcwt.py
+++ b/pytests/test_dtcwt.py
@@ -20,67 +20,75 @@ def sequential_array(shape):
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input1D(par):
     """Test for DTCWT with 1D input"""
-    if int(np_version[0]) < 2:
-        t = sequential_array((par["ny"],))
+    if int(np_version[0]) >= 2:
+        return
 
-        for level in range(1, 10):
-            Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
-            x = Dtcwt @ t
-            y = Dtcwt.H @ x
+    t = sequential_array((par["ny"],))
 
-            np.testing.assert_allclose(t, y)
+    for level in range(1, 10):
+        Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
+        x = Dtcwt @ t
+        y = Dtcwt.H @ x
+
+        np.testing.assert_allclose(t, y)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input2D(par):
     """Test for DTCWT with 2D input (forward-inverse pair)"""
-    if int(np_version[0]) < 2:
-        t = sequential_array(
-            (
-                par["ny"],
-                par["ny"],
-            )
+    if int(np_version[0]) >= 2:
+        return
+
+    t = sequential_array(
+        (
+            par["ny"],
+            par["ny"],
         )
+    )
 
-        for level in range(1, 10):
-            Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
-            x = Dtcwt @ t
-            y = Dtcwt.H @ x
+    for level in range(1, 10):
+        Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
+        x = Dtcwt @ t
+        y = Dtcwt.H @ x
 
-            np.testing.assert_allclose(t, y)
+        np.testing.assert_allclose(t, y)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input3D(par):
     """Test for DTCWT with 3D input (forward-inverse pair)"""
-    if int(np_version[0]) < 2:
-        t = sequential_array((par["ny"], par["ny"], par["ny"]))
+    if int(np_version[0]) >= 2:
+        return
 
-        for level in range(1, 10):
-            Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
-            x = Dtcwt @ t
-            y = Dtcwt.H @ x
+    t = sequential_array((par["ny"], par["ny"], par["ny"]))
 
-            np.testing.assert_allclose(t, y)
+    for level in range(1, 10):
+        Dtcwt = DTCWT(dims=t.shape, level=level, dtype=par["dtype"])
+        x = Dtcwt @ t
+        y = Dtcwt.H @ x
+
+        np.testing.assert_allclose(t, y)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_birot(par):
     """Test for DTCWT birot (forward-inverse pair)"""
-    if int(np_version[0]) < 2:
-        birots = ["antonini", "legall", "near_sym_a", "near_sym_b"]
+    if int(np_version[0]) >= 2:
+        return
 
-        t = sequential_array(
-            (
-                par["ny"],
-                par["ny"],
-            )
+    birots = ["antonini", "legall", "near_sym_a", "near_sym_b"]
+
+    t = sequential_array(
+        (
+            par["ny"],
+            par["ny"],
         )
+    )
 
-        for _b in birots:
-            print(f"birot {_b}")
-            Dtcwt = DTCWT(dims=t.shape, biort=_b, dtype=par["dtype"])
-            x = Dtcwt @ t
-            y = Dtcwt.H @ x
+    for _b in birots:
+        print(f"birot {_b}")
+        Dtcwt = DTCWT(dims=t.shape, biort=_b, dtype=par["dtype"])
+        x = Dtcwt @ t
+        y = Dtcwt.H @ x
 
-            np.testing.assert_allclose(t, y)
+        np.testing.assert_allclose(t, y)

--- a/pytests/test_sparsity.py
+++ b/pytests/test_sparsity.py
@@ -362,25 +362,27 @@ def test_ISTA_FISTA_multiplerhs(par):
 )
 def test_SPGL1(par):
     """Invert problem with SPGL1"""
-    if int(np_version[0]) < 2:
-        np.random.seed(42)
-        Aop = MatrixMult(np.random.randn(par["ny"], par["nx"]))
+    if int(np_version[0]) >= 2:
+        return
 
-        x = np.zeros(par["nx"])
-        x[par["nx"] // 2] = 1
-        x[3] = 1
-        x[par["nx"] - 4] = -1
+    np.random.seed(42)
+    Aop = MatrixMult(np.random.randn(par["ny"], par["nx"]))
 
-        x0 = (
-            np.random.normal(0, 10, par["nx"])
-            + par["imag"] * np.random.normal(0, 10, par["nx"])
-            if par["x0"]
-            else None
-        )
-        y = Aop * x
-        xinv = spgl1(Aop, y, x0=x0, iter_lim=5000)[0]
+    x = np.zeros(par["nx"])
+    x[par["nx"] // 2] = 1
+    x[3] = 1
+    x[par["nx"] - 4] = -1
 
-        assert_array_almost_equal(x, xinv, decimal=1)
+    x0 = (
+        np.random.normal(0, 10, par["nx"])
+        + par["imag"] * np.random.normal(0, 10, par["nx"])
+        if par["x0"]
+        else None
+    )
+    y = Aop * x
+    xinv = spgl1(Aop, y, x0=x0, iter_lim=5000)[0]
+
+    assert_array_almost_equal(x, xinv, decimal=1)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
@@ -416,6 +418,6 @@ def test_SplitBregman(par):
         x0=x0 if par["x0"] else None,
         restart=False,
         show=False,
-        **dict(iter_lim=5, damp=1e-3)
+        **dict(iter_lim=5, damp=1e-3),
     )
     assert (np.linalg.norm(x - xinv) / np.linalg.norm(x)) < 1e-1

--- a/pytests/test_sparsity.py
+++ b/pytests/test_sparsity.py
@@ -5,6 +5,9 @@ from numpy.testing import assert_array_almost_equal
 from pylops.basicoperators import FirstDerivative, Identity, MatrixMult
 from pylops.optimization.sparsity import fista, irls, ista, omp, spgl1, splitbregman
 
+# currently test spgl1 only if numpy<2.0.0 is installed...
+np_version = np.__version__.split(".")
+
 par1 = {
     "ny": 11,
     "nx": 11,
@@ -359,24 +362,25 @@ def test_ISTA_FISTA_multiplerhs(par):
 )
 def test_SPGL1(par):
     """Invert problem with SPGL1"""
-    np.random.seed(42)
-    Aop = MatrixMult(np.random.randn(par["ny"], par["nx"]))
+    if int(np_version[0]) < 2:
+        np.random.seed(42)
+        Aop = MatrixMult(np.random.randn(par["ny"], par["nx"]))
 
-    x = np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+        x = np.zeros(par["nx"])
+        x[par["nx"] // 2] = 1
+        x[3] = 1
+        x[par["nx"] - 4] = -1
 
-    x0 = (
-        np.random.normal(0, 10, par["nx"])
-        + par["imag"] * np.random.normal(0, 10, par["nx"])
-        if par["x0"]
-        else None
-    )
-    y = Aop * x
-    xinv = spgl1(Aop, y, x0=x0, iter_lim=5000)[0]
+        x0 = (
+            np.random.normal(0, 10, par["nx"])
+            + par["imag"] * np.random.normal(0, 10, par["nx"])
+            if par["x0"]
+            else None
+        )
+        y = Aop * x
+        xinv = spgl1(Aop, y, x0=x0, iter_lim=5000)[0]
 
-    assert_array_almost_equal(x, xinv, decimal=1)
+        assert_array_almost_equal(x, xinv, decimal=1)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -21,7 +21,7 @@ def test_TorchOperator(par):
     """
     # temporarily, skip tests on mac as torch seems not to recognized
     # numpy when v2 is installed
-    if platform.system is not "Darwin":
+    if platform.system() != "Darwin":
         Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
         Top = TorchOperator(Dop, batch=False)
 
@@ -47,7 +47,7 @@ def test_TorchOperator_batch(par):
     """Apply forward for input with multiple samples (= batch) and flattened arrays"""
     # temporarily, skip tests on mac as torch seems not to recognized
     # numpy when v2 is installed
-    if platform.system is not "Darwin":
+    if platform.system() != "Darwin":
         Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
         Top = TorchOperator(Dop, batch=True)
 
@@ -66,7 +66,7 @@ def test_TorchOperator_batch_nd(par):
     """Apply forward for input with multiple samples (= batch) and nd-arrays"""
     # temporarily, skip tests on mac as torch seems not to recognized
     # numpy when v2 is installed
-    if platform.system is not "Darwin":
+    if platform.system() != "Darwin":
         Dop = MatrixMult(
             np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,)
         )

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -21,25 +21,27 @@ def test_TorchOperator(par):
     """
     # temporarily, skip tests on mac as torch seems not to recognized
     # numpy when v2 is installed
-    if platform.system() != "Darwin":
-        Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
-        Top = TorchOperator(Dop, batch=False)
+    if platform.system() == "Darwin":
+        return
 
-        x = np.random.normal(0.0, 1.0, par["nx"])
-        xt = torch.from_numpy(x).view(-1)
-        xt.requires_grad = True
-        v = torch.randn(par["ny"])
+    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
+    Top = TorchOperator(Dop, batch=False)
 
-        # pylops operator
-        y = Dop * x
-        xadj = Dop.H * v
+    x = np.random.normal(0.0, 1.0, par["nx"])
+    xt = torch.from_numpy(x).view(-1)
+    xt.requires_grad = True
+    v = torch.randn(par["ny"])
 
-        # torch operator
-        yt = Top.apply(xt)
-        yt.backward(v, retain_graph=True)
+    # pylops operator
+    y = Dop * x
+    xadj = Dop.H * v
 
-        assert_array_equal(y, yt.detach().cpu().numpy())
-        assert_array_equal(xadj, xt.grad.cpu().numpy())
+    # torch operator
+    yt = Top.apply(xt)
+    yt.backward(v, retain_graph=True)
+
+    assert_array_equal(y, yt.detach().cpu().numpy())
+    assert_array_equal(xadj, xt.grad.cpu().numpy())
 
 
 @pytest.mark.parametrize("par", [(par1)])
@@ -47,18 +49,20 @@ def test_TorchOperator_batch(par):
     """Apply forward for input with multiple samples (= batch) and flattened arrays"""
     # temporarily, skip tests on mac as torch seems not to recognized
     # numpy when v2 is installed
-    if platform.system() != "Darwin":
-        Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
-        Top = TorchOperator(Dop, batch=True)
+    if platform.system() == "Darwin":
+        return
 
-        x = np.random.normal(0.0, 1.0, (4, par["nx"]))
-        xt = torch.from_numpy(x)
-        xt.requires_grad = True
+    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
+    Top = TorchOperator(Dop, batch=True)
 
-        y = Dop.matmat(x.T).T
-        yt = Top.apply(xt)
+    x = np.random.normal(0.0, 1.0, (4, par["nx"]))
+    xt = torch.from_numpy(x)
+    xt.requires_grad = True
 
-        assert_array_equal(y, yt.detach().cpu().numpy())
+    y = Dop.matmat(x.T).T
+    yt = Top.apply(xt)
+
+    assert_array_equal(y, yt.detach().cpu().numpy())
 
 
 @pytest.mark.parametrize("par", [(par1)])
@@ -66,17 +70,17 @@ def test_TorchOperator_batch_nd(par):
     """Apply forward for input with multiple samples (= batch) and nd-arrays"""
     # temporarily, skip tests on mac as torch seems not to recognized
     # numpy when v2 is installed
-    if platform.system() != "Darwin":
-        Dop = MatrixMult(
-            np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,)
-        )
-        Top = TorchOperator(Dop, batch=True, flatten=False)
+    if platform.system() == "Darwin":
+        return
 
-        x = np.random.normal(0.0, 1.0, (4, par["nx"], 2))
-        xt = torch.from_numpy(x)
-        xt.requires_grad = True
+    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,))
+    Top = TorchOperator(Dop, batch=True, flatten=False)
 
-        y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
-        yt = Top.apply(xt)
+    x = np.random.normal(0.0, 1.0, (4, par["nx"], 2))
+    xt = torch.from_numpy(x)
+    xt.requires_grad = True
 
-        assert_array_equal(y, yt.detach().cpu().numpy())
+    y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
+    yt = Top.apply(xt)
+
+    assert_array_equal(y, yt.detach().cpu().numpy())

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -1,3 +1,5 @@
+import platform
+
 import numpy as np
 import pytest
 import torch
@@ -17,53 +19,64 @@ def test_TorchOperator(par):
     must equal the adjoint of operator applied to the same vector, the two
     results are also checked to be the same.
     """
-    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
-    Top = TorchOperator(Dop, batch=False)
+    # temporarily, skip tests on mac as torch seems not to recognized
+    # numpy when v2 is installed
+    if platform.system is not "Darwin":
+        Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
+        Top = TorchOperator(Dop, batch=False)
 
-    x = np.random.normal(0.0, 1.0, par["nx"])
-    xt = torch.from_numpy(x).view(-1)
-    xt.requires_grad = True
-    v = torch.randn(par["ny"])
+        x = np.random.normal(0.0, 1.0, par["nx"])
+        xt = torch.from_numpy(x).view(-1)
+        xt.requires_grad = True
+        v = torch.randn(par["ny"])
 
-    # pylops operator
-    y = Dop * x
-    xadj = Dop.H * v
+        # pylops operator
+        y = Dop * x
+        xadj = Dop.H * v
 
-    # torch operator
-    yt = Top.apply(xt)
-    yt.backward(v, retain_graph=True)
+        # torch operator
+        yt = Top.apply(xt)
+        yt.backward(v, retain_graph=True)
 
-    assert_array_equal(y, yt.detach().cpu().numpy())
-    assert_array_equal(xadj, xt.grad.cpu().numpy())
+        assert_array_equal(y, yt.detach().cpu().numpy())
+        assert_array_equal(xadj, xt.grad.cpu().numpy())
 
 
 @pytest.mark.parametrize("par", [(par1)])
 def test_TorchOperator_batch(par):
     """Apply forward for input with multiple samples (= batch) and flattened arrays"""
-    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
-    Top = TorchOperator(Dop, batch=True)
+    # temporarily, skip tests on mac as torch seems not to recognized
+    # numpy when v2 is installed
+    if platform.system is not "Darwin":
+        Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
+        Top = TorchOperator(Dop, batch=True)
 
-    x = np.random.normal(0.0, 1.0, (4, par["nx"]))
-    xt = torch.from_numpy(x)
-    xt.requires_grad = True
+        x = np.random.normal(0.0, 1.0, (4, par["nx"]))
+        xt = torch.from_numpy(x)
+        xt.requires_grad = True
 
-    y = Dop.matmat(x.T).T
-    yt = Top.apply(xt)
+        y = Dop.matmat(x.T).T
+        yt = Top.apply(xt)
 
-    assert_array_equal(y, yt.detach().cpu().numpy())
+        assert_array_equal(y, yt.detach().cpu().numpy())
 
 
 @pytest.mark.parametrize("par", [(par1)])
 def test_TorchOperator_batch_nd(par):
     """Apply forward for input with multiple samples (= batch) and nd-arrays"""
-    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,))
-    Top = TorchOperator(Dop, batch=True, flatten=False)
+    # temporarily, skip tests on mac as torch seems not to recognized
+    # numpy when v2 is installed
+    if platform.system is not "Darwin":
+        Dop = MatrixMult(
+            np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,)
+        )
+        Top = TorchOperator(Dop, batch=True, flatten=False)
 
-    x = np.random.normal(0.0, 1.0, (4, par["nx"], 2))
-    xt = torch.from_numpy(x)
-    xt.requires_grad = True
+        x = np.random.normal(0.0, 1.0, (4, par["nx"], 2))
+        xt = torch.from_numpy(x)
+        xt.requires_grad = True
 
-    y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
-    yt = Top.apply(xt)
+        y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
+        yt = Top.apply(xt)
 
-    assert_array_equal(y, yt.detach().cpu().numpy())
+        assert_array_equal(y, yt.detach().cpu().numpy())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy>=1.21.0,<2.0.0
+numpy>=1.21.0
 scipy>=1.11.0
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=1.2.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,32 @@
+# Currently we force rdt to use numpy<2.0.0 to build the documentation
+# since the dtcwt and spgl1 are not yet compatible with numpy=2.0.0
+numpy>=1.21.0,<2.0.0
+scipy>=1.11.0
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch>=1.2.0
+numba
+pyfftw
+PyWavelets
+spgl1
+scikit-fmm
+sympy
+devito
+dtcwt
+matplotlib
+ipython
+pytest
+pytest-runner
+setuptools_scm
+docutils<0.18
+Sphinx
+pydata-sphinx-theme
+sphinx-gallery
+numpydoc
+nbsphinx
+image
+pre-commit
+autopep8
+isort
+black
+flake8
+mypy


### PR DESCRIPTION
This PR aims to allow users to use pylops with numpy>=2.0.0.

Currently we need to make the following work-arounds:
- disable tests for `spgl1` until new release of `spgl1` library
- disable tests for `DTCWT` until new release of `dtcwt` library
- disable tests for `TorchOperator` in darwin os (currently torch does give this error `RuntimeError: Numpy is not available`)
 