### PR TITLE
build: added separate requirement file for torch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements-dev.txt; fi
+        pip install -r requirements-dev.txt
+        pip install -r requirements-torch.txt
     - name: Install pylops
       run: |
         python -m setuptools_scm

--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -26,7 +26,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements-dev.txt; fi
+        pip install -r requirements-dev.txt
+        pip install -r requirements-torch.txt
     - name: Install pylops
       run: |
         pip install .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,5 +19,6 @@ sphinx:
 python:
   install:
     - requirements: requirements-doc.txt
+    - requirements: requirements-torch.txt
     - method: pip
       path: .

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ install:
 
 dev-install:
 	make pipcheck
-	$(PIP) install -r requirements-dev.txt && $(PIP) install -e .
+	$(PIP) install -r requirements-dev.txt &&\
+	$(PIP) install -r requirements-torch.txt && $(PIP) install -e .
 
 install_conda:
 	conda env create -f environment.yml && conda activate pylops && pip install .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools wheel django
       pip install -r requirements-dev.txt
+      pip install -r requirements-torch.txt
       pip install .
     displayName: 'Install prerequisites and library'
 
@@ -90,6 +91,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools wheel django
       pip install -r requirements-dev.txt
+      pip install -r requirements-torch.txt
       pip install .
     displayName: 'Install prerequisites and library'
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,5 @@
 numpy>=1.21.0
 scipy>=1.11.0
---extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.2.0
 jax
 numba
 pyfftw

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,2 +1,2 @@
---extra-index-url https://download.pytorch.org/whl/cpu
+--index-url https://download.pytorch.org/whl/cpu
 torch>=1.2.0

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,0 +1,2 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch>=1.2.0


### PR DESCRIPTION
Closes https://github.com/PyLops/pylops/issues/597 by adding a `requirements-torch.txt` file that installs PyTorch from a specific index. 

We have also simplified the GA installation process removing unneeded `if [ -f requirements.txt ]; then pip install -r requirements-dev.txt; fi`, simply installing all dependencies as follows:

```
pip install -r requirements-dev.txt
pip install -r requirements-torch.txt
```