### PR TITLE
bug: move _CustomSource to private file

### DIFF
--- a/pylops/waveeqprocessing/_twoway.py
+++ b/pylops/waveeqprocessing/_twoway.py
@@ -1,0 +1,43 @@
+from examples.seismic.utils import PointSource
+
+
+class _CustomSource(PointSource):
+    """Custom source
+
+    This class creates a Devito symbolic object that encapsulates a set of
+    sources with a user defined source signal wavelet ``wav``
+
+    Parameters
+    ----------
+    name : :obj:`str`
+        Name for the resulting symbol.
+    grid : :obj:`devito.types.grid.Grid`
+        The computational domain.
+    time_range : :obj:`examples.seismic.source.TimeAxis`
+        TimeAxis(start, step, num) object.
+    wav : :obj:`numpy.ndarray`
+        Wavelet of size
+
+    """
+
+    __rkwargs__ = PointSource.__rkwargs__ + ["wav"]
+
+    @classmethod
+    def __args_setup__(cls, *args, **kwargs):
+        kwargs.setdefault("npoint", 1)
+
+        return super().__args_setup__(*args, **kwargs)
+
+    def __init_finalize__(self, *args, **kwargs):
+        super().__init_finalize__(*args, **kwargs)
+
+        self.wav = kwargs.get("wav")
+
+        if not self.alias:
+            for p in range(kwargs["npoint"]):
+                self.data[:, p] = self.wavelet
+
+    @property
+    def wavelet(self):
+        """Return user-provided wavelet"""
+        return self.wav

--- a/pylops/waveeqprocessing/twoway.py
+++ b/pylops/waveeqprocessing/twoway.py
@@ -14,7 +14,8 @@ devito_message = deps.devito_import("the twoway module")
 if devito_message is None:
     from examples.seismic import AcquisitionGeometry, Model
     from examples.seismic.acoustic import AcousticWaveSolver
-    from examples.seismic.utils import _CustomSource
+
+    from ._twoway import _CustomSource
 else:
     AcousticWaveSolver = Any
 

--- a/pylops/waveeqprocessing/twoway.py
+++ b/pylops/waveeqprocessing/twoway.py
@@ -1,6 +1,6 @@
 __all__ = ["AcousticWave2D"]
 
-from typing import Tuple
+from typing import Any, NewType, Tuple
 
 import numpy as np
 
@@ -15,6 +15,10 @@ if devito_message is None:
     from examples.seismic import AcquisitionGeometry, Model
     from examples.seismic.acoustic import AcousticWaveSolver
     from examples.seismic.utils import _CustomSource
+else:
+    AcousticWaveSolver = Any
+
+AcousticWaveSolverType = NewType("AcousticWaveSolver", AcousticWaveSolver)
 
 
 class AcousticWave2D(LinearOperator):
@@ -285,7 +289,7 @@ class AcousticWave2D(LinearOperator):
                 self.src_wavefield.append(src_wav)
             self.src_illumination += src_ill
 
-    def _born_oneshot(self, solver: AcousticWaveSolver, dm: NDArray) -> NDArray:
+    def _born_oneshot(self, solver: AcousticWaveSolverType, dm: NDArray) -> NDArray:
         """Born modelling for one shot
 
         Parameters

--- a/pylops/waveeqprocessing/twoway.py
+++ b/pylops/waveeqprocessing/twoway.py
@@ -14,49 +14,7 @@ devito_message = deps.devito_import("the twoway module")
 if devito_message is None:
     from examples.seismic import AcquisitionGeometry, Model
     from examples.seismic.acoustic import AcousticWaveSolver
-    from examples.seismic.utils import PointSource
-
-
-class _CustomSource(PointSource):
-    """Custom source
-
-    This class creates a Devito symbolic object that encapsulates a set of
-    sources with a user defined source signal wavelet ``wav``
-
-    Parameters
-    ----------
-    name : :obj:`str`
-        Name for the resulting symbol.
-    grid : :obj:`devito.types.grid.Grid`
-        The computational domain.
-    time_range : :obj:`examples.seismic.source.TimeAxis`
-        TimeAxis(start, step, num) object.
-    wav : :obj:`numpy.ndarray`
-        Wavelet of size
-
-    """
-
-    __rkwargs__ = PointSource.__rkwargs__ + ["wav"]
-
-    @classmethod
-    def __args_setup__(cls, *args, **kwargs):
-        kwargs.setdefault("npoint", 1)
-
-        return super().__args_setup__(*args, **kwargs)
-
-    def __init_finalize__(self, *args, **kwargs):
-        super().__init_finalize__(*args, **kwargs)
-
-        self.wav = kwargs.get("wav")
-
-        if not self.alias:
-            for p in range(kwargs["npoint"]):
-                self.data[:, p] = self.wavelet
-
-    @property
-    def wavelet(self):
-        """Return user-provided wavelet"""
-        return self.wav
+    from examples.seismic.utils import _CustomSource
 
 
 class AcousticWave2D(LinearOperator):


### PR DESCRIPTION
This PR moves `_CustomSource` to a private file to avoid pylops raising a import error when devito is not installed. Similarly, an `AcousticWaveSolverType` is created for type hinting