### PR TITLE
Add button to GitHub Repo

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,6 +124,7 @@ html_show_copyright = True
 # Theme config
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
+    "github_url": "https://github.com/PyLops/pylops",
     # "logo_only": True,
     # "display_version": True,
     "logo": {


### PR DESCRIPTION
I personally dislike it a lot when I come to the documentation of a source code, but there is no easy/quick link to the code repo, which means I have to google to find the repo ;-)

Adding the `"github_url"` to the `"html_theme_options"` should add a GitHub-link-button on the top-right corner, next to the switch for light/dark theme.

I haven't built the PyLops-docs to check it, but this is how it looks on the empymod website:
![GitHub-Button](https://github.com/user-attachments/assets/a6fa54f0-47cd-4063-a162-547fc9ff91e7)
