### PR TITLE
feat: speedup fourierradon with engine=cuda

### DIFF
--- a/pylops/signalprocessing/_fourierradon2d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon2d_cuda.py
@@ -1,4 +1,3 @@
-from cmath import exp
 from math import pi
 
 import cupy as cp
@@ -6,7 +5,7 @@ from numba import cuda
 
 TWO_PI_MINUS = cp.float32(-2.0 * pi)
 TWO_PI_PLUS = cp.float32(2.0 * pi)
-I = cp.complex64(1j)
+IMG = cp.complex64(1j)
 
 
 @cuda.jit
@@ -25,7 +24,7 @@ def _radon_inner_2d_kernel(x, y, f, px, h, flim0, flim1, npx, nh):
             # y[ih, ifr] += x[ipx, ifr] * exp(TWO_PI_MINUS * f[ifr] * px[ipx] * h[ih])
             # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
             s, c = cuda.libdevice.sincosf(TWO_PI_MINUS * f[ifr] * px[ipx] * h[ih])
-            y[ih, ifr] += x[ipx, ifr] * (c + I * s)
+            y[ih, ifr] += x[ipx, ifr] * (c + IMG * s)
 
 
 @cuda.jit
@@ -44,7 +43,7 @@ def _aradon_inner_2d_kernel(x, y, f, px, h, flim0, flim1, npx, nh):
             # x[ipx, ifr] += y[ih, ifr] * exp(TWO_PI_I_PLUS * f[ifr] * px[ipx] * h[ih])
             # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
             s, c = cuda.libdevice.sincosf(TWO_PI_PLUS * f[ifr] * px[ipx] * h[ih])
-            x[ipx, ifr] += y[ih, ifr] * (c + I * s)
+            x[ipx, ifr] += y[ih, ifr] * (c + IMG * s)
 
 
 def _radon_inner_2d_cuda(

--- a/pylops/signalprocessing/_fourierradon3d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon3d_cuda.py
@@ -1,7 +1,12 @@
 from cmath import exp
 from math import pi
 
+import cupy as cp
 from numba import cuda
+
+TWO_PI_MINUS = cp.float32(-2.0 * pi)
+TWO_PI_PLUS = cp.float32(2.0 * pi)
+I = cp.complex64(1j)
 
 
 @cuda.jit
@@ -17,9 +22,15 @@ def _radon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy,
     if ihy < nhy and ihx < nhx and ifr >= flim0 and ifr <= flim1:
         for ipy in range(npy):
             for ipx in range(npx):
-                y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * exp(
-                    -1j * 2 * pi * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
+                # slow computation of exp(1j * x)
+                # y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * exp(
+                #     TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
+                # )
+                # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
+                s, c = cuda.libdevice.sincosf(
+                    TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
+                y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * (c + I * s)
 
 
 @cuda.jit
@@ -35,9 +46,14 @@ def _aradon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy
     if ipy < npy and ipx < npx and ifr >= flim0 and ifr <= flim1:
         for ihy in range(nhy):
             for ihx in range(nhx):
-                x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * exp(
-                    1j * 2 * pi * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
+                # slow computation of exp(1j * x)
+                # x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * exp(
+                #     TWO_PI_I_PLUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
+                # )
+                s, c = cuda.libdevice.sincosf(
+                    TWO_PI_PLUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
+                x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * (c + I * s)
 
 
 def _radon_inner_3d_cuda(

--- a/pylops/signalprocessing/_fourierradon3d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon3d_cuda.py
@@ -1,4 +1,3 @@
-from cmath import exp
 from math import pi
 
 import cupy as cp
@@ -6,7 +5,7 @@ from numba import cuda
 
 TWO_PI_MINUS = cp.float32(-2.0 * pi)
 TWO_PI_PLUS = cp.float32(2.0 * pi)
-I = cp.complex64(1j)
+IMG = cp.complex64(1j)
 
 
 @cuda.jit
@@ -30,7 +29,7 @@ def _radon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy,
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
-                y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * (c + I * s)
+                y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * (c + IMG * s)
 
 
 @cuda.jit
@@ -53,7 +52,7 @@ def _aradon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_PLUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
-                x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * (c + I * s)
+                x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * (c + IMG * s)
 
 
 def _radon_inner_3d_cuda(

--- a/pylops/signalprocessing/fourierradon2d.py
+++ b/pylops/signalprocessing/fourierradon2d.py
@@ -13,10 +13,12 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, NDArray
 
 jit_message = deps.numba_import("the radon2d module")
+cupy_message = deps.cupy_import("the radon2d module")
 
 if jit_message is None:
-    from ._fourierradon2d_cuda import _aradon_inner_2d_cuda, _radon_inner_2d_cuda
     from ._fourierradon2d_numba import _aradon_inner_2d, _radon_inner_2d
+if jit_message is None and cupy_message is None:
+    from ._fourierradon2d_cuda import _aradon_inner_2d_cuda, _radon_inner_2d_cuda
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
@@ -167,7 +169,7 @@ class FourierRadon2D(LinearOperator):
         self._register_multiplications(engine)
 
     def _register_multiplications(self, engine: str) -> None:
-        if engine == "numba" and jit_message is None:
+        if engine == "numba":
             self._matvec = self._matvec_numba
             self._rmatvec = self._rmatvec_numba
         elif engine == "cuda":

--- a/pylops/signalprocessing/fourierradon3d.py
+++ b/pylops/signalprocessing/fourierradon3d.py
@@ -13,10 +13,12 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, NDArray
 
 jit_message = deps.numba_import("the radon2d module")
+cupy_message = deps.cupy_import("the radon2d module")
 
 if jit_message is None:
-    from ._fourierradon3d_cuda import _aradon_inner_3d_cuda, _radon_inner_3d_cuda
     from ._fourierradon3d_numba import _aradon_inner_3d, _radon_inner_3d
+if jit_message is None and cupy_message is None:
+    from ._fourierradon3d_cuda import _aradon_inner_3d_cuda, _radon_inner_3d_cuda
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
@@ -192,7 +194,7 @@ class FourierRadon3D(LinearOperator):
         self._register_multiplications(engine)
 
     def _register_multiplications(self, engine: str) -> None:
-        if engine == "numba" and jit_message is None:
+        if engine == "numba":
             self._matvec = self._matvec_numba
             self._rmatvec = self._rmatvec_numba
         elif engine == "cuda":


### PR DESCRIPTION
This PR introduces a number of changes to the radonfourier cuda implementations based on discussions in https://github.com/PyLops/pylops/pull/611

Those changes improve the speed of both the 2D and 3D implementations (see https://github.com/PyLops/pylops_notebooks/blob/master/developement-cupy/Radon-Fourier.ipynb):

2D: forward 10.2ms, adjoint 11.2ms  --> forward 2.5ms, adjoint 2.4ms

3D: forward 9.8ms, adjoint 6.1ms  --> forward 3.1ms, adjoint 1.65ms

I would like to get this changes in before moving on to adding the grid-strided loops (https://github.com/PyLops/pylops/issues/616) 
