### PR TITLE
Bug: fix sampling when not given

### DIFF
--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -272,8 +272,8 @@ def SeismicInterpolation(
                     )
                 else:
                     sampling = (
-                        np.abs(spataxis[1] - spataxis[1]),
-                        np.abs(taxis[1] - taxis[1]),
+                        np.abs(spataxis[1] - spataxis[0]),
+                        np.abs(taxis[1] - taxis[0]),
                     )
             Pop = FFT2D(dims=dims, nffts=nffts, sampling=sampling)
             Pop = Pop.H

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -256,11 +256,7 @@ def SeismicInterpolation(
                         f"spat1axis and taxis for kind=%{kind}"
                     )
                 else:
-                    sampling = (
-                        np.abs(spataxis[1] - spataxis[1]),
-                        np.abs(spat1axis[1] - spat1axis[1]),
-                        np.abs(taxis[1] - taxis[1]),
-                    )
+                    sampling = (dspat, dspat1, dt)
             Pop = FFTND(dims=dims, nffts=nffts, sampling=sampling)
             Pop = Pop.H
         else:

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -271,10 +271,7 @@ def SeismicInterpolation(
                         f"and taxis for kind={kind}"
                     )
                 else:
-                    sampling = (
-                        np.abs(spataxis[1] - spataxis[0]),
-                        np.abs(taxis[1] - taxis[0]),
-                    )
+                    sampling = (dspat, dt)
             Pop = FFT2D(dims=dims, nffts=nffts, sampling=sampling)
             Pop = Pop.H
         SIop = Rop * Pop


### PR DESCRIPTION
For trace interpolation, it is necessary to define either `sampling` or both `taxis` and `spataxis`. In case of using the latter, the function `SeismicInterpolation` is supposed to calculate the sampling. However, the calculated `sampling` was always `[0, 0]`. 

This PR fixes this problem. 