### PR TITLE
minor: switch np.dot to np.matmul in code snipped in installation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -264,7 +264,7 @@ and run the following code in Python:
    B = np.random.random((size, size))
    print("Time with %s threads: %f s" \
          %(os.environ.get("OMP_NUM_THREADS"),
-           timeit(lambda: np.dot(A, B), number=4)))
+           timeit(lambda: np.matmul(A, B), number=4)))
 
 Subsequently set the environment variables to ``2`` or any higher number of threads available
 in your hardware (multi-threaded), and run the same code.


### PR DESCRIPTION
This change is made in the light of the fact that `np.dot` does not seem to multi-thread anyone (as I am quite sure used to do in the past given the fact we built this small test example around it...)