### PR TITLE
Added missing `iiter` and `xnorm` to the documentation of `pylops.lsqr`

### DIFF
--- a/pylops/optimization/basic.py
+++ b/pylops/optimization/basic.py
@@ -242,6 +242,8 @@ def lsqr(
 
         ``7`` means the iteration limit has been reached
 
+    iiter : :obj:`int`
+        Iteration number upon termination
     r1norm : :obj:`float`
         :math:`||\mathbf{r}||_2^2`, where
         :math:`\mathbf{r} = \mathbf{y} - \mathbf{Op}\,\mathbf{x}`
@@ -257,6 +259,8 @@ def lsqr(
     arnorm : :obj:`float`
         Estimate of norm of :math:`\cond(\mathbf{Op}^H\mathbf{r}-
         \epsilon^2\mathbf{x})`
+    xnorm : :obj:`float`
+        :math:`||\mathbf{x}||_2`
     var : :obj:`float`
         Diagonals of :math:`(\mathbf{Op}^H\mathbf{Op})^{-1}` (if ``damp=0``)
         or more generally :math:`(\mathbf{Op}^H\mathbf{Op} +

--- a/pylops/optimization/cls_basic.py
+++ b/pylops/optimization/cls_basic.py
@@ -1043,6 +1043,8 @@ class LSQR(Solver):
 
             ``7`` means the iteration limit has been reached
 
+        iiter : :obj:`int`
+            Iteration number upon termination
         r1norm : :obj:`float`
             :math:`||\mathbf{r}||_2^2`, where
             :math:`\mathbf{r} = \mathbf{y} - \mathbf{Op}\,\mathbf{x}`
@@ -1058,6 +1060,8 @@ class LSQR(Solver):
         arnorm : :obj:`float`
             Estimate of norm of :math:`\cond(\mathbf{Op}^H\mathbf{r}-
             \epsilon^2\mathbf{x})`
+        xnorm : :obj:`float`
+            :math:`||\mathbf{x}||_2`
         var : :obj:`float`
             Diagonals of :math:`(\mathbf{Op}^H\mathbf{Op})^{-1}` (if ``damp=0``)
             or more generally :math:`(\mathbf{Op}^H\mathbf{Op} +


### PR DESCRIPTION
The documentation of [pylops.lsqr](https://pylops.readthedocs.io/en/stable/api/generated/pylops.optimization.basic.lsqr.html) was missing the returns of `iiter` and `xnorm`. 
They were added to the docs of all related functions and methods.

For `iiter` the same phrasing as for [`scipy.sparse.linalg.lsqr`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.lsqr.html) was used.
For `xnorm`, the mathematical style of `pylops` was adopted.

Closes #637 