### PR TITLE
bug: missing cols in callback of omp solver

### DIFF
--- a/pylops/optimization/cls_sparsity.py
+++ b/pylops/optimization/cls_sparsity.py
@@ -914,7 +914,7 @@ class OMP(Solver):
                 else False
             )
             x, cols = self.step(x, cols, showstep)
-            self.callback(x)
+            self.callback(x, cols)
         return x, cols
 
     def finalize(

--- a/pylops/optimization/sparsity.py
+++ b/pylops/optimization/sparsity.py
@@ -166,8 +166,9 @@ def omp(
         and every N3 steps in between where N1, N2, N3 are the
         three element of the list.
     callback : :obj:`callable`, optional
-        Function with signature (``callback(x)``) to call after each iteration
-        where ``x`` is the current model vector
+        Function with signature (``callback(x, cols)``) to call after each iteration
+        where ``x`` contains the non-zero model coefficient and ``cols`` are the
+        indices where the current model vector is non-zero
 
     Returns
     -------


### PR DESCRIPTION
This commit changes the signature of the callback of the omp solver, which provided only the non-zero coefficients (in x) without their indices - added now in the second input parameter (col).