### PR TITLE
test: make pytensoroperator tests run on macOS

### DIFF
--- a/pytests/test_pytensoroperator.py
+++ b/pytests/test_pytensoroperator.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import numpy as np
 import pytest
@@ -11,6 +12,10 @@ pytensor_message = deps.pytensor_import("the pytensor module")
 
 if pytensor_message is None:
     import pytensor
+
+    # avoid compile error on mac
+    if platform.system() == "Darwin":
+        pytensor.config.gcc__cxxflags = "-Wno-c++11-narrowing"
 
 
 par1 = {"ny": 11, "nx": 11, "dtype": np.float32}  # square


### PR DESCRIPTION
This PR adds `pytensor.config.gcc__cxxflags = "-Wno-c++11-narrowing"` as already explained in the installation part of the documentation to ensure tests can be run on macOS (without this I was getting a CompileError locally)