### PR TITLE
CI: Fix Github Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: PyLops
+name: PyLops Testing
 
 on: [push, pull_request]
 
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-13 ]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", ]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -30,6 +30,6 @@ jobs:
       run: |
         python -m setuptools_scm
         pip install .
-    - name: Test with pytest
+    - name: Tests with pytest
       run: |
         pytest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-13 ]
-        python-version: ["3.10", ]
+        python-version: ["3.10", ] # "3.11" temporarely removed due to issues with scikit-fmm
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/codacy-coverage-reporter.yaml
+++ b/.github/workflows/codacy-coverage-reporter.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, ]
-        python-version: ["3.11", ]
+        python-version: ["3.10", ]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 #   displayName: 'Windows'
 #
 #   pool:
-#     vmImage: 'windows-2019'
+#     vmImage: 'windows-2025'
 #
 #   variables:
 #     NUMBA_NUM_THREADS: 1
@@ -26,17 +26,18 @@ jobs:
 #   steps:
 #   - task: UsePythonVersion@0
 #     inputs:
-#       versionSpec: '3.9'
+#       versionSpec: '3.10'
 #       architecture: 'x64'
 #
 #   - script: |
 #       python -m pip install --upgrade pip setuptools wheel django
 #       pip install -r requirements-dev.txt
+#       pip install -r requirements-torch.txt
 #       pip install .
 #     displayName: 'Install prerequisites and library'
 #
 #   - script: |
-#       python setup.py test
+#       pytest
 #     condition: succeededOrFailed()
 #     displayName: 'Run tests'
 
@@ -55,7 +56,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.11'
+      versionSpec: '3.10'
       architecture: 'x64'
 
   - script: |
@@ -85,7 +86,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.11'
+      versionSpec: '3.10'
       architecture: 'x64'
 
   - script: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy==2.2.5
+numpy>=1.21.0
 scipy>=1.11.0
 jax
 numba

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy==2.2.5
+numpy==2.2.1
 scipy>=1.11.0
 jax
 numba

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy>=1.21.0
+numpy==2.2.6
 scipy>=1.11.0
 jax
 numba

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy==2.2.1
+numpy==2.2.5
 scipy>=1.11.0
 jax
 numba

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-numpy==2.2.6
+numpy==2.2.5
 scipy>=1.11.0
 jax
 numba


### PR DESCRIPTION
This PR temporarily removes `python3.11` from the various CI actions due to know building issues of `scikit-fmm` - soon to be fixed