### PR TITLE
build: added make rules for tests on gpu and more on documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,12 @@ that the both old and new tests pass successfully:
     make tests
     ```
 
+If you have access to a GPU, it is advised also that old and new tests run with the CuPy
+backend pass successfully:
+    ```
+    make tests_gpu
+    ```
+
 4. Run flake8 to check the quality of your code:
     ```
     make lint

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PIP := $(shell command -v pip3 2> /dev/null || command which pip 2> /dev/null)
 PYTHON := $(shell command -v python3 2> /dev/null || command which python 2> /dev/null)
 
-.PHONY: install dev-install dev-install_gpu install_conda dev-install_conda dev-install_conda_arm tests doc docupdate servedoc lint typeannot coverage
+.PHONY: install dev-install dev-install_gpu install_conda dev-install_conda dev-install_conda_arm tests tests_cpu_ongpu tests_gpu doc docupdate servedoc lint typeannot coverage
 
 pipcheck:
 ifndef PIP
@@ -42,8 +42,19 @@ dev-install_conda_gpu:
 	conda env create -f environment-dev-gpu.yml && conda activate pylops_gpu && pip install -e .
 
 tests:
+	# Run tests with CPU
 	make pythoncheck
 	pytest
+
+tests_cpu_ongpu:
+	# Run tests with CPU on a system with GPU (and CuPy installed)
+	make pythoncheck
+	export CUPY_PYLOPS=0 && export TEST_CUPY_PYLOPS=0 && pytest
+
+tests_gpu:
+	# Run tests with GPU (requires CuPy to be installed)
+	make pythoncheck
+	export TEST_CUPY_PYLOPS=1 && pytest
 
 doc:
 	cd docs  && rm -rf source/api/generated && rm -rf source/gallery &&\

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -75,6 +75,13 @@ that the both old and new tests pass successfully:
 
    >> make tests
 
+If you have access to a GPU, it is advised also that old and new tests run with the CuPy 
+backend pass successfully:
+
+.. code-block:: bash
+
+   >> make tests_gpu
+
 4. Run flake8 to check the quality of your code:
 
 .. code-block:: bash

--- a/docs/source/gpu.rst
+++ b/docs/source/gpu.rst
@@ -32,6 +32,20 @@ be also wrapped into a :class:`pylops.JaxOperator`.
 See below for a comphrensive list of supported operators and additional functionalities for both the
 ``cupy`` and ``jax`` backends.
 
+Install dependencies
+--------------------
+GPU-enabled development environments can created using ``conda`` 
+
+.. code-block:: bash
+
+   >> make dev-install_conda_gpu
+
+or ``pip``
+
+.. code-block:: bash
+
+   >> make dev-install_gpu
+
 
 Examples
 --------


### PR DESCRIPTION
This PR adds some rules in the `Makefile` to run NumPy tests on a system with CuPy installed and CuPy tests; some details about CuPy environments and tests are also added to the documentation.