### PR TITLE
ci: reinstate python 3.11 and add 3.12 to GA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-13 ]
-        python-version: ["3.10", ] # "3.11" temporarely removed due to issues with scikit-fmm
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
This PR reinstates Python 3.11 to the GA CI, and adds Python 3.12.