### PR TITLE
test: added tests to solver with preallocate=True

### DIFF
--- a/pytests/test_leastsquares.py
+++ b/pytests/test_leastsquares.py
@@ -101,57 +101,58 @@ def test_NormalEquationsInversion(par):
     )
     y = Gop * x
 
-    # normal equations with regularization
-    xinv = normal_equations_inversion(
-        Gop,
-        y,
-        [Reg],
-        epsI=1e-5,
-        epsRs=[1e-8],
-        x0=x0,
-        engine="pylops",
-        **dict(niter=200, tol=1e-10)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
-    # normal equations with weight
-    xinv = normal_equations_inversion(
-        Gop,
-        y,
-        None,
-        Weight=Weigth,
-        epsI=1e-5,
-        x0=x0,
-        engine="pylops",
-        **dict(niter=200, tol=1e-10)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
-    # normal equations with weight and small regularization
-    xinv = normal_equations_inversion(
-        Gop,
-        y,
-        [Reg],
-        Weight=Weigth,
-        epsI=1e-5,
-        epsRs=[1e-8],
-        x0=x0,
-        engine="pylops",
-        **dict(niter=200, tol=1e-10)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
-    # normal equations with weight and small normal regularization
-    xinv = normal_equations_inversion(
-        Gop,
-        y,
-        [],
-        NRegs=[NReg],
-        Weight=Weigth,
-        epsI=1e-5,
-        epsNRs=[1e-8],
-        x0=x0,
-        engine="pylops",
-        **dict(niter=200, tol=1e-10)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
+    for preallocate in [False, True]:
+        # normal equations with regularization
+        xinv = normal_equations_inversion(
+            Gop,
+            y,
+            [Reg],
+            epsI=1e-5,
+            epsRs=[1e-8],
+            x0=x0,
+            engine="pylops",
+            **dict(niter=200, tol=1e-10, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
+        # normal equations with weight
+        xinv = normal_equations_inversion(
+            Gop,
+            y,
+            None,
+            Weight=Weigth,
+            epsI=1e-5,
+            x0=x0,
+            engine="pylops",
+            **dict(niter=200, tol=1e-10, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
+        # normal equations with weight and small regularization
+        xinv = normal_equations_inversion(
+            Gop,
+            y,
+            [Reg],
+            Weight=Weigth,
+            epsI=1e-5,
+            epsRs=[1e-8],
+            x0=x0,
+            engine="pylops",
+            **dict(niter=200, tol=1e-10, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
+        # normal equations with weight and small normal regularization
+        xinv = normal_equations_inversion(
+            Gop,
+            y,
+            [],
+            NRegs=[NReg],
+            Weight=Weigth,
+            epsI=1e-5,
+            epsNRs=[1e-8],
+            x0=x0,
+            engine="pylops",
+            **dict(niter=200, tol=1e-10, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
 
 
 @pytest.mark.parametrize(
@@ -175,40 +176,41 @@ def test_RegularizedInversion(par):
     )
     y = Gop * x
 
-    # regularized inversion with regularization
-    xinv = regularized_inversion(
-        Gop,
-        y,
-        [Reg],
-        epsRs=[1e-8],
-        x0=x0,
-        engine="pylops",
-        **dict(damp=0, niter=200, show=0)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
-    # regularized inversion with weight
-    xinv = regularized_inversion(
-        Gop,
-        y,
-        None,
-        Weight=Weigth,
-        x0=x0,
-        engine="pylops",
-        **dict(damp=0, niter=200, show=0)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
-    # regularized inversion with regularization
-    xinv = regularized_inversion(
-        Gop,
-        y,
-        [Reg],
-        Weight=Weigth,
-        epsRs=[1e-8],
-        x0=x0,
-        engine="pylops",
-        **dict(damp=0, niter=200, show=0)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=3)
+    for preallocate in [False, True]:
+        # regularized inversion with regularization
+        xinv = regularized_inversion(
+            Gop,
+            y,
+            [Reg],
+            epsRs=[1e-8],
+            x0=x0,
+            engine="pylops",
+            **dict(damp=0, niter=200, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
+        # regularized inversion with weight
+        xinv = regularized_inversion(
+            Gop,
+            y,
+            None,
+            Weight=Weigth,
+            x0=x0,
+            engine="pylops",
+            **dict(damp=0, niter=200, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
+        # regularized inversion with regularization
+        xinv = regularized_inversion(
+            Gop,
+            y,
+            [Reg],
+            Weight=Weigth,
+            epsRs=[1e-8],
+            x0=x0,
+            engine="pylops",
+            **dict(damp=0, niter=200, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=3)
 
 
 @pytest.mark.parametrize(
@@ -230,13 +232,24 @@ def test_WeightedInversion(par):
     x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
     y = Gop * x
 
-    xne = normal_equations_inversion(
-        Gop, y, None, Weight=Weigth, engine="pylops", **dict(niter=5, tol=1e-10)
-    )[0]
-    xreg = regularized_inversion(
-        Gop, y, None, Weight=Weigth1, engine="pylops", **dict(damp=0, niter=5, show=0)
-    )[0]
-    assert_array_almost_equal(xne, xreg, decimal=3)
+    for preallocate in [False, True]:
+        xne = normal_equations_inversion(
+            Gop,
+            y,
+            None,
+            Weight=Weigth,
+            engine="pylops",
+            **dict(niter=5, tol=1e-10, preallocate=preallocate)
+        )[0]
+        xreg = regularized_inversion(
+            Gop,
+            y,
+            None,
+            Weight=Weigth1,
+            engine="pylops",
+            **dict(damp=0, niter=5, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(xne, xreg, decimal=3)
 
 
 @pytest.mark.parametrize(
@@ -260,10 +273,17 @@ def test_PreconditionedInversion(par):
         else None
     )
     y = Gop * x
-    xinv = preconditioned_inversion(
-        Gop, y, Pre, x0=x0, engine="pylops", **dict(damp=0, niter=800, show=0)
-    )[0]
-    assert_array_almost_equal(x, xinv, decimal=2)
+
+    for preallocate in [False, True]:
+        xinv = preconditioned_inversion(
+            Gop,
+            y,
+            Pre,
+            x0=x0,
+            engine="pylops",
+            **dict(damp=0, niter=800, preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=2)
 
 
 @pytest.mark.parametrize("par", [(par1)])
@@ -279,8 +299,23 @@ def test_skinnyregularization(par):
     x = np.arange(par["nx"] - 1)
     y = Dop * x
 
-    xinv = normal_equations_inversion(Dop, y, [Regop], epsRs=[1e-4], engine="pylops")[0]
-    assert_array_almost_equal(x, xinv, decimal=2)
+    for preallocate in [False, True]:
+        xinv = normal_equations_inversion(
+            Dop,
+            y,
+            [Regop],
+            epsRs=[1e-4],
+            engine="pylops",
+            **dict(preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=2)
 
-    xinv = regularized_inversion(Dop, y, [Regop], epsRs=[1e-4], engine="pylops")[0]
-    assert_array_almost_equal(x, xinv, decimal=2)
+        xinv = regularized_inversion(
+            Dop,
+            y,
+            [Regop],
+            epsRs=[1e-4],
+            engine="pylops",
+            **dict(preallocate=preallocate)
+        )[0]
+        assert_array_almost_equal(x, xinv, decimal=2)

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -96,8 +96,10 @@ def test_cg(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
-    assert_array_almost_equal(x, xinv, decimal=4)
+
+    for preallocate in [False, True]:
+        xinv = cg(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, preallocate=preallocate)[0]
+        assert_array_almost_equal(x, xinv, decimal=4)
 
 
 @pytest.mark.parametrize(
@@ -124,9 +126,11 @@ def test_cg_ndarray(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=0, show=True)[0]
-    assert xinv.shape == x.shape
-    assert_array_almost_equal(x, xinv, decimal=4)
+
+    for preallocate in [False, True]:
+        xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=0, preallocate=preallocate)[0]
+        assert xinv.shape == x.shape
+        assert_array_almost_equal(x, xinv, decimal=4)
 
 
 @pytest.mark.parametrize(
@@ -153,9 +157,11 @@ def test_cg_forceflat(par):
         x0 = None
 
     y = Aop * x
-    xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=0, show=True)[0]
-    assert xinv.shape == x.ravel().shape
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4)
+
+    for preallocate in [False, True]:
+        xinv = cg(Aop, y, x0=x0, niter=2 * x.size, tol=0, preallocate=preallocate)[0]
+        assert xinv.shape == x.ravel().shape
+        assert_array_almost_equal(x.ravel(), xinv, decimal=4)
 
 
 @pytest.mark.parametrize(
@@ -179,8 +185,12 @@ def test_cgls(par):
         x0 = None
 
     y = Aop * x
-    xinv = cgls(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, show=True)[0]
-    assert_array_almost_equal(x, xinv, decimal=4)
+
+    for preallocate in [False, True]:
+        xinv = cgls(Aop, y, x0=x0, niter=par["nx"], tol=1e-5, preallocate=preallocate)[
+            0
+        ]
+        assert_array_almost_equal(x, xinv, decimal=4)
 
 
 @pytest.mark.skipif(
@@ -210,10 +220,13 @@ def test_lsqr(par):
         y_sp = y - Aop * x0
     else:
         y_sp = y.copy()
-    xinv = lsqr(Aop, y, x0, niter=par["nx"])[0]
+
     xinv_sp = sp_lsqr(Aop, y_sp, iter_lim=par["nx"])[0]
     if par["x0"]:
         xinv_sp += x0
 
-    assert_array_almost_equal(xinv, x, decimal=4)
-    assert_array_almost_equal(xinv_sp, x, decimal=4)
+    for preallocate in [False, True]:
+        xinv = lsqr(Aop, y, x0, niter=par["nx"], preallocate=preallocate)[0]
+
+        assert_array_almost_equal(xinv, x, decimal=4)
+        assert_array_almost_equal(xinv_sp, x, decimal=4)


### PR DESCRIPTION
This PR adds a for...loop statement to all tests related to the solvers `pylops.optimization` that tests both the option with `preallocate=True/False`