### PR TITLE
doc: move from scipy.misc to scipy.datasets and add pooch as dependency

### DIFF
--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -35,6 +35,7 @@ dependencies:
     - pytest-runner
     - setuptools_scm
     - pydata-sphinx-theme
+    - pooch
     - sphinx-gallery
     - nbsphinx
     - sphinxemoji

--- a/environment-dev-gpu.yml
+++ b/environment-dev-gpu.yml
@@ -26,6 +26,7 @@ dependencies:
     - pytest-runner
     - setuptools_scm
     - pydata-sphinx-theme
+    - pooch
     - sphinx-gallery
     - nbsphinx
     - sphinxemoji

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,6 +36,7 @@ dependencies:
     - pytest-runner
     - setuptools_scm
     - pydata-sphinx-theme
+    - pooch
     - sphinx-gallery
     - nbsphinx
     - sphinxemoji

--- a/examples/plot_bilinear.py
+++ b/examples/plot_bilinear.py
@@ -6,7 +6,7 @@ operator to perform bilinear interpolation to a 2-dimensional input vector.
 """
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy import misc
+from scipy import datasets
 
 import pylops
 
@@ -15,8 +15,8 @@ np.random.seed(0)
 
 ###############################################################################
 # First of all, we create a 2-dimensional input vector containing an image
-# from the ``scipy.misc`` family.
-x = misc.face()[::5, ::5, 0]
+# from the ``scipy.datasets`` family.
+x = datasets.face()[::5, ::5, 0]
 nz, nx = x.shape
 
 ###############################################################################

--- a/requirements-dev-gpu.txt
+++ b/requirements-dev-gpu.txt
@@ -11,6 +11,7 @@ pytest-runner
 setuptools_scm
 docutils<0.18
 Sphinx
+pooch
 pydata-sphinx-theme
 sphinx-gallery
 sphinxemoji

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,6 +16,7 @@ pytest-runner
 setuptools_scm
 docutils<0.18
 Sphinx
+pooch
 pydata-sphinx-theme
 sphinx-gallery
 sphinxemoji

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -22,6 +22,7 @@ pytest-runner
 setuptools_scm
 docutils<0.18
 Sphinx
+pooch
 pydata-sphinx-theme
 sphinx-gallery
 sphinxemoji


### PR DESCRIPTION
This PR aims to switch from using `scipy.misc` in examples as this is deprecated, `scipy.datasets` is used instead and requires adding `pooch` as dependency in our dev/doc environments