### PR TITLE
build: disable dtcwt example and test to be able to support numpy v2 in CI and doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ docs/build
 docs/source/api/generated
 docs/source/gallery
 docs/source/tutorials
+docs/source/sg_execution_times.rst
 
 # Pylint #
 pylint_plot.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,14 +60,16 @@ numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False
 
 sphinx_gallery_conf = {
-    # path to your examples scripts
+    # Path to examples scripts
     "examples_dirs": [
         "../../examples",
         "../../tutorials",
     ],
-    # path where to save gallery generated examples
+    # Path where to save gallery generated examples
     "gallery_dirs": ["gallery", "tutorials"],
     "filename_pattern": r"\.py",
+    # Examples to skip when building the gallery
+    "ignore_pattern": r"plot_dtcwt\.py$",
     # Remove the "Download all examples" button from the top level gallery
     "download_all_examples": False,
     # Sort gallery example by file name instead of number of lines (default)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -453,10 +453,6 @@ or via ``pip`` with
    >> pip install pytensor pymc
 
 .. warning::
-   ``PyTensor`` does not support NumPy 2 yet, so make sure you use NumPy 1.x with PyTensor and PyMC.
-   to be able to use PyLops operators with ``PyMC``.
-   
-.. warning::
    OSX users may experience a ``CompileError`` error when using PyTensor. This can be solved by adding 
    ``pytensor.config.gcc__cxxflags = "-Wno-c++11-narrowing"`` after ``import pytensor``.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -322,10 +322,6 @@ In alphabetic order:
 dtcwt
 -----
 
-.. warning::
-
-   ``dtcwt`` is not yet supported with Numpy 2.
-
 `dtcwt <https://dtcwt.readthedocs.io/en/0.12.0/>`_ is a library used to implement the DT-CWT operators.
 
 Install it via ``pip`` with:
@@ -334,7 +330,9 @@ Install it via ``pip`` with:
 
    >> pip install dtcwt
 
-
+.. warning::
+   ``dtcwt`` does not support NumPy 2 yet, so make sure you use NumPy 1.x 
+   to be able to use the ``DTCWT`` operator.
 
 Devito
 ------
@@ -439,6 +437,7 @@ It can also be checked dynamically with ``numba.config.NUMBA_DEFAULT_NUM_THREADS
 
 PyMC and PyTensor
 -----------------
+
 `PyTensor <https://pytensor.readthedocs.io/en/latest/>`_ is used to allow seamless integration between PyLops and 
 `PyMC <https://www.pymc.io/welcome.html>`_ operators.
 Install both of them via ``conda`` with:
@@ -453,10 +452,11 @@ or via ``pip`` with
 
    >> pip install pytensor pymc
 
-.. note::
-   PyTensor does not support NumPy 2 yet, so make sure you use NumPy 1.x with PyTensor and PyMC.
-
-.. note::
+.. warning::
+   ``PyTensor`` does not support NumPy 2 yet, so make sure you use NumPy 1.x with PyTensor and PyMC.
+   to be able to use PyLops operators with ``PyMC``.
+   
+.. warning::
    OSX users may experience a ``CompileError`` error when using PyTensor. This can be solved by adding 
    ``pytensor.config.gcc__cxxflags = "-Wno-c++11-narrowing"`` after ``import pytensor``.
 

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -11,8 +11,8 @@ dependencies:
   - pyfftw
   - pywavelets
   - sympy
-  - pytensor>=2.28.0
-  - pymc>=5.21.0
+  - pymc>=5
+  - pytensor
   - matplotlib
   - ipython
   - pytest

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.11.0
   - pip
   - numpy>=2.0.0
-  - scipy>=1.11.0
+  - scipy>=1.13.0
   - pyfftw
   - pywavelets
   - sympy

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -3,15 +3,11 @@ channels:
   - defaults
   - conda-forge
   - numba
-  - pytorch
 dependencies:
-  - python>=3.9.0
+  - python>=3.11.0
   - pip
-  - numpy>=1.21.0
+  - numpy>=2.0.0
   - scipy>=1.11.0
-  - pytorch>=1.2.0
-  - cpuonly
-  - jax
   - pyfftw
   - pywavelets
   - sympy
@@ -28,10 +24,12 @@ dependencies:
   - isort
   - black
   - pip:
+    - torch
     - devito
-    - dtcwt
+    # - dtcwt (until numpy>=2.0.0 is supported)
     - scikit-fmm
     - spgl1
+    - jax
     - pytest-runner
     - setuptools_scm
     - pydata-sphinx-theme

--- a/environment-dev-arm.yml
+++ b/environment-dev-arm.yml
@@ -11,8 +11,8 @@ dependencies:
   - pyfftw
   - pywavelets
   - sympy
-  - pymc>=5
-  - pytensor
+  - pytensor>=2.28.0
+  - pymc>=5.21.0
   - matplotlib
   - ipython
   - pytest

--- a/environment-dev-gpu.yml
+++ b/environment-dev-gpu.yml
@@ -6,8 +6,8 @@ channels:
 dependencies:
   - python>=3.11.0
   - pip
-  - numpy>=1.21.0
-  - scipy>=1.11.0
+  - numpy>=2.0.0
+  - scipy>=1.13.0
   - cupy
   - sympy
   - matplotlib

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,8 +11,8 @@ dependencies:
   - pyfftw
   - pywavelets
   - sympy
-  - pytensor>=2.28.0
-  - pymc>=5.21.0
+  - pymc>=5
+  - pytensor
   - matplotlib
   - ipython
   - pytest

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -30,7 +30,7 @@ dependencies:
   - black
   - pip:
     - devito
-    - dtcwt
+    # - dtcwt (until numpy>=2.0.0 is supported)
     - scikit-fmm
     - spgl1
     - pytest-runner

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,15 +3,11 @@ channels:
   - defaults
   - conda-forge
   - numba
-  - pytorch
 dependencies:
-  - python>=3.9.0
+  - python>=3.11.0
   - pip
-  - numpy>=1.21.0
-  - scipy>=1.11.0
-  - pytorch>=1.2.0
-  - cpuonly
-  - jax
+  - numpy>=2.0.0
+  - scipy>=1.13.0
   - pyfftw
   - pywavelets
   - sympy
@@ -29,10 +25,12 @@ dependencies:
   - isort
   - black
   - pip:
+    - torch
     - devito
     # - dtcwt (until numpy>=2.0.0 is supported)
     - scikit-fmm
     - spgl1
+    - jax
     - pytest-runner
     - setuptools_scm
     - pydata-sphinx-theme

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,8 +11,8 @@ dependencies:
   - pyfftw
   - pywavelets
   - sympy
-  - pymc>=5
-  - pytensor
+  - pytensor>=2.28.0
+  - pymc>=5.21.0
   - matplotlib
   - ipython
   - pytest

--- a/pytests/test_dtcwt.py
+++ b/pytests/test_dtcwt.py
@@ -22,11 +22,10 @@ def sequential_array(shape):
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
+@pytest.mark.skipif(int(np_version[0]) >= 2, reason="dtcwt does not support numpy v2")
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input1D(par):
     """Test for DTCWT with 1D input"""
-    if int(np_version[0]) >= 2:
-        return
 
     t = sequential_array((par["ny"],))
 

--- a/pytests/test_dtcwt.py
+++ b/pytests/test_dtcwt.py
@@ -40,11 +40,10 @@ def test_dtcwt1D_input1D(par):
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
+@pytest.mark.skipif(int(np_version[0]) >= 2, reason="dtcwt does not support numpy v2")
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input2D(par):
     """Test for DTCWT with 2D input (forward-inverse pair)"""
-    if int(np_version[0]) >= 2:
-        return
 
     t = sequential_array(
         (
@@ -64,11 +63,10 @@ def test_dtcwt1D_input2D(par):
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
+@pytest.mark.skipif(int(np_version[0]) >= 2, reason="dtcwt does not support numpy v2")
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_input3D(par):
     """Test for DTCWT with 3D input (forward-inverse pair)"""
-    if int(np_version[0]) >= 2:
-        return
 
     t = sequential_array((par["ny"], par["ny"], par["ny"]))
 
@@ -83,11 +81,10 @@ def test_dtcwt1D_input3D(par):
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
+@pytest.mark.skipif(int(np_version[0]) >= 2, reason="dtcwt does not support numpy v2")
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_dtcwt1D_birot(par):
     """Test for DTCWT birot (forward-inverse pair)"""
-    if int(np_version[0]) >= 2:
-        return
 
     birots = ["antonini", "legall", "near_sym_a", "near_sym_b"]
 

--- a/requirements-dev-gpu.txt
+++ b/requirements-dev-gpu.txt
@@ -1,5 +1,5 @@
-numpy>=1.21.0
-scipy>=1.11.0
+numpy>=2.0.0
+scipy>=1.13.0
 cupy-cuda12x
 torch
 numba

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-numpy>=1.21.0
-scipy>=1.11.0
+numpy>=2.0.0
+scipy>=1.13.0
 jax
 numba
 pyfftw

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,4 +29,4 @@ isort
 black
 flake8
 mypy
-pytensor
+pytensor>=2.28.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ spgl1
 scikit-fmm
 sympy
 devito
-dtcwt
+# dtcwt (until numpy>=2.0.0 is supported)
 matplotlib
 ipython
 pytest

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,6 @@
 # Currently we force rdt to use numpy<2.0.0 to build the documentation
 # since the dtcwt is not yet compatible with numpy=2.0.0. For the
-# same reason, we force devito==4.8.7 as later versions of devito
+# same reason, we force devito==4.8.6 as later versions of devito
 # require numpy>=2.0.0
 numpy>=1.21.0,<2.0.0
 scipy>=1.11.0,<1.13

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -29,5 +29,5 @@ isort
 black
 flake8
 mypy
-pytensor
-pymc
+pytensor>=2.28.0
+pymc>=5.21.0

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,20 +1,14 @@
-# Currently we force rdt to use numpy<2.0.0 to build the documentation
-# since the dtcwt is not yet compatible with numpy=2.0.0. For the
-# same reason, we force devito==4.8.6 as later versions of devito
-# require numpy>=2.0.0
-numpy>=1.21.0,<2.0.0
-scipy>=1.11.0,<1.13
+numpy>=2.0.0
+scipy>=1.13.0
 jax
---extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.2.0
 numba
 pyfftw
 PyWavelets
 spgl1
 scikit-fmm
 sympy
-devito==4.8.6
-dtcwt
+devito
+# dtcwt (until numpy>=2.0.0 is supported)
 matplotlib
 ipython
 pytest

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,2 +1,2 @@
 --index-url https://download.pytorch.org/whl/cpu
-torch>=1.2.0,<2.5
+torch>=2.0.0


### PR DESCRIPTION
This PR is primarily focused on removing `dtcwt` from all environment/requirement files as by not supporting numpy v2 it was making it very hard to have a working local environment on ARM MacOSX (and like this is going to be the same soon for Linux).

Similarly, a skip `@pytest.mark.skipif(int(np_version[0]) >= 2, reason="dtcwt does not support numpy v2")` is added to the `test_dtcwt`, currently disabling any test for this operator.

Finally RTD is now using python 3.11 and numpy v2 and the `plot_dtcwt` example is currently disabled (we still keep the file in the repository in case `dtcwt` starts to support numpy v2, so we will be able to bring it back...).

Additionally, all requirements/environments files have been slightly revamped with the following changes:
- `python>=3.11` is now the new default in environment files 
- `numpy>=2.0.0` and `scipy>=1.13.0` (the first version supporting numpy2) are now the new default in environment/requirement files
- `torch` is now installed via pip and not conda in environment files as this is now the reccomended way (https://pytorch.org/get-started/locally/)
- `Jax` is also now installed via pip and not conda in environment files


