### PR TITLE
bug: fix import of avo module

### DIFF
--- a/pylops/avo/__init__.py
+++ b/pylops/avo/__init__.py
@@ -20,6 +20,7 @@ and a list of applications:
 
 """
 
+from .avo import *
 from .poststack import *
 from .prestack import *
 


### PR DESCRIPTION
This PR fixes a problem arising when running `from pylops.avo import *` due to the fact that the `avo` subpackage was missing in the init file.