### PR TITLE
feat: improved used of logging library

### DIFF
--- a/pylops/__init__.py
+++ b/pylops/__init__.py
@@ -45,6 +45,8 @@ utils
 
 """
 
+import logging
+
 from .config import *
 from .linearoperator import *
 from .torchoperator import *
@@ -68,6 +70,9 @@ from .utils.seismicevents import *
 from .utils.tapers import *
 from .utils.utils import *
 from .utils.wavelets import *
+
+# Prevent no handler message if an application using PyLops does not configure logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
     from .version import version as __version__

--- a/pylops/_torchoperator.py
+++ b/pylops/_torchoperator.py
@@ -1,4 +1,4 @@
-import logging
+import warnings
 
 from pylops.utils import deps
 
@@ -22,8 +22,8 @@ class _TorchOperator(torch.autograd.Function):
 
         # check if data is moved to cpu and warn user
         if ctx.device == "cpu" and ctx.devicetorch != "cpu":
-            logging.warning(
-                "pylops operator will be applied on the cpu "
+            warnings.warn(
+                "PyLops operator will be applied on the cpu "
                 "whilst the input torch vector is on "
                 "%s, this may lead to poor performance" % ctx.devicetorch
             )

--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -9,7 +9,6 @@ __all__ = [
     "AVOLinearModelling",
 ]
 
-import logging
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -21,8 +20,6 @@ from pylops.utils._internal import _value_or_sized_to_tuple
 from pylops.utils.backend import get_array_module
 from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, NDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def zoeppritz_scattering(
@@ -659,7 +656,6 @@ class AVOLinearModelling(LinearOperator):
         elif linearization == "ps":
             Gs = ps(theta, vsvp, n=self.nt0)
         else:
-            logging.error("%s not an available " "linearization...", linearization)
             raise NotImplementedError(
                 "%s not an available linearization..." % linearization
             )

--- a/pylops/avo/poststack.py
+++ b/pylops/avo/poststack.py
@@ -3,7 +3,6 @@ __all__ = [
     "PoststackInversion",
 ]
 
-import logging
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -31,8 +30,6 @@ from pylops.utils.backend import (
 )
 from pylops.utils.signalprocessing import convmtx, nonstationary_convmtx
 from pylops.utils.typing import NDArray, ShapeLike
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _PoststackLinearModelling(

--- a/pylops/avo/prestack.py
+++ b/pylops/avo/prestack.py
@@ -4,7 +4,6 @@ __all__ = [
     "PrestackInversion",
 ]
 
-import logging
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -35,8 +34,6 @@ from pylops.utils.backend import (
 )
 from pylops.utils.signalprocessing import convmtx
 from pylops.utils.typing import NDArray, ShapeLike
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 _linearizations = {"akirich": 3, "fatti": 3, "ps": 3}
 
@@ -167,7 +164,6 @@ def PrestackLinearModelling(
         elif callable(linearization):
             G = linearization(theta, vsvp, n=nt0)
         else:
-            logging.error("%s not an available linearization...", linearization)
             raise NotImplementedError(
                 "%s not an available linearization..." % linearization
             )
@@ -326,7 +322,6 @@ def PrestackWaveletModelling(
     elif callable(linearization):
         G = linearization(theta, vsvp, n=nt0)
     else:
-        logging.error("%s not an available linearization...", linearization)
         raise NotImplementedError(
             "%s not an available linearization..." % linearization
         )

--- a/pylops/basicoperators/linearregression.py
+++ b/pylops/basicoperators/linearregression.py
@@ -1,13 +1,9 @@
 __all__ = ["LinearRegression"]
 
-import logging
-
 import numpy.typing as npt
 
 from pylops.basicoperators import Regression
 from pylops.utils.typing import DTypeLike
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class LinearRegression(Regression):
@@ -76,5 +72,7 @@ class LinearRegression(Regression):
     ``order=1``.
     """
 
-    def __init__(self, taxis: npt.ArrayLike, dtype: DTypeLike = "float64", name: str = 'L'):
+    def __init__(
+        self, taxis: npt.ArrayLike, dtype: DTypeLike = "float64", name: str = "L"
+    ):
         super().__init__(taxis=taxis, order=1, dtype=dtype, name=name)

--- a/pylops/basicoperators/matrixmult.py
+++ b/pylops/basicoperators/matrixmult.py
@@ -1,6 +1,7 @@
 __all__ = ["MatrixMult"]
 
 import logging
+import warnings
 from typing import Optional, Union
 
 import numpy as np
@@ -12,7 +13,7 @@ from pylops.utils._internal import _value_or_sized_to_array
 from pylops.utils.backend import get_array_module
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 class MatrixMult(LinearOperator):
@@ -92,8 +93,8 @@ class MatrixMult(LinearOperator):
 
         # Check if forceflat is needed and set it back to None otherwise
         if otherdims is not None and forceflat is not None:
-            logging.warning(
-                "setting forceflat=None since otherdims!=None. "
+            logger.warning(
+                "Setting forceflat=None since otherdims!=None. "
                 "PyLops will automatically detect whether to return "
                 "a 1d or nd array based on the shape of the input "
                 "array."
@@ -102,7 +103,7 @@ class MatrixMult(LinearOperator):
         # Check dtype for correctness (upcast to complex when A is complex)
         if np.iscomplexobj(A) and not np.iscomplexobj(np.ones(1, dtype=dtype)):
             dtype = A.dtype
-            logging.warning("Matrix A is a complex object, dtype cast to %s" % dtype)
+            warnings.warn("Matrix A is a complex object, dtype cast to %s" % dtype)
         super().__init__(
             dtype=np.dtype(dtype),
             dims=dims,

--- a/pylops/basicoperators/regression.py
+++ b/pylops/basicoperators/regression.py
@@ -1,15 +1,11 @@
 __all__ = ["Regression"]
 
-import logging
-
 import numpy as np
 import numpy.typing as npt
 
 from pylops import LinearOperator
 from pylops.utils.backend import get_array_module
 from pylops.utils.typing import DTypeLike, NDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class Regression(LinearOperator):
@@ -92,7 +88,6 @@ class Regression(LinearOperator):
     ) -> None:
         ncp = get_array_module(taxis)
         if not isinstance(taxis, ncp.ndarray):
-            logging.error("t must be ndarray...")
             raise TypeError("t must be ndarray...")
         else:
             self.taxis = taxis

--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -16,7 +16,7 @@ from pylops.utils.backend import (
 )
 from pylops.utils.typing import DTypeLike, InputDimsLike, IntNDArray, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def _compute_iavamask(dims, axis, iava, ncp):
@@ -123,8 +123,8 @@ class Restriction(LinearOperator):
         # check if forceflat is needed and set it back to None otherwise
         if len(dims) > 2:
             if forceflat is not None:
-                logging.warning(
-                    f"setting forceflat=None since len(dims)={len(dims)}>2. "
+                logger.warning(
+                    f"Setting forceflat=None since len(dims)={len(dims)}>2. "
                     f"PyLops will automatically detect whether to return "
                     f"a 1d or nd array based on the shape of the input"
                     f"array."

--- a/pylops/basicoperators/spread.py
+++ b/pylops/basicoperators/spread.py
@@ -22,7 +22,7 @@ if jit_message is None:
         _rmatvec_numba_table,
     )
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 class Spread(LinearOperator):
@@ -184,7 +184,7 @@ class Spread(LinearOperator):
             self.engine = "numba"
         else:
             if engine == "numba" and jit is not None:
-                logging.warning(jit_message)
+                logger.warning(jit_message)
             self.engine = "numpy"
 
         # axes
@@ -222,7 +222,7 @@ class Spread(LinearOperator):
                 if len(fh(0, 0)) == 2:
                     self.interp = True
         if interp is not None and self.interp != interp:
-            logging.warning("interp has been overridden to %r.", self.interp)
+            logger.warning("interp has been overridden to %r.", self.interp)
 
     def _matvec_numpy(self, x: NDArray) -> NDArray:
         y = np.zeros(self.dimsd, dtype=self.dtype)

--- a/pylops/basicoperators/sum.py
+++ b/pylops/basicoperators/sum.py
@@ -10,7 +10,7 @@ from pylops.utils.backend import get_array_module
 from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 class Sum(LinearOperator):
@@ -84,8 +84,8 @@ class Sum(LinearOperator):
         dimsd.pop(self.axis)
         # check if forceflat is needed and set it back to None otherwise
         if len(dims) > 2 and forceflat is not None:
-            logging.warning(
-                f"setting forceflat=None since len(dims)={len(dims)}>2. "
+            logger.warning(
+                f"Setting forceflat=None since len(dims)={len(dims)}>2. "
                 f"PyLops will automatically detect whether to return "
                 f"a 1d or nd array based on the shape of the input"
                 f"array."

--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -5,7 +5,6 @@ __all__ = [
     "aslinearoperator",
 ]
 
-import logging
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -36,8 +35,6 @@ from pylops.utils.backend import get_array_module, get_module, get_sparse_eye
 from pylops.utils.decorators import count
 from pylops.utils.estimators import trace_hutchinson, trace_hutchpp, trace_nahutchpp
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray, ShapeLike
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class _LinearOperator(ABC):

--- a/pylops/optimization/basesolver.py
+++ b/pylops/optimization/basesolver.py
@@ -1,8 +1,8 @@
 __all__ = ["Solver"]
 
 import functools
-import logging
 import time
+import warnings
 from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -133,7 +133,7 @@ class Solver(metaclass=ABCMeta):
         self.preallocate = preallocate if not self.isjax else False
 
         if preallocate and self.isjax:
-            logging.warning(
+            warnings.warn(
                 "Preallocation is not supported for JAX arrays. "
                 "Setting preallocate to False."
             )

--- a/pylops/optimization/cls_leastsquares.py
+++ b/pylops/optimization/cls_leastsquares.py
@@ -5,7 +5,6 @@ __all__ = [
     "PreconditionedInversion",
 ]
 
-import logging
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
 import numpy as np
@@ -20,9 +19,6 @@ from pylops.utils.typing import NDArray
 
 if TYPE_CHECKING:
     from pylops.linearoperator import LinearOperator
-
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _check_regularization_dims(

--- a/pylops/optimization/cls_sparsity.py
+++ b/pylops/optimization/cls_sparsity.py
@@ -30,7 +30,7 @@ spgl1_message = deps.spgl1_import("the spgl1 solver")
 if spgl1_message is None:
     from spgl1 import spgl1 as ext_spgl1
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def _hardthreshold(x: NDArray, thresh: float) -> NDArray:
@@ -1825,9 +1825,7 @@ class ISTA(Solver):
             x, xupdate = self.step(x, showstep)
             self.callback(x)
         if xupdate <= self.tol:
-            logging.warning(
-                "update smaller that tolerance for " "iteration %d", self.iiter
-            )
+            logger.info("Update smaller that tolerance for iteration %d", self.iiter)
         return x
 
     def finalize(self, show: bool = False) -> None:
@@ -2208,8 +2206,8 @@ class FISTA(ISTA):
             x, z, xupdate = self.step(x, z, showstep)
             self.callback(x)
         if xupdate <= self.tol:
-            logging.warning(
-                "update smaller that tolerance for " "iteration %d", self.iiter
+            logger.warning(
+                "Update smaller that tolerance for " "iteration %d", self.iiter
             )
         return x
 

--- a/pylops/signalprocessing/_baseffts.py
+++ b/pylops/signalprocessing/_baseffts.py
@@ -1,4 +1,3 @@
-import logging
 import warnings
 from enum import Enum, auto
 from typing import Optional, Sequence, Union

--- a/pylops/signalprocessing/_baseffts.py
+++ b/pylops/signalprocessing/_baseffts.py
@@ -18,8 +18,6 @@ from pylops.utils.backend import (
 )
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
-
 
 class _FFTNorms(Enum):
     ORTHO = auto()

--- a/pylops/signalprocessing/bilinear.py
+++ b/pylops/signalprocessing/bilinear.py
@@ -10,7 +10,7 @@ from pylops.utils.backend import get_add_at, get_array_module, to_numpy
 from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, InputDimsLike, IntNDArray, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def _checkunique(iava: npt.ArrayLike) -> None:
@@ -106,8 +106,8 @@ class Bilinear(LinearOperator):
         # check if forceflat is needed and set it back to None otherwise
         if ndims > 2:
             if forceflat is not None:
-                logging.warning(
-                    f"setting forceflat=None since len(dims)={len(dims)}>2. "
+                logger.warning(
+                    f"Setting forceflat=None since len(dims)={len(dims)}>2. "
                     f"PyLops will automatically detect whether to return "
                     f"a 1d or nd array based on the shape of the input"
                     f"array."

--- a/pylops/signalprocessing/chirpradon2d.py
+++ b/pylops/signalprocessing/chirpradon2d.py
@@ -1,7 +1,5 @@
 __all__ = ["ChirpRadon2D"]
 
-import logging
-
 import numpy as np
 
 from pylops import LinearOperator
@@ -9,8 +7,6 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, NDArray
 
 from ._chirpradon2d import _chirp_radon_2d
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class ChirpRadon2D(LinearOperator):

--- a/pylops/signalprocessing/chirpradon3d.py
+++ b/pylops/signalprocessing/chirpradon3d.py
@@ -1,7 +1,5 @@
 __all__ = ["ChirpRadon3D"]
 
-import logging
-
 import numpy as np
 
 from pylops import LinearOperator
@@ -15,8 +13,6 @@ pyfftw_message = deps.pyfftw_import("the chirpradon3d module")
 
 if pyfftw_message is None:
     from ._chirpradon3d import _chirp_radon_3d_fftw
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class ChirpRadon3D(LinearOperator):

--- a/pylops/signalprocessing/dwt.py
+++ b/pylops/signalprocessing/dwt.py
@@ -1,6 +1,5 @@
 __all__ = ["DWT"]
 
-import logging
 from math import ceil, log
 from typing import Union
 
@@ -16,8 +15,6 @@ pywt_message = deps.pywt_import("the dwt module")
 
 if pywt_message is None:
     import pywt
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _checkwavelet(wavelet: str) -> None:

--- a/pylops/signalprocessing/dwt2d.py
+++ b/pylops/signalprocessing/dwt2d.py
@@ -1,6 +1,5 @@
 __all__ = ["DWT2D"]
 
-import logging
 from math import ceil, log
 
 import numpy as np
@@ -16,8 +15,6 @@ pywt_message = deps.pywt_import("the dwt2d module")
 
 if pywt_message is None:
     import pywt
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class DWT2D(LinearOperator):

--- a/pylops/signalprocessing/dwtnd.py
+++ b/pylops/signalprocessing/dwtnd.py
@@ -1,6 +1,5 @@
 __all__ = ["DWTND"]
 
-import logging
 from math import ceil, log
 
 import numpy as np
@@ -16,8 +15,6 @@ pywt_message = deps.pywt_import("the dwtnd module")
 
 if pywt_message is None:
     import pywt
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class DWTND(LinearOperator):

--- a/pylops/signalprocessing/fft.py
+++ b/pylops/signalprocessing/fft.py
@@ -20,7 +20,7 @@ pyfftw_message = deps.pyfftw_import("the fft module")
 if pyfftw_message is None:
     import pyfftw
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 class _FFT_numpy(_BaseFFT):
@@ -581,7 +581,7 @@ def FFT(
         )
     elif engine == "numpy" or (engine == "fftw" and pyfftw_message is not None):
         if engine == "fftw" and pyfftw_message is not None:
-            logging.warning(pyfftw_message)
+            logger.warning(pyfftw_message)
         f = _FFT_numpy(
             dims,
             axis=axis,

--- a/pylops/signalprocessing/fft2d.py
+++ b/pylops/signalprocessing/fft2d.py
@@ -1,6 +1,5 @@
 __all__ = ["FFT2D"]
 
-import logging
 import warnings
 from typing import Dict, Optional, Sequence, Union
 
@@ -12,8 +11,6 @@ from pylops.signalprocessing._baseffts import _BaseFFTND, _FFTNorms
 from pylops.utils.backend import get_array_module
 from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, InputDimsLike
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class _FFT2D_numpy(_BaseFFTND):

--- a/pylops/signalprocessing/fftnd.py
+++ b/pylops/signalprocessing/fftnd.py
@@ -1,6 +1,5 @@
 __all__ = ["FFTND"]
 
-import logging
 import warnings
 from typing import Optional, Sequence, Union
 
@@ -12,8 +11,6 @@ from pylops.signalprocessing._baseffts import _BaseFFTND, _FFTNorms
 from pylops.utils.backend import get_array_module, get_sp_fft
 from pylops.utils.decorators import reshaped
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class _FFTND_numpy(_BaseFFTND):

--- a/pylops/signalprocessing/fourierradon2d.py
+++ b/pylops/signalprocessing/fourierradon2d.py
@@ -1,6 +1,5 @@
 __all__ = ["FourierRadon2D"]
 
-import logging
 from typing import Optional, Tuple
 
 import numpy as np
@@ -19,8 +18,6 @@ if jit_message is None:
     from ._fourierradon2d_numba import _aradon_inner_2d, _radon_inner_2d
 if jit_message is None and cupy_message is None:
     from ._fourierradon2d_cuda import _aradon_inner_2d_cuda, _radon_inner_2d_cuda
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class FourierRadon2D(LinearOperator):

--- a/pylops/signalprocessing/fourierradon3d.py
+++ b/pylops/signalprocessing/fourierradon3d.py
@@ -1,6 +1,5 @@
 __all__ = ["FourierRadon3D"]
 
-import logging
 from typing import Optional, Tuple
 
 import numpy as np
@@ -19,8 +18,6 @@ if jit_message is None:
     from ._fourierradon3d_numba import _aradon_inner_3d, _radon_inner_3d
 if jit_message is None and cupy_message is None:
     from ._fourierradon3d_cuda import _aradon_inner_3d_cuda, _radon_inner_3d_cuda
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class FourierRadon3D(LinearOperator):

--- a/pylops/signalprocessing/interp.py
+++ b/pylops/signalprocessing/interp.py
@@ -1,6 +1,6 @@
 __all__ = ["Interp"]
 
-import logging
+import warnings
 from typing import Tuple, Union
 
 import numpy as np
@@ -11,8 +11,6 @@ from pylops.basicoperators import Diagonal, MatrixMult, Restriction, Transpose
 from pylops.utils._internal import _value_or_sized_to_tuple
 from pylops.utils.backend import get_array_module
 from pylops.utils.typing import DTypeLike, InputDimsLike, IntNDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _checkunique(iava: npt.ArrayLike) -> None:
@@ -54,8 +52,8 @@ def _linearinterp(
     # penultimate sample and raise a warning
     outside = iava >= lastsample - 1
     if sum(outside) > 0:
-        logging.warning(
-            "at least one value is beyond penultimate sample, "
+        warnings.warn(
+            "At least one value is beyond the penultimate sample, "
             "forced to be at penultimate sample"
         )
     iava[outside] = lastsample - 1 - 1e-10

--- a/pylops/signalprocessing/patch2d.py
+++ b/pylops/signalprocessing/patch2d.py
@@ -20,7 +20,7 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.tapers import taper2d
 from pylops.utils.typing import InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def patch2d_design(
@@ -53,8 +53,8 @@ def patch2d_design(
     nop : :obj:`tuple`
         Size of model in the transformed domain.
     verb : :obj:`bool`, optional
-        Verbosity flag. If ``verb==True``, print the data
-        and model windows start-end indices
+        *Deprecated*, will be removed in v3.0.0. Simply kept for
+        back-compatibility with previous implementation
 
     Returns
     -------
@@ -83,22 +83,21 @@ def patch2d_design(
     mwins_inends = ((mwin0_ins, mwin0_ends), (mwin1_ins, mwin1_ends))
 
     # print information about patching
-    if verb:
-        logging.warning("%d-%d windows required...", nwins0, nwins1)
-        logging.warning(
-            "data wins - start:%s, end:%s / start:%s, end:%s",
-            dwin0_ins,
-            dwin0_ends,
-            dwin1_ins,
-            dwin1_ends,
-        )
-        logging.warning(
-            "model wins - start:%s, end:%s / start:%s, end:%s",
-            mwin0_ins,
-            mwin0_ends,
-            mwin1_ins,
-            mwin1_ends,
-        )
+    logger.info("%d-%d windows required...", nwins0, nwins1)
+    logger.info(
+        "Data wins - start:%s, end:%s / start:%s, end:%s",
+        dwin0_ins,
+        dwin0_ends,
+        dwin1_ins,
+        dwin1_ends,
+    )
+    logger.info(
+        "Model wins - start:%s, end:%s / start:%s, end:%s",
+        mwin0_ins,
+        mwin0_ends,
+        mwin1_ins,
+        mwin1_ends,
+    )
     return nwins, dims, mwins_inends, dwins_inends
 
 

--- a/pylops/signalprocessing/patch3d.py
+++ b/pylops/signalprocessing/patch3d.py
@@ -20,7 +20,7 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.tapers import tapernd
 from pylops.utils.typing import InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def patch3d_design(
@@ -53,8 +53,8 @@ def patch3d_design(
     nop : :obj:`tuple`
         Size of model in the transformed domain.
     verb : :obj:`bool`, optional
-        Verbosity flag. If ``verb==True``, print the data
-        and model windows start-end indices
+        *Deprecated*, will be removed in v3.0.0. Simply kept for
+        back-compatibility with previous implementation
 
     Returns
     -------
@@ -94,26 +94,25 @@ def patch3d_design(
     )
 
     # print information about patching
-    if verb:
-        logging.warning("%d-%d-%d windows required...", nwins0, nwins1, nwins2)
-        logging.warning(
-            "data wins - start:%s, end:%s / start:%s, end:%s / start:%s, end:%s",
-            dwin0_ins,
-            dwin0_ends,
-            dwin1_ins,
-            dwin1_ends,
-            dwin2_ins,
-            dwin2_ends,
-        )
-        logging.warning(
-            "model wins - start:%s, end:%s / start:%s, end:%s / start:%s, end:%s",
-            mwin0_ins,
-            mwin0_ends,
-            mwin1_ins,
-            mwin1_ends,
-            mwin2_ins,
-            mwin2_ends,
-        )
+    logger.info("%d-%d-%d windows required...", nwins0, nwins1, nwins2)
+    logger.info(
+        "Data wins - start:%s, end:%s / start:%s, end:%s / start:%s, end:%s",
+        dwin0_ins,
+        dwin0_ends,
+        dwin1_ins,
+        dwin1_ends,
+        dwin2_ins,
+        dwin2_ends,
+    )
+    logger.info(
+        "Model wins - start:%s, end:%s / start:%s, end:%s / start:%s, end:%s",
+        mwin0_ins,
+        mwin0_ends,
+        mwin1_ins,
+        mwin1_ends,
+        mwin2_ins,
+        mwin2_ends,
+    )
     return nwins, dims, mwins_inends, dwins_inends
 
 

--- a/pylops/signalprocessing/radon2d.py
+++ b/pylops/signalprocessing/radon2d.py
@@ -1,6 +1,5 @@
 __all__ = ["Radon2D"]
 
-import logging
 from typing import Callable, Optional, Tuple
 
 import numpy as np
@@ -21,8 +20,6 @@ if jit_message is None:
         _linear_numba,
         _parabolic_numba,
     )
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _linear(

--- a/pylops/signalprocessing/radon3d.py
+++ b/pylops/signalprocessing/radon3d.py
@@ -1,6 +1,5 @@
 __all__ = ["Radon3D"]
 
-import logging
 from typing import Callable, Optional, Tuple
 
 import numpy as np
@@ -21,8 +20,6 @@ if jit_message is None:
         _linear_numba,
         _parabolic_numba,
     )
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _linear(

--- a/pylops/signalprocessing/sliding1d.py
+++ b/pylops/signalprocessing/sliding1d.py
@@ -20,7 +20,7 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.tapers import taper
 from pylops.utils.typing import InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def sliding1d_design(
@@ -48,8 +48,8 @@ def sliding1d_design(
     nop : :obj:`tuple`
         Size of model in the transformed domain.
     verb : :obj:`bool`, optional
-        Verbosity flag. If ``verb==True``, print the data
-        and model windows start-end indices
+        *Deprecated*, will be removed in v3.0.0. Simply kept for
+        back-compatibility with previous implementation
 
     Returns
     -------
@@ -74,18 +74,17 @@ def sliding1d_design(
     mwins_inends = (mwin_ins, mwin_ends)
 
     # print information about patching
-    if verb:
-        logging.warning("%d windows required...", nwins)
-        logging.warning(
-            "data wins - start:%s, end:%s",
-            dwin_ins,
-            dwin_ends,
-        )
-        logging.warning(
-            "model wins - start:%s, end:%s",
-            mwin_ins,
-            mwin_ends,
-        )
+    logger.info("%d windows required...", nwins)
+    logger.info(
+        "Data wins - start:%s, end:%s",
+        dwin_ins,
+        dwin_ends,
+    )
+    logger.info(
+        "Model wins - start:%s, end:%s",
+        mwin_ins,
+        mwin_ends,
+    )
     return nwins, dim, mwins_inends, dwins_inends
 
 

--- a/pylops/signalprocessing/sliding2d.py
+++ b/pylops/signalprocessing/sliding2d.py
@@ -19,7 +19,7 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.tapers import taper2d
 from pylops.utils.typing import InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def _slidingsteps(
@@ -80,8 +80,8 @@ def sliding2d_design(
     nop : :obj:`tuple`
         Size of model in the transformed domain.
     verb : :obj:`bool`, optional
-        Verbosity flag. If ``verb==True``, print the data
-        and model windows start-end indices
+        *Deprecated*, will be removed in v3.0.0. Simply kept for
+        back-compatibility with previous implementation
 
     Returns
     -------
@@ -106,18 +106,17 @@ def sliding2d_design(
     mwins_inends = (mwin_ins, mwin_ends)
 
     # print information about patching
-    if verb:
-        logging.warning("%d windows required...", nwins)
-        logging.warning(
-            "data wins - start:%s, end:%s",
-            dwin_ins,
-            dwin_ends,
-        )
-        logging.warning(
-            "model wins - start:%s, end:%s",
-            mwin_ins,
-            mwin_ends,
-        )
+    logger.info("%d windows required...", nwins)
+    logger.info(
+        "Data wins - start:%s, end:%s",
+        dwin_ins,
+        dwin_ends,
+    )
+    logger.info(
+        "Model wins - start:%s, end:%s",
+        mwin_ins,
+        mwin_ends,
+    )
     return nwins, dims, mwins_inends, dwins_inends
 
 

--- a/pylops/signalprocessing/sliding3d.py
+++ b/pylops/signalprocessing/sliding3d.py
@@ -20,7 +20,7 @@ from pylops.utils.decorators import reshaped
 from pylops.utils.tapers import taper3d
 from pylops.utils.typing import InputDimsLike, NDArray
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def sliding3d_design(
@@ -53,8 +53,8 @@ def sliding3d_design(
     nop : :obj:`tuple`
         Size of model in the transformed domain.
     verb : :obj:`bool`, optional
-        Verbosity flag. If ``verb==True``, print the data
-        and model windows start-end indices
+        *Deprecated*, will be removed in v3.0.0. Simply kept for
+        back-compatibility with previous implementation
 
     Returns
     -------
@@ -83,22 +83,21 @@ def sliding3d_design(
     mwins_inends = ((mwin0_ins, mwin0_ends), (mwin1_ins, mwin1_ends))
 
     # print information about patching
-    if verb:
-        logging.warning("%d-%d windows required...", nwins0, nwins1)
-        logging.warning(
-            "data wins - start:%s, end:%s / start:%s, end:%s",
-            dwin0_ins,
-            dwin0_ends,
-            dwin1_ins,
-            dwin1_ends,
-        )
-        logging.warning(
-            "model wins - start:%s, end:%s / start:%s, end:%s",
-            mwin0_ins,
-            mwin0_ends,
-            mwin1_ins,
-            mwin1_ends,
-        )
+    logger.info("%d-%d windows required...", nwins0, nwins1)
+    logger.info(
+        "Data wins - start:%s, end:%s / start:%s, end:%s",
+        dwin0_ins,
+        dwin0_ends,
+        dwin1_ins,
+        dwin1_ends,
+    )
+    logger.info(
+        "Model wins - start:%s, end:%s / start:%s, end:%s",
+        mwin0_ins,
+        mwin0_ends,
+        mwin1_ins,
+        mwin1_ends,
+    )
     return nwins, dims, mwins_inends, dwins_inends
 
 

--- a/pylops/utils/describe.py
+++ b/pylops/utils/describe.py
@@ -3,7 +3,6 @@ __all__ = ["describe"]
 import logging
 import random
 import string
-
 from typing import List, Set, Union
 
 from pylops import LinearOperator
@@ -35,7 +34,7 @@ compositeops = (
     BlockDiag,
 )
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 def _in_notebook() -> bool:
@@ -95,7 +94,7 @@ def _assign_name(Op, Ops, names: List[str]) -> str:
         while proposedname in names:
             proposedname = random.choice(string.ascii_letters).upper() + suffix
         name = proposedname
-        logging.warning(
+        logger.warning(
             f"The user has used the same name {origname} for two distinct operators, "
             f"changing name of operator {type(Op).__name__} to {name}..."
         )

--- a/pylops/utils/wavelets.py
+++ b/pylops/utils/wavelets.py
@@ -18,7 +18,7 @@ def _tcrop(t: npt.ArrayLike) -> npt.ArrayLike:
     """Crop time axis with even number of samples"""
     if len(t) % 2 == 0:
         t = t[:-1]
-        warnings.warn("one sample removed from time axis...")
+        warnings.warn("One sample removed from time axis...")
     return t
 
 

--- a/pylops/waveeqprocessing/kirchhoff.py
+++ b/pylops/waveeqprocessing/kirchhoff.py
@@ -34,7 +34,7 @@ if jit_message is None:
 else:
     prange = range
 
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
 class Kirchhoff(LinearOperator):
@@ -1034,7 +1034,7 @@ class Kirchhoff(LinearOperator):
             self._kirch_rmatvec = self.cuda_helper._rmatvec_cuda
         else:
             if engine == "numba" and jit_message is not None:
-                logging.warning(jit_message)
+                logger.warning(jit_message)
             if self.dynamic and self.travsrcrec:
                 self._kirch_matvec = self._ampsrcrec_kirch_matvec
                 self._kirch_rmatvec = self._ampsrcrec_kirch_rmatvec

--- a/pylops/waveeqprocessing/lsm.py
+++ b/pylops/waveeqprocessing/lsm.py
@@ -1,6 +1,5 @@
 __all__ = ["LSM"]
 
-import logging
 from typing import Callable, Optional
 
 from scipy.sparse.linalg import lsqr
@@ -9,8 +8,6 @@ from pylops.utils import dottest as Dottest
 from pylops.utils.typing import NDArray
 from pylops.waveeqprocessing.kirchhoff import Kirchhoff
 from pylops.waveeqprocessing.twoway import AcousticWave2D
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class LSM:

--- a/pylops/waveeqprocessing/mdd.py
+++ b/pylops/waveeqprocessing/mdd.py
@@ -23,6 +23,8 @@ from pylops.utils.backend import (
 )
 from pylops.utils.typing import NDArray
 
+logger = logging.getLogger(__name__)
+
 
 def _MDC(
     G: NDArray,
@@ -87,7 +89,7 @@ def _MDC(
     nfft = int(np.ceil((nt + 1) / 2))
     if nfmax > nfft:
         nfmax = nfft
-        logging.warning("nfmax set equal to ceil[(nt+1)/2=%d]", nfmax)
+        logger.warning("nfmax set equal to ceil[(nt+1)/2=%d]", nfmax)
 
     Fop = _FFT(
         dims=(nt, nr, nv),
@@ -401,7 +403,7 @@ def MDD(
     # Fix nfmax to be at maximum equal to half of the size of fft samples
     if nfmax is None or nfmax > nfmax_allowed:
         nfmax = nfmax_allowed
-        logging.warning("nfmax set equal to ceil[(nt+1)/2=%d]", nfmax)
+        logger.warning("nfmax set equal to ceil[(nt+1)/2=%d]", nfmax)
 
     # Add negative part to data and model
     if twosided and add_negative:

--- a/pylops/waveeqprocessing/oneway.py
+++ b/pylops/waveeqprocessing/oneway.py
@@ -3,8 +3,6 @@ __all__ = [
     "Deghosting",
 ]
 
-
-import logging
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -16,8 +14,6 @@ from pylops.utils import dottest as Dottest
 from pylops.utils.backend import to_cupy_conditional
 from pylops.utils.tapers import taper2d, taper3d
 from pylops.utils.typing import DTypeLike, NDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 class _PhaseShift(LinearOperator):

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -1,6 +1,5 @@
 __all__ = ["SeismicInterpolation"]
 
-import logging
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -21,8 +20,6 @@ from pylops.signalprocessing import (
 )
 from pylops.utils.dottest import dottest as Dottest
 from pylops.utils.typing import InputDimsLike, NDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def SeismicInterpolation(

--- a/pylops/waveeqprocessing/wavedecomposition.py
+++ b/pylops/waveeqprocessing/wavedecomposition.py
@@ -5,7 +5,6 @@ __all__ = [
     "WavefieldDecomposition",
 ]
 
-import logging
 from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -17,8 +16,6 @@ from pylops.signalprocessing import FFT2D, FFTND
 from pylops.utils import dottest as Dottest
 from pylops.utils.backend import get_array_module, get_module, get_module_name
 from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
 
 
 def _filter_obliquity(


### PR DESCRIPTION
This PR is aimed at improving the use of the `logging` library. 

The most notable change is the removal of all `logging.basicConfig` (which should be left to the user application) and the use of `logger = logging.getLogger(__name__)` instead. 

Some of the `logging.error` messages are also removed (as accompanied by a raise exception) and some `logging.warning` converted to `warnings.warn` based on the definition of how these two ways of raising a warning compare in https://docs.python.org/3/howto/logging.html)