### PR TITLE
bug: fix bug when applying power of Op to CuPy arrays

### DIFF
--- a/pylops/linearoperator.py
+++ b/pylops/linearoperator.py
@@ -1474,7 +1474,7 @@ class _PowerLinearOperator(LinearOperator):
         self.args = (A, p)
 
     def _power(self, fun: Callable, x: NDArray) -> NDArray:
-        res = np.array(x, copy=True)
+        res = x.copy()
         for _ in range(self.args[1]):
             res = fun(res)
         return res


### PR DESCRIPTION
This PR fixes a bug in the `_power` method of `_PowerLinearOperator` that was casting CuPy arrays back to Numpy