### PR TITLE
Feat: stopping criteria for solvers

### DIFF
--- a/docs/source/addingsolver.rst
+++ b/docs/source/addingsolver.rst
@@ -83,7 +83,6 @@ note that the ``setup`` method returns the created starting guess ``x`` (does no
 .. code-block:: python
 
     def setup(self, y, x0=None, niter=None, tol=1e-4, show=False):
-
         self.y = y
         self.tol = tol
         self.niter = niter

--- a/docs/source/addingsolver.rst
+++ b/docs/source/addingsolver.rst
@@ -4,8 +4,8 @@ Implementing new solvers
 ========================
 Users are welcome to create new solvers and add them to the PyLops library.
 
-In this tutorial, we will go through the key steps in the definition of a solver, using the
-:py:class:`pylops.optimization.basic.CG` as an example.
+In this tutorial, we will go through the key steps in the definition of a solver, using a
+sligthly simplified version of :py:class:`pylops.optimization.basic.CG` as an example.
 
 .. note::
     In case the solver that you are planning to create falls within the category of proximal solvers,
@@ -134,7 +134,26 @@ can add additional input parameters. For CG, the step is:
 
 
 Similarly, we also implement a ``run`` method that is in charge of running a number of iterations by repeatedly
-calling the ``step`` method. It is also usually convenient to implement a finalize method; this method can do any required post-processing that should
+calling the ``step`` method. 
+
+.. code-block:: python
+
+    def run(self, x, niter, show, itershow):
+        while self.iiter < niter and self.kold > self.tol:
+            x = self.step(x, showstep)
+            self.callback(x)
+            # check if any callback has raised a stop flag
+            stop = _callback_stop(self.callbacks)
+            if stop:
+                break
+        return x
+
+It is worth noting that any number of callbacks can be attached to the solver; some of these
+callbacks can implement a stopping criterion and set the ``stop`` member to True when a given
+condition is met. The ``_callback_stop`` method is in change of checking if any of the callbacks
+has set ``stop`` to True and in the case break the iterations.
+
+Finally, it is also usually convenient to implement a ``finalize`` method; this method can do any required post-processing that should
 not be applied at the end of each step, rather at the end of the entire optimization process. For CG, this is as simple
 as converting the ``cost`` variable from a list to a ``numpy`` array. For more details, see our implementations for CG.
 
@@ -169,8 +188,10 @@ input and returns some of the most valuable properties of the class-based solver
 
 .. code-block:: python
 
-    def cg(Op, y, x0, niter=10, tol=1e-4, show=False, itershow=(10, 10, 10), callback=None):
-        cgsolve = CG(Op)
+    def cg(Op, y, x0, niter=10, tol=1e-4, rtol=0.0,
+           show=False, itershow=(10, 10, 10), callback=None):
+        rcallback = ResidualNormCallback(rtol)
+        cgsolve = CG(Op, callbacks=[rcallback, ])
         if callback is not None:
             cgsolve.callback = callback
         x, iiter, cost = cgsolve.solve(

--- a/pylops/optimization/basic.py
+++ b/pylops/optimization/basic.py
@@ -6,6 +6,7 @@ __all__ = [
 
 from typing import TYPE_CHECKING, Callable, Optional, Tuple
 
+from pylops.optimization.callback import ResidualNormCallback
 from pylops.optimization.cls_basic import CG, CGLS, LSQR
 from pylops.utils.decorators import add_ndarray_support_to_solver
 from pylops.utils.typing import NDArray
@@ -21,6 +22,7 @@ def cg(
     x0: Optional[NDArray] = None,
     niter: int = 10,
     tol: float = 1e-4,
+    rtol: bool = 0.0,
     show: bool = False,
     itershow: Tuple[int, int, int] = (10, 10, 10),
     callback: Optional[Callable] = None,
@@ -42,7 +44,12 @@ def cg(
     niter : :obj:`int`, optional
         Number of iterations
     tol : :obj:`float`, optional
-        Tolerance on residual norm
+        Absolute tolerance on residual norm. Stops the solver when the
+        residual norm is below this value.
+    rtol : :obj:`float`, optional
+        Relative tolerance on residual norm. Stops the solver when the
+        ratio of the current residual norm to the initial residual norm is
+        below this value.
     show : :obj:`bool`, optional
         Display iterations log
     itershow : :obj:`tuple`, optional
@@ -71,7 +78,13 @@ def cg(
     See :class:`pylops.optimization.cls_basic.CG`
 
     """
-    cgsolve = CG(Op)
+    rcallback = ResidualNormCallback(rtol)
+    cgsolve = CG(
+        Op,
+        callbacks=[
+            rcallback,
+        ],
+    )
     if callback is not None:
         cgsolve.callback = callback
     x, iiter, cost = cgsolve.solve(
@@ -94,6 +107,7 @@ def cgls(
     niter: int = 10,
     damp: float = 0.0,
     tol: float = 1e-4,
+    rtol: float = 0.0,
     show: bool = False,
     itershow: Tuple[int, int, int] = (10, 10, 10),
     callback: Optional[Callable] = None,
@@ -117,7 +131,12 @@ def cgls(
     damp : :obj:`float`, optional
         Damping coefficient
     tol : :obj:`float`, optional
-        Tolerance on residual norm
+        Absolute tolerance on residual norm. Stops the solver when the
+        residual norm is below this value.
+    rtol : :obj:`float`, optional
+        Relative tolerance on residual norm. Stops the solver when the
+        ratio of the current residual norm to the initial residual norm is
+        below this value.
     show : :obj:`bool`, optional
         Display iterations log
     itershow : :obj:`tuple`, optional
@@ -161,7 +180,13 @@ def cgls(
     See :class:`pylops.optimization.cls_basic.CGLS`
 
     """
-    cgsolve = CGLS(Op)
+    rcallback = ResidualNormCallback(rtol)
+    cgsolve = CGLS(
+        Op,
+        callbacks=[
+            rcallback,
+        ],
+    )
     if callback is not None:
         cgsolve.callback = callback
     x, istop, iiter, r1norm, r2norm, cost = cgsolve.solve(

--- a/pylops/optimization/callback.py
+++ b/pylops/optimization/callback.py
@@ -29,30 +29,32 @@ class Callbacks:
 
     All methods take two input parameters: the solver itself, and the vector ``x``.
 
-    Moreover, some callback may be used to implement custom stopping criteria for the solvers.
-    This can be done by adding a boolean attribute `stop` to the callback object, which will
-    be initially set to `False`. As soon as the callback sets this attribute to `True`, the
+    Moreover, some callback may be used to implement custom stopping criteria for the solver.
+    This can be done by adding a boolean attribute ``stop`` to the callback object, which will
+    be initially set to ``False``. As soon as the callback sets this attribute to ``True``, the
     ``run`` method of the solver will stop iterating and return the current model vector.
 
     Examples
     --------
     >>> import numpy as np
     >>> from pylops.basicoperators import MatrixMult
-    >>> from pylops.optimization.solver import CG
+    >>> from pylops.optimization.basic import CG
     >>> from pylops.optimization.callback import Callbacks
+    >>>
     >>> class StoreIterCallback(Callbacks):
     ...     def __init__(self):
     ...         self.stored = []
     ...     def on_step_end(self, solver, x):
     ...         self.stored.append(solver.iiter)
-    >>> cb_sto = StoreIterCallback()
+    >>>
     >>> Aop = MatrixMult(np.random.normal(0., 1., 36).reshape(6, 6))
     >>> Aop = Aop.H @ Aop
     >>> y = Aop @ np.ones(6)
+    >>> cb_sto = StoreIterCallback()
     >>> cgsolve = CG(Aop, callbacks=[cb_sto, ])
     >>> xest = cgsolve.solve(y=y, x0=np.zeros(6), tol=0, niter=6, show=False)[0]
-    >>> xest
-    array([1., 1., 1., 1., 1., 1.])
+    >>> xest, cb_sto.stored
+    (array([1., 1., 1., 1., 1., 1.]), [1, 2, 3, 4, 5, 6])
 
     """
 

--- a/pylops/optimization/cls_basic.py
+++ b/pylops/optimization/cls_basic.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 import numpy as np
 
 from pylops.optimization.basesolver import Solver, _units
+from pylops.optimization.callback import _callback_stop
 from pylops.utils.backend import (
     get_array_module,
     get_module_name,
@@ -121,7 +122,8 @@ class CG(Solver):
             Number of iterations (default to ``None`` in case a user wants to
             manually step over the solver)
         tol : :obj:`float`, optional
-            Tolerance on residual norm
+            Absolute tolerance on residual norm. Stops the solver when the
+            residual norm is below this value.
         preallocate : :obj:`bool`, optional
             .. versionadded:: 2.6.0
 
@@ -260,6 +262,10 @@ class CG(Solver):
             )
             x = self.step(x, showstep)
             self.callback(x)
+            # check if any callback has raised a stop flag
+            stop = _callback_stop(self.callbacks)
+            if stop:
+                break
         return x
 
     def finalize(self, show: bool = False) -> None:
@@ -592,22 +598,26 @@ class CGLS(Solver):
             Estimated model of size :math:`[M \times 1]`
 
         """
-        niter = self.niter if niter is None else niter
-        if niter is None:
+        self.niter = self.niter if niter is None else niter
+        if self.niter is None:
             raise ValueError("niter must not be None")
-        while self.iiter < niter and self.kold > self.tol:
+        while self.iiter < self.niter and self.kold > self.tol:
             showstep = (
                 True
                 if show
                 and (
                     self.iiter < itershow[0]
-                    or niter - self.iiter < itershow[1]
+                    or self.niter - self.iiter < itershow[1]
                     or self.iiter % itershow[2] == 0
                 )
                 else False
             )
             x = self.step(x, showstep)
             self.callback(x)
+            # check if any callback has raised a stop flag
+            stop = _callback_stop(self.callbacks)
+            if stop:
+                break
         return x
 
     def finalize(self, show: bool = False) -> None:
@@ -622,7 +632,12 @@ class CGLS(Solver):
         self.tend = time.time()
         self.telapsed = self.tend - self.tstart
         # reason for termination
-        self.istop = 1 if self.kold < self.tol else 2
+        if self.kold < self.tol:
+            self.istop = 1
+        elif self.iiter >= self.niter:
+            self.istop = 2
+        else:
+            self.istop = 3
         self.r1norm = self.kold
         self.r2norm = self.cost1[self.iiter]
         if show:
@@ -677,10 +692,14 @@ class CGLS(Solver):
             Gives the reason for termination
 
             ``1`` means :math:`\mathbf{x}` is an approximate solution to
-            :math:`\mathbf{y} = \mathbf{Op}\,\mathbf{x}`
+            :math:`\mathbf{y} = \mathbf{Op}\,\mathbf{x}` with the provided
+            tolerance ``tol``
 
             ``2`` means :math:`\mathbf{x}` approximately solves the least-squares
-            problem
+            problem (reached the maximum number of iterations ``niter``)
+
+            ``3`` means another stopping criterion implemented via a callback
+            was reached
         iit : :obj:`int`
             Iteration number upon termination
         r1norm : :obj:`float`

--- a/pylops/optimization/cls_basic.py
+++ b/pylops/optimization/cls_basic.py
@@ -305,7 +305,8 @@ class CG(Solver):
         niter : :obj:`int`, optional
             Number of iterations
         tol : :obj:`float`, optional
-            Tolerance on residual norm
+            Absolute tolerance on residual norm. Stops the solver when the
+            residual norm is below this value.
         preallocate : :obj:`bool`, optional
             .. versionadded:: 2.6.0
 
@@ -446,7 +447,8 @@ class CGLS(Solver):
         damp : :obj:`float`, optional
             Damping coefficient
         tol : :obj:`float`, optional
-            Tolerance on residual norm
+            Absolute tolerance on residual norm. Stops the solver when the
+            residual norm is below this value.
         preallocate : :obj:`bool`, optional
             .. versionadded:: 2.6.0
 
@@ -670,7 +672,8 @@ class CGLS(Solver):
         damp : :obj:`float`, optional
             Damping coefficient
         tol : :obj:`float`, optional
-            Tolerance on residual norm
+            Absolute tolerance on residual norm. Stops the solver when the
+            residual norm is below this value.
         preallocate : :obj:`bool`, optional
             .. versionadded:: 2.6.0
 

--- a/pylops/optimization/cls_leastsquares.py
+++ b/pylops/optimization/cls_leastsquares.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
 import numpy as np
 from scipy.sparse.linalg import cg as sp_cg
-from scipy.sparse.linalg import lsqr
+from scipy.sparse.linalg import lsqr as sp_lsqr
 
 from pylops.basicoperators import Diagonal, VStack
 from pylops.optimization.basesolver import Solver, _units
@@ -676,7 +676,7 @@ class RegularizedInversion(Solver):
         if engine == "scipy" and self.ncp == np:
             if show:
                 kwargs_solver["show"] = 1
-            xinv, istop, itn, r1norm, r2norm = lsqr(
+            xinv, istop, itn, r1norm, r2norm = sp_lsqr(
                 self.RegOp, self.datatot, x0=x, **kwargs_solver
             )[0:5]
         elif engine == "pylops" or self.ncp != np:
@@ -938,7 +938,7 @@ class PreconditionedInversion(Solver):
         if engine == "scipy" and self.ncp == np:
             if show:
                 kwargs_solver["show"] = 1
-            pinv, istop, itn, r1norm, r2norm = lsqr(
+            pinv, istop, itn, r1norm, r2norm = sp_lsqr(
                 self.POp,
                 self.y,
                 x0=x,

--- a/pylops/optimization/cls_sparsity.py
+++ b/pylops/optimization/cls_sparsity.py
@@ -1771,7 +1771,7 @@ class ISTA(Solver):
         if self.SOp is not None:
             x = self.SOpmatvec(x)
 
-        # check model update
+        # compute model update norm
         if not self.preallocate:
             xupdate = np.linalg.norm(x - xold)
         else:
@@ -1782,7 +1782,7 @@ class ISTA(Solver):
             )
             xupdate = np.linalg.norm(self.xold)
 
-        # cost functions
+        # compute cost functions
         costdata = 0.5 * np.linalg.norm(self.res if self.preallocate else res) ** 2
         costreg = self.eps * np.linalg.norm(x, ord=1)
         self.cost.append(float(costdata + costreg))

--- a/pytests/test_memoizeoperator.py
+++ b/pytests/test_memoizeoperator.py
@@ -10,8 +10,6 @@ else:
     from numpy.testing import assert_array_almost_equal
 
     backend = "numpy"
-import itertools
-
 import pytest
 
 from pylops import MemoizeOperator
@@ -73,7 +71,7 @@ def test_memoize_evals_2(par):
 
     # Approach 1
     Aop1 = Aop.toreal(forw=False, adj=True)
-    xinv1 = Aop1.div(y)
+    xinv1 = Aop1.div(y).real
     assert_array_almost_equal(x, xinv1)
 
     # Approach 2

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -167,6 +167,38 @@ def test_cg_forceflat(par):
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
 )
+def test_cg_stopping(par):
+    """CG testing stopping criterion rtol"""
+    np.random.seed(10)
+
+    A = np.random.normal(0, 10, (par["ny"], par["nx"])) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = np.conj(A).T @ A  # to ensure definite positive matrix
+    Aop = MatrixMult(A, dtype=par["dtype"])
+
+    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, par["nx"]) + par["imag"] * np.random.normal(
+            0, 10, par["nx"]
+        )
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        rtol = 1e-2
+        _, _, cost = cg(
+            Aop, y, x0=x0, niter=par["nx"], tol=0, rtol=rtol, preallocate=preallocate
+        )
+        assert cost[-2] / cost[0] >= rtol
+        assert cost[-1] / cost[0] < rtol
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
 def test_cgls(par):
     """CGLS with linear operator"""
     np.random.seed(10)
@@ -193,14 +225,105 @@ def test_cgls(par):
         assert_array_almost_equal(x, xinv, decimal=4)
 
 
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
+def test_cgls_ndarray(par):
+    """CGLS with linear operator (and ndarray as input and output)"""
+    np.random.seed(10)
+
+    dims = dimsd = (par["nx"], par["ny"])
+    x = np.ones(dims) + par["imag"] * np.ones(dims)
+
+    A = np.random.normal(0, 10, (x.size, x.size)) + par["imag"] * np.random.normal(
+        0, 10, (x.size, x.size)
+    )
+    Aop = MatrixMult(A, dtype=par["dtype"])
+    Aop.dims = dims
+    Aop.dimsd = dimsd
+
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, dims) + par["imag"] * np.random.normal(0, 10, dims)
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        xinv = cgls(Aop, y, x0=x0, niter=2 * x.size, tol=0, preallocate=preallocate)[0]
+        assert xinv.shape == x.shape
+        assert_array_almost_equal(x, xinv, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
+def test_cgls_forceflat(par):
+    """CGLS with linear operator (and forced 1darray as input and output)"""
+    np.random.seed(10)
+
+    dims = dimsd = (par["nx"], par["ny"])
+    x = np.ones(dims) + par["imag"] * np.ones(dims)
+
+    A = np.random.normal(0, 10, (x.size, x.size)) + par["imag"] * np.random.normal(
+        0, 10, (x.size, x.size)
+    )
+    Aop = MatrixMult(A, dtype=par["dtype"], forceflat=True)
+    Aop.dims = dims
+    Aop.dimsd = dimsd
+
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, dims) + par["imag"] * np.random.normal(0, 10, dims)
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        xinv = cgls(Aop, y, x0=x0, niter=2 * x.size, tol=0, preallocate=preallocate)[0]
+        assert xinv.shape == x.ravel().shape
+        assert_array_almost_equal(x.ravel(), xinv, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
+def test_cgls_stopping(par):
+    """CGLS testing stopping criterion rtol"""
+    np.random.seed(10)
+
+    A = np.random.normal(0, 10, (par["ny"], par["nx"])) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"]))
+    Aop = MatrixMult(A, dtype=par["dtype"])
+
+    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, par["nx"]) + par["imag"] * np.random.normal(
+            0, 10, par["nx"]
+        )
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        rtol = 1e-2
+        cost = cgls(
+            Aop, y, x0=x0, niter=par["nx"], tol=0, rtol=rtol, preallocate=preallocate
+        )[-1]
+        assert cost[-2] / cost[0] >= rtol
+        assert cost[-1] / cost[0] < rtol
+
+
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
 )
-def test_lsqr(par):
-    """Compare local Pylops and scipy LSQR"""
+def test_lsqr_pylops_scipy(par):
+    """Compare Pylops and scipy LSQR"""
     np.random.seed(10)
 
     A = np.random.normal(0, 10, (par["ny"], par["nx"])) + par[
@@ -230,3 +353,92 @@ def test_lsqr(par):
 
         assert_array_almost_equal(xinv, x, decimal=4)
         assert_array_almost_equal(xinv_sp, x, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
+def test_lsqr(par):
+    """LSQR with linear operator"""
+    np.random.seed(10)
+
+    A = np.random.normal(0, 10, (par["ny"], par["nx"])) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"]))
+    Aop = MatrixMult(A, dtype=par["dtype"])
+
+    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, par["nx"]) + par["imag"] * np.random.normal(
+            0, 10, par["nx"]
+        )
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        xinv = lsqr(Aop, y, x0=x0, niter=par["nx"], atol=1e-5, preallocate=preallocate)[
+            0
+        ]
+        assert_array_almost_equal(x, xinv, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
+def test_lsqr_ndarray(par):
+    """LSQR with linear operator (and ndarray as input and output)"""
+    np.random.seed(10)
+
+    dims = dimsd = (par["nx"], par["ny"])
+    x = np.ones(dims) + par["imag"] * np.ones(dims)
+
+    A = np.random.normal(0, 10, (x.size, x.size)) + par["imag"] * np.random.normal(
+        0, 10, (x.size, x.size)
+    )
+    Aop = MatrixMult(A, dtype=par["dtype"])
+    Aop.dims = dims
+    Aop.dimsd = dimsd
+
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, dims) + par["imag"] * np.random.normal(0, 10, dims)
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        xinv = lsqr(Aop, y, x0=x0, niter=2 * x.size, atol=0, preallocate=preallocate)[0]
+        assert xinv.shape == x.shape
+        assert_array_almost_equal(x, xinv, decimal=4)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
+)
+def test_lsqr_forceflat(par):
+    """LSQR with linear operator (and forced 1darray as input and output)"""
+    np.random.seed(10)
+
+    dims = dimsd = (par["nx"], par["ny"])
+    x = np.ones(dims) + par["imag"] * np.ones(dims)
+
+    A = np.random.normal(0, 10, (x.size, x.size)) + par["imag"] * np.random.normal(
+        0, 10, (x.size, x.size)
+    )
+    Aop = MatrixMult(A, dtype=par["dtype"], forceflat=True)
+    Aop.dims = dims
+    Aop.dimsd = dimsd
+
+    if par["x0"]:
+        x0 = np.random.normal(0, 10, dims) + par["imag"] * np.random.normal(0, 10, dims)
+    else:
+        x0 = None
+
+    y = Aop * x
+
+    for preallocate in [False, True]:
+        xinv = lsqr(Aop, y, x0=x0, niter=2 * x.size, atol=0, preallocate=preallocate)[0]
+        assert xinv.shape == x.ravel().shape
+        assert_array_almost_equal(x.ravel(), xinv, decimal=4)


### PR DESCRIPTION
## Motivation 
PyLops's solvers tend to lack stopping criteria or have one/two simple stopping criterion directly implemented as part of the ``while`` statement in the ``run`` method (with one of them always being the max number of iterations). 

This PR aims to introduce additional stopping criteria. However instead of adding them directly to the ``while`` statement , those are implemented as special ``callbacks`` with a ``stop`` member. 

For the moment, only one of such stopping criterion is implemented based on the ratio between the initial and current residual norm or total cost function (``ResidualNormCallback``) and is added to all solvers that have a ``cost`` internal member tracking the history of the residual norm or total cost function.

## Definition of done 

- [x] Added new callback ``ResidualNormCallback`` and stopping auxiliary routine ``_callback_stop``
- [x] Included callback based stopping criteria to basic and sparsity solvers
- [x] Added tests
- [x] Added documentation