### PR TITLE
Patch: fix ISTA/FISTA with complex numbers

### DIFF
--- a/pylops/optimization/cls_sparsity.py
+++ b/pylops/optimization/cls_sparsity.py
@@ -125,13 +125,17 @@ def _halfthreshold(x: NDArray, thresh: float) -> NDArray:
             Since version 1.17.0 does not produce ``np.nan`` on bad input.
 
     """
-    arg = np.ones_like(x)
-    arg[x != 0] = (thresh / 8.0) * (np.abs(x[x != 0]) / 3.0) ** (-1.5)
-    arg = np.clip(arg, -1, 1)
-    phi = 2.0 / 3.0 * np.arccos(arg)
-    x1 = 2.0 / 3.0 * x * (1 + np.cos(2.0 * np.pi / 3.0 - phi))
-    # x1[np.abs(x) <= 1.5 * thresh ** (2. / 3.)] = 0
-    x1[np.abs(x) <= (54 ** (1.0 / 3.0) / 4.0) * thresh ** (2.0 / 3.0)] = 0
+    ncp = get_array_module(x)
+    arg = ncp.ones_like(x)
+    arg[x != 0] = (thresh / 8.0) * (ncp.abs(x[x != 0.0]) / 3.0) ** (-1.5)
+    if ncp.iscomplexobj(arg):
+        arg.real = ncp.clip(arg.real, -1.0, 1.0)
+        arg.imag = ncp.clip(arg.imag, -1.0, 1.0)
+    else:
+        arg = ncp.clip(arg, -1.0, 1.0)
+    phi = 2.0 / 3.0 * ncp.arccos(arg)
+    x1 = 2.0 / 3.0 * x * (1.0 + ncp.cos(2.0 * np.pi / 3.0 - phi))
+    x1[ncp.abs(x) <= (54.0 ** (1.0 / 3.0) / 4.0) * thresh ** (2.0 / 3.0)] = 0
     return x1
 
 

--- a/pytests/test_sparsity.py
+++ b/pytests/test_sparsity.py
@@ -149,9 +149,10 @@ def test_IRLS_datamodel(par):
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
+
     x0 = (
         np.asarray(
             npp.random.normal(0, 1, par["nx"])
@@ -186,15 +187,15 @@ def test_IRLS_datamodel(par):
 def test_IRLS_model(par):
     """Invert problem with model IRLS"""
     npp.random.seed(42)
-    A = npp.random.normal(0, 10, (par["ny"], par["nx"])) + par[
-        "imag"
-    ] * npp.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = npp.random.randn(par["ny"], par["nx"]) + par["imag"] * npp.random.randn(
+        par["ny"], par["nx"]
+    )
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
     y = Aop * x
 
     maxit = 100
@@ -210,15 +211,15 @@ def test_IRLS_model_stopping(par):
     """IRLS model testing stopping criterion rtol (here the class based
     solver is used as cost is not returned by the function based one)"""
     npp.random.seed(42)
-    A = npp.random.normal(0, 10, (par["ny"], par["nx"])) + par[
-        "imag"
-    ] * npp.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = npp.random.randn(par["ny"], par["nx"]) + par["imag"] * npp.random.randn(
+        par["ny"], par["nx"]
+    )
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
     y = Aop * x
 
     maxit = 100
@@ -247,15 +248,15 @@ def test_IRLS_model_stopping(par):
 def test_MP(par):
     """Invert problem with MP"""
     npp.random.seed(42)
-    A = npp.random.normal(0, 10, (par["ny"], par["nx"])) + par[
-        "imag"
-    ] * npp.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = npp.random.randn(par["ny"], par["nx"]) + par["imag"] * npp.random.randn(
+        par["ny"], par["nx"]
+    )
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
     y = Aop * x
 
     sigma = 1e-4
@@ -277,15 +278,15 @@ def test_MP(par):
 def test_OMP(par):
     """Invert problem with OMP"""
     npp.random.seed(42)
-    A = npp.random.normal(0, 10, (par["ny"], par["nx"])) + par[
-        "imag"
-    ] * npp.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = npp.random.randn(par["ny"], par["nx"]) + par["imag"] * npp.random.randn(
+        par["ny"], par["nx"]
+    )
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
     y = Aop * x
 
     sigma = 1e-4
@@ -299,15 +300,15 @@ def test_OMP(par):
 def test_OMP_stopping(par):
     """OMP testing stopping criterion rtol"""
     npp.random.seed(42)
-    A = npp.random.normal(0, 10, (par["ny"], par["nx"])) + par[
-        "imag"
-    ] * npp.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = npp.random.randn(par["ny"], par["nx"]) + par["imag"] * npp.random.randn(
+        par["ny"], par["nx"]
+    )
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
     y = Aop * x
 
     maxit = 100
@@ -505,15 +506,15 @@ def test_ISTA_FISTA_multiplerhs(par):
 def test_ISTA_FISTA_stopping(par):
     """ISTA/FISTA testing stopping criterion rtol"""
     npp.random.seed(42)
-    A = npp.random.normal(0, 10, (par["ny"], par["nx"])) + par[
-        "imag"
-    ] * npp.random.normal(0, 10, (par["ny"], par["nx"]))
+    A = npp.random.randn(par["ny"], par["nx"]) + par["imag"] * npp.random.randn(
+        par["ny"], par["nx"]
+    )
     Aop = MatrixMult(np.asarray(A), dtype=par["dtype"])
 
     x = np.zeros(par["nx"]) + par["imag"] * np.zeros(par["nx"])
-    x[par["nx"] // 2] = 1
-    x[3] = 1
-    x[par["nx"] - 4] = -1
+    x[par["nx"] // 2] = 1.0 + par["imag"] * 1.0
+    x[3] = 1.0 + par["imag"] * 1.0
+    x[par["nx"] - 4] = -1.0 - par["imag"] * 1.0
     y = Aop * x
 
     eps = 0.5


### PR DESCRIPTION
This PR introduces a number of fixes for ISTA/FISTA to allow them to run with complex valued model vectors and operators, namely:
-  the definition of `decay`, making sure it is always a real valued array (also for complex valued operators). This suppresses a warning in `_hardthreshold`.
- the clipping in `_halfthreshold` is now performed separately for real and imag part of complex valued arrays

Additionally, some of the tests in `test_sparsity` are modified to also test scenarios with complex valued model vectors and operators.