### PR TITLE
Feat: integers in stacking operators

### DIFF
--- a/examples/plot_stacking.py
+++ b/examples/plot_stacking.py
@@ -58,7 +58,7 @@ plt.tight_layout()
 plt.subplots_adjust(top=0.8)
 
 ###############################################################################
-# We now want to *vertically stack* three operators
+# We now want to *vertically stack* two operators
 #
 #    .. math::
 #       \mathbf{D_{Vstack}} =
@@ -90,6 +90,41 @@ axs[1].set_title(r"$y$")
 plt.colorbar(im, ax=axs[1])
 plt.tight_layout()
 plt.subplots_adjust(top=0.8)
+
+###############################################################################
+# If one or more operators in the stack are of type :py:class:`pylops.Zero`,
+# one can alternatively and more efficiently use integer values to define the
+# number of rows of the operator. For example,
+#
+#    .. math::
+#       \mathbf{D_{Vstack}} =
+#        \begin{bmatrix}
+#          \mathbf{D_v}    \\
+#          \mathbf{Z}      \\
+#          \mathbf{D_h}
+#        \end{bmatrix}, \qquad
+#       \mathbf{y} =
+#        \begin{bmatrix}
+#          \mathbf{D_v}\mathbf{x}    \\
+#          \mathbf{0}                \\
+#          \mathbf{D_h}\mathbf{x}
+#        \end{bmatrix}
+#
+# Note that this feature will become very handy when defining :py:class:`pylops.Block`
+# operators with large zero blocks.
+
+# With Zero operator
+Zop = pylops.Zero(Nv * Nh)
+Dstack = pylops.VStack([D2vop, Zop, D2hop])
+
+Y = np.reshape(Dstack * X.ravel(), (Nv * 3, Nh))
+
+# With integer
+D1stack = pylops.VStack([D2vop, Nv * Nh, D2hop])
+
+Y1 = np.reshape(D1stack * X.ravel(), (Nv * 3, Nh))
+
+print("Y == Y1:", np.allclose(Y, Y1))
 
 ###############################################################################
 # Similarly we can now *horizontally stack* three operators

--- a/pylops/basicoperators/block.py
+++ b/pylops/basicoperators/block.py
@@ -57,9 +57,19 @@ class Block(_Block):
     Parameters
     ----------
     ops : :obj:`list`
-        List of lists of operators to be combined in block fashion.
-        Alternatively, :obj:`numpy.ndarray` or :obj:`scipy.sparse` matrices
-        can be passed in place of one or more operators.
+        Linear operators to be stacked. They can be of type:
+
+        - :obj:`pylops.LinearOperator`: simply added to the stack;
+        - :obj:`numpy.ndarray` or :obj:`scipy.sparse`: converted to
+          :obj:`pylops.MatrixMult` and added to the stack;
+        - :obj:`int`: interpreted as a zero-operator of size ``(nops, int)``,
+          where the number of columns is equivalent to the provided value and
+          ``nops`` is inferred from the number of rows of the other operators
+          in the row of the block. Whilst a PyLops :obj:`pylops.Zero` operator
+          could be used instead, this option is more efficient as it simply
+          skips any computation.
+
+        Note that the last option is not allowed when ``nproc>1``.
     nproc : :obj:`int`, optional
         Number of processes used to evaluate the N operators in parallel using
         ``multiprocessing``. If ``nproc=1``, work in serial mode.

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -39,6 +39,18 @@ def test_VStack_incosistent_columns(par):
 
 
 @pytest.mark.parametrize("par", [(par1)])
+def test_VStack_integer_multiprocess(par):
+    """Check error is raised if operators with different number of columns
+    are passed to VStack
+    """
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+    with pytest.raises(NotImplementedError):
+        VStack(
+            [MatrixMult(G1, dtype=par["dtype"]), par["nx"]], dtype=par["dtype"], nproc=2
+        )
+
+
+@pytest.mark.parametrize("par", [(par1)])
 def test_HStack_incosistent_columns(par):
     """Check error is raised if operators with different number of rows
     are passed to VStack
@@ -49,6 +61,18 @@ def test_HStack_incosistent_columns(par):
         HStack(
             [MatrixMult(G1, dtype=par["dtype"]), MatrixMult(G2, dtype=par["dtype"])],
             dtype=par["dtype"],
+        )
+
+
+@pytest.mark.parametrize("par", [(par1)])
+def test_HStack_integer_multiprocess(par):
+    """Check error is raised if operators with different number of columns
+    are passed to VStack
+    """
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+    with pytest.raises(NotImplementedError):
+        HStack(
+            [MatrixMult(G1, dtype=par["dtype"]), par["ny"]], dtype=par["dtype"], nproc=2
         )
 
 
@@ -105,6 +129,16 @@ def test_VStack(par):
         backend=backend,
     )
 
+    # use integer directly in the definition of the operator
+    V3op = VStack([G1, par["ny"]], dtype=par["dtype"])
+    assert dottest(
+        V3op,
+        2 * par["ny"],
+        par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        backend=backend,
+    )
+
 
 @pytest.mark.parametrize("par", [(par2), (par2j)])
 def test_HStack(par):
@@ -147,6 +181,17 @@ def test_HStack(par):
     # use scipy matrix directly in the definition of the operator
     G1 = sp_random(par["ny"], par["nx"], density=0.4).astype("float32")
     H2op = HStack([G1, MatrixMult(G2, dtype=par["dtype"])], dtype=par["dtype"])
+    assert dottest(
+        H2op,
+        par["ny"],
+        2 * par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        backend=backend,
+    )
+
+    # use integer directly in the definition of the operator
+    G1 = sp_random(par["ny"], par["nx"], density=0.4).astype("float32")
+    H2op = HStack([G1, par["nx"]], dtype=par["dtype"])
     assert dottest(
         H2op,
         par["ny"],
@@ -216,6 +261,22 @@ def test_Block(par):
         [
             [G11, MatrixMult(G12, dtype=par["dtype"])],
             [MatrixMult(G21, dtype=par["dtype"]), G22],
+        ],
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        B2op,
+        2 * par["ny"],
+        2 * par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        backend=backend,
+    )
+
+    # use integer directly in the definition of the operator
+    B2op = Block(
+        [
+            [G11, par["nx"]],
+            [par["nx"], G22],
         ],
         dtype=par["dtype"],
     )


### PR DESCRIPTION
## Motivation

PyLops' stacking operators allow one to pass PyLops multiple LinearOperators or numpy/scipy matrices. However, in many practical scenarios, especially for the `Block` Operator, one may have some zero blocks (either many small ones or few large ones). Currently, one must rely on `pylops.Zero` to fill those zero blocks. However the inner working of `pylops.Zero` is such that every time matvec/rmatvec is called a zero array is instantiated. For stacking operators, this is actually redundant as one could simply skip filling part of the output vector. The current approach is particularly problematic when using the CuPy backend as instantiating new arrays on GPU memory is tremendously slow and unefficient (compared to performing arithmetic operations).

To solve this issue, this PR proposes to allow passing integer numbers (alongside LinearOperators or numpy/scipy matrices), which represent the number of zero columns (in `HStack` and `Block`) and the number of zero rows (in `VStack`). By doing so, matvec/rmatvec simply do not perform any operation for the indices of the `ops` list that contain `int` values.


## Definition of Done

- [x] Modify `HStack`
- [x] Modify `VStack`
- [x] Modify `Block`
- [x] Add tests
- [x] Add examples 

⏰ https://github.com/PyLops/pylops/pull/702 seems to solve the same issue with much less code changes - and since `Zero` instantiation has pretty much no overhead, this PR seems to be an overkill...