### PR TITLE
Feat: change internal handling of Zero in hstack/vstack

### DIFF
--- a/pylops/basicoperators/block.py
+++ b/pylops/basicoperators/block.py
@@ -53,6 +53,10 @@ class Block(_Block):
     r"""Block operator.
 
     Create a block operator from N lists of M linear operators each.
+    Note that in case one or more operators are filled with zeros, it is
+    recommended to use the :py:class:`pylops.Zero` operator instead of e.g.,
+    :py:class:`pylops.MatrixMult` with a matrix of zeros, as the former will
+    be simply by-passed both in the forward and adjoint steps.
 
     Parameters
     ----------

--- a/pylops/basicoperators/hstack.py
+++ b/pylops/basicoperators/hstack.py
@@ -20,7 +20,7 @@ else:
 from typing import Optional, Sequence
 
 from pylops import LinearOperator
-from pylops.basicoperators import MatrixMult
+from pylops.basicoperators import MatrixMult, Zero
 from pylops.utils.backend import get_array_module, get_module, inplace_add, inplace_set
 from pylops.utils.typing import NDArray
 
@@ -178,11 +178,12 @@ class HStack(LinearOperator):
         )
         y = ncp.zeros(self.nops, dtype=self.dtype)
         for iop, oper in enumerate(self.ops):
-            y = inplace_add(
-                oper.matvec(x[self.mmops[iop] : self.mmops[iop + 1]]).squeeze(),
-                y,
-                slice(None, None),
-            )
+            if not isinstance(oper, Zero):
+                y = inplace_add(
+                    oper.matvec(x[self.mmops[iop] : self.mmops[iop + 1]]).squeeze(),
+                    y,
+                    slice(None, None),
+                )
         return y
 
     def _rmatvec_serial(self, x: NDArray) -> NDArray:
@@ -193,11 +194,12 @@ class HStack(LinearOperator):
         )
         y = ncp.zeros(self.mops, dtype=self.dtype)
         for iop, oper in enumerate(self.ops):
-            y = inplace_set(
-                oper.rmatvec(x).squeeze(),
-                y,
-                slice(self.mmops[iop], self.mmops[iop + 1]),
-            )
+            if not isinstance(oper, Zero):
+                y = inplace_set(
+                    oper.rmatvec(x).squeeze(),
+                    y,
+                    slice(self.mmops[iop], self.mmops[iop + 1]),
+                )
         return y
 
     def _matvec_multiproc(self, x: NDArray) -> NDArray:

--- a/pylops/basicoperators/hstack.py
+++ b/pylops/basicoperators/hstack.py
@@ -33,7 +33,12 @@ def _matvec_rmatvec_map(op, x: NDArray) -> NDArray:
 class HStack(LinearOperator):
     r"""Horizontal stacking.
 
-    Stack a set of N linear operators horizontally.
+    Stack a set of N linear operators horizontally. Note that in case
+    one or more operators are filled with zeros, it is recommended to use
+    the :py:class:`pylops.Zero` operator instead of e.g.,
+    :py:class:`pylops.MatrixMult` with a matrix of zeros, as the former will
+    be simply by-passed both in the forward and adjoint steps.
+
 
     Parameters
     ----------

--- a/pylops/basicoperators/vstack.py
+++ b/pylops/basicoperators/vstack.py
@@ -33,7 +33,11 @@ def _matvec_rmatvec_map(op: Callable, x: NDArray) -> NDArray:
 class VStack(LinearOperator):
     r"""Vertical stacking.
 
-    Stack a set of N linear operators vertically.
+    Stack a set of N linear operators vertically. Note that in case
+    one or more operators are filled with zeros, it is recommended to use
+    the :py:class:`pylops.Zero` operator instead of e.g.,
+    :py:class:`pylops.MatrixMult` with a matrix of zeros, as the former will
+    be simply by-passed both in the forward and adjoint steps.
 
     Parameters
     ----------

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -14,7 +14,15 @@ else:
     backend = "numpy"
 import pytest
 
-from pylops.basicoperators import Block, BlockDiag, HStack, MatrixMult, Real, VStack
+from pylops.basicoperators import (
+    Block,
+    BlockDiag,
+    HStack,
+    MatrixMult,
+    Real,
+    VStack,
+    Zero,
+)
 from pylops.optimization.basic import lsqr
 from pylops.utils import dottest
 
@@ -105,6 +113,23 @@ def test_VStack(par):
         backend=backend,
     )
 
+    # use Zero operator directly in the definition of the operator
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+    V3op = VStack(
+        [
+            MatrixMult(G1, dtype=par["dtype"]),
+            Zero(par["ny"], par["nx"], dtype=par["dtype"]),
+        ],
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        V3op,
+        2 * par["ny"],
+        par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        backend=backend,
+    )
+
 
 @pytest.mark.parametrize("par", [(par2), (par2j)])
 def test_HStack(par):
@@ -114,7 +139,10 @@ def test_HStack(par):
     G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
     x = np.ones(2 * par["nx"]) + par["imag"] * np.ones(2 * par["nx"])
 
-    Hop = HStack([G1, MatrixMult(G2, dtype=par["dtype"])], dtype=par["dtype"])
+    Hop = HStack(
+        [MatrixMult(G1, dtype=par["dtype"]), MatrixMult(G2, dtype=par["dtype"])],
+        dtype=par["dtype"],
+    )
     assert dottest(
         Hop,
         par["ny"],
@@ -149,6 +177,23 @@ def test_HStack(par):
     H2op = HStack([G1, MatrixMult(G2, dtype=par["dtype"])], dtype=par["dtype"])
     assert dottest(
         H2op,
+        par["ny"],
+        2 * par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        backend=backend,
+    )
+
+    # use Zero operator directly in the definition of the operator
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
+    H3op = HStack(
+        [
+            MatrixMult(G1, dtype=par["dtype"]),
+            Zero(par["ny"], par["nx"], dtype=par["dtype"]),
+        ],
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        H3op,
         par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
@@ -216,6 +261,26 @@ def test_Block(par):
         [
             [G11, MatrixMult(G12, dtype=par["dtype"])],
             [MatrixMult(G21, dtype=par["dtype"]), G22],
+        ],
+        dtype=par["dtype"],
+    )
+    assert dottest(
+        B2op,
+        2 * par["ny"],
+        2 * par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        backend=backend,
+    )
+
+    # use Zero operator directly in the definition of the operator
+    G11 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+    B2op = Block(
+        [
+            [
+                MatrixMult(G11, dtype=par["dtype"]),
+                Zero(par["ny"], par["nx"], dtype=par["dtype"]),
+            ],
+            [Zero(par["ny"], par["nx"], dtype=par["dtype"]), G22],
         ],
         dtype=par["dtype"],
     )


### PR DESCRIPTION
## Motivation

PyLops' stacking operators allow one to pass PyLops multiple LinearOperators or numpy/scipy matrices. However, in many practical scenarios, especially for the `Block` Operator, one may have some zero blocks (either many small ones or few large ones). Currently, one must rely on `pylops.Zero` to fill those zero blocks. However the inner working of `pylops.Zero` is such that every time matvec/rmatvec is called a zero array is instantiated. For stacking operators, this is actually redundant as one could simply skip filling part of the output vector. The current approach is particularly problematic when using the CuPy backend as instantiating new arrays on GPU memory is tremendously slow and unefficient (compared to performing arithmetic operations).

To solve this issue, this PR proposes to add a check prior to calling the matvec/rmatvec of an operator and skip it if the operator is of instance `Zero`

## Definition of Done

- [x] Modify `HStack`
- [x] Modify `VStack`
- [x] Add tests

⏰ This is a much simpler solution to the one initially proposed in https://github.com/PyLops/pylops/pull/699