### PR TITLE
feat: added multithreading support to stacking ops

### DIFF
--- a/examples/plot_multiproc.py
+++ b/examples/plot_multiproc.py
@@ -1,15 +1,14 @@
 """
-Operators with Multiprocessing
-==============================
+Operators with Multithreading/Multiprocessing
+=============================================
 This example shows how perform a scalability test for one of PyLops operators
-that uses ``multiprocessing`` to spawn multiple processes. Operators that
-support such feature are :class:`pylops.basicoperators.VStack`,
-:class:`pylops.basicoperators.HStack`, and
-:class:`pylops.basicoperators.BlockDiagonal`, and
-:class:`pylops.basicoperators.Block`.
+that uses ``concurrent.futures``/``multiprocessing`` to spawn multiple
+threads/processes. Operators that support such feature are
+:class:`pylops.VStack`, :class:`pylops.HStack`, and
+:class:`pylops.BlockDiag`, and :class:`pylops.Block`.
 
-In this example we will consider the BlockDiagonal operator which contains
-:class:`pylops.basicoperators.MatrixMult` operators along its main diagonal.
+In this example we will consider the :class:`pylops.BlockDiag` operator which
+contains :class:`pylops.MatrixMult` operators along its main diagonal.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -24,7 +23,7 @@ N = 100
 Nops = 32
 Ops = [pylops.MatrixMult(np.random.normal(0.0, 1.0, (N, N))) for _ in range(Nops)]
 
-Op = pylops.BlockDiag(Ops, nproc=1)
+Op = pylops.BlockDiag(Ops, nproc=1, parallel_kind="multithread")
 
 ###############################################################################
 # We can now perform a scalability test on the forward operation
@@ -53,8 +52,9 @@ plt.tight_layout()
 
 ###############################################################################
 # Note that we have not tested here the case with 1 worker. In this specific
-# case, since the computations are very small, the overhead of spawning processes
-# is actually dominating the time of computations and so computing the
-# forward and adjoint operations with a single worker is more efficient. We
-# hope that this example can serve as a basis to inspect the scalability of
-# multiprocessing-enabled operators and choose the best number of processes.
+# case, since the computations are very small, the overhead of multithreading
+# (or multiprocessing) is actually dominating the time of computations and
+# so computing the forward and adjoint operations with a single worker is
+# more efficient. We hope that this example can serve as a basis to inspect
+# the scalability of multithreading/multiprocessing-enabled operators and
+# choose the best number of threads/processes.

--- a/pylops/basicoperators/block.py
+++ b/pylops/basicoperators/block.py
@@ -72,18 +72,21 @@ class Block(_Block):
         .. versionadded:: 2.2.0
 
         Force an array to be flattened after rmatvec.
-    multiproc : :obj:`bool`, optional
+    parallel_kind : :obj:`str`, optional
         .. versionadded:: 2.6.0
 
-        Use multiprocessing (``True``) or multithreading (``False``) when ``nproc>1``.
+        Parallelism kind when ``nproc>1``. Can be ``multiproc`` (using
+        :mod:`multiprocessing`) or ``multithread`` (using
+        :class:`concurrent.futures.ThreadPoolExecutor`). Defaults
+        to ``multiproc``.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
     Attributes
     ----------
-    pool : :obj:`multiprocessing.Pool` or :obj:`None`
-        Pool of workers used to evaluate the N operators in parallel using
-        ``multiprocessing``. When ``nproc=1``, no pool is created (i.e.,
+    pool : :obj:`multiprocessing.Pool` or :obj:`concurrent.futures.ThreadPoolExecutor` or :obj:`None`
+        Pool of workers used to evaluate the N operators in parallel.
+        When ``nproc=1``, no pool is created (i.e.,
         ``pool=None``).
     shape : :obj:`tuple`
         Operator shape.
@@ -153,17 +156,12 @@ class Block(_Block):
         ops: Iterable[Iterable[LinearOperator]],
         nproc: int = 1,
         forceflat: bool = None,
-        multiproc: bool = True,
+        parallel_kind: str = "multiproc",
         dtype: Optional[DTypeLike] = None,
     ):
-        if nproc > 1:
-            if multiproc:
-                self.pool = mp.Pool(processes=nproc)
-            else:
-                self.pool = mt.ThreadPoolExecutor(max_workers=nproc)
         super().__init__(
             ops=ops,
             forceflat=forceflat,
             dtype=dtype,
-            _args_VStack={"nproc": nproc, "multiproc": multiproc},
+            _args_VStack={"nproc": nproc, "parallel_kind": parallel_kind},
         )

--- a/pylops/basicoperators/block.py
+++ b/pylops/basicoperators/block.py
@@ -1,7 +1,5 @@
 __all__ = ["Block"]
 
-import concurrent.futures as mt
-import multiprocessing as mp
 from typing import Iterable, Optional
 
 from pylops import LinearOperator

--- a/pylops/basicoperators/blockdiag.py
+++ b/pylops/basicoperators/blockdiag.py
@@ -268,7 +268,7 @@ class BlockDiag(LinearOperator):
             self.pool.map(
                 lambda args: _matvec_rmatvec_map(*args),
                 [
-                    (oper._matvec, x[self.nnops[iop] : self.nnops[iop + 1]])
+                    (oper._matvec, x[self.mmops[iop] : self.mmops[iop + 1]])
                     for iop, oper in enumerate(self.ops)
                 ],
             )
@@ -283,7 +283,7 @@ class BlockDiag(LinearOperator):
             self.pool.map(
                 lambda args: _matvec_rmatvec_map(*args),
                 [
-                    (oper._rmatvec, x[self.mmops[iop] : self.mmops[iop + 1]])
+                    (oper._rmatvec, x[self.nnops[iop] : self.nnops[iop + 1]])
                     for iop, oper in enumerate(self.ops)
                 ],
             )

--- a/pylops/basicoperators/blockdiag.py
+++ b/pylops/basicoperators/blockdiag.py
@@ -1,5 +1,6 @@
 __all__ = ["BlockDiag"]
 
+import concurrent.futures as mt
 import multiprocessing as mp
 
 import numpy as np
@@ -42,8 +43,8 @@ class BlockDiag(LinearOperator):
         :obj:`numpy.ndarray` or :obj:`scipy.sparse` matrices can be passed
         in place of one or more operators.
     nproc : :obj:`int`, optional
-        Number of processes used to evaluate the N operators in parallel using
-        ``multiprocessing``. If ``nproc=1``, work in serial mode.
+        Number of processes/threads used to evaluate the N operators in parallel using
+        ``multiprocessing``/``concurrent.futures``. If ``nproc=1``, work in serial mode.
     forceflat : :obj:`bool`, optional
         .. versionadded:: 2.2.0
 
@@ -54,6 +55,10 @@ class BlockDiag(LinearOperator):
         Type of output vectors of `matvec` and `rmatvec. If ``None``, this is
         inferred directly from the input vectors. Note that this is ignored
         if ``nproc>1``.
+    multiproc : :obj:`bool`, optional
+        .. versionadded:: 2.6.0
+
+        Use multiprocessing (``True``) or multithreading (``False``) when ``nproc>1``.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -137,6 +142,7 @@ class BlockDiag(LinearOperator):
         nproc: int = 1,
         forceflat: bool = None,
         inoutengine: Optional[tuple] = None,
+        multiproc: bool = True,
         dtype: Optional[DTypeLike] = None,
     ) -> None:
         self.ops = ops
@@ -167,12 +173,15 @@ class BlockDiag(LinearOperator):
         else:
             dimsd = (self.nops,)
             forceflat = True
-        # create pool for multiprocessing
+        # create pool for multithreading / multiprocessing
+        self.multiproc = multiproc
         self._nproc = nproc
         self.pool: Optional[mp.pool.Pool] = None
         if self.nproc > 1:
-            self.pool = mp.Pool(processes=nproc)
-
+            if multiproc:
+                self.pool = mp.Pool(processes=nproc)
+            else:
+                self.pool = mt.ThreadPoolExecutor(max_workers=nproc)
         self.inoutengine = inoutengine
         dtype = _get_dtype(ops) if dtype is None else np.dtype(dtype)
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
@@ -252,16 +261,64 @@ class BlockDiag(LinearOperator):
         y = np.hstack(ys)
         return y
 
+    def _matvec_multithread(self, x: NDArray) -> NDArray:
+        if self.pool is None:
+            raise ValueError
+        ys = list(
+            self.pool.map(
+                lambda args: _matvec_rmatvec_map(*args),
+                [
+                    (oper._matvec, x[self.nnops[iop] : self.nnops[iop + 1]])
+                    for iop, oper in enumerate(self.ops)
+                ],
+            )
+        )
+        y = np.hstack(ys)
+        return y
+
+    def _rmatvec_multithread(self, x: NDArray) -> NDArray:
+        if self.pool is None:
+            raise ValueError
+        ys = list(
+            self.pool.map(
+                lambda args: _matvec_rmatvec_map(*args),
+                [
+                    (oper._rmatvec, x[self.mmops[iop] : self.mmops[iop + 1]])
+                    for iop, oper in enumerate(self.ops)
+                ],
+            )
+        )
+        y = np.hstack(ys)
+        return y
+
     def _matvec(self, x: NDArray) -> NDArray:
         if self.nproc == 1:
             y = self._matvec_serial(x)
         else:
-            y = self._matvec_multiproc(x)
+            if self.multiproc:
+                y = self._matvec_multiproc(x)
+            else:
+                y = self._matvec_multithread(x)
         return y
 
     def _rmatvec(self, x: NDArray) -> NDArray:
         if self.nproc == 1:
             y = self._rmatvec_serial(x)
         else:
-            y = self._rmatvec_multiproc(x)
+            if self.multiproc:
+                y = self._rmatvec_multiproc(x)
+            else:
+                y = self._rmatvec_multithread(x)
         return y
+
+    def close(self):
+        """Close the pool of workers used for multiprocessing
+        / multithreading.
+        """
+        if self.pool is not None:
+            if self.multiproc:
+                self.pool.close()
+                self.pool.join()
+            else:
+                self.pool.shutdown()
+            self.pool = None

--- a/pylops/basicoperators/hstack.py
+++ b/pylops/basicoperators/hstack.py
@@ -278,15 +278,15 @@ class HStack(LinearOperator):
         if self.nproc == 1:
             y = self._matvec_serial(x)
         else:
-            y = self._matvec_multiproc(x)
-        return y
-
-    def _rmatvec(self, x: NDArray) -> NDArray:
-        if self.nproc == 1:
             if self.multiproc:
                 y = self._matvec_multiproc(x)
             else:
                 y = self._matvec_multithread(x)
+        return y
+
+    def _rmatvec(self, x: NDArray) -> NDArray:
+        if self.nproc == 1:
+            y = self._rmatvec_serial(x)
         else:
             if self.multiproc:
                 y = self._rmatvec_multiproc(x)

--- a/pylops/basicoperators/hstack.py
+++ b/pylops/basicoperators/hstack.py
@@ -68,10 +68,13 @@ class HStack(LinearOperator):
         Type of output vectors of `matvec` and `rmatvec. If ``None``, this is
         inferred directly from the input vectors. Note that this is ignored
         if ``nproc>1``.
-    multiproc : :obj:`bool`, optional
+    parallel_kind : :obj:`str`, optional
         .. versionadded:: 2.6.0
 
-        Use multiprocessing (``True``) or multithreading (``False``) when ``nproc>1``.
+        Parallelism kind when ``nproc>1``. Can be ``multiproc`` (using
+        :mod:`multiprocessing`) or ``multithread`` (using
+        :class:`concurrent.futures.ThreadPoolExecutor`). Defaults
+        to ``multiproc``.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -91,10 +94,9 @@ class HStack(LinearOperator):
         Shape of the array after the forward, but before flattening.
 
         For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
-    pool : :obj:`multiprocessing.Pool` or :obj:`None`
-        Pool of workers used to evaluate the N operators in parallel using
-        ``multiprocessing``. When ``nproc=1``, no pool is created (i.e.,
-        ``pool=None``).
+    pool : :obj:`multiprocessing.Pool` or :obj:`concurrent.futures.ThreadPoolExecutor` or :obj:`None`
+        Pool of workers used to evaluate the N operators in parallel.
+        When ``nproc=1``, no pool is created (i.e., ``pool=None``).
     shape : :obj:`tuple`
         Operator shape.
 
@@ -152,9 +154,12 @@ class HStack(LinearOperator):
         nproc: int = 1,
         forceflat: bool = None,
         inoutengine: Optional[tuple] = None,
-        multiproc: bool = True,
+        parallel_kind: str = "multiproc",
         dtype: Optional[str] = None,
     ) -> None:
+        if parallel_kind not in ["multiproc", "multithread"]:
+            raise ValueError("parallel_kind must be 'multiproc' or 'multithread'")
+        # identify dimensions
         self.ops = ops
         mops = np.zeros(len(ops), dtype=int)
         for iop, oper in enumerate(ops):
@@ -176,11 +181,11 @@ class HStack(LinearOperator):
             dimsd = (self.nops,)
             forceflat = True
         # create pool for multithreading / multiprocessing
-        self.multiproc = multiproc
+        self.parallel_kind = parallel_kind
         self._nproc = nproc
         self.pool = None
         if self.nproc > 1:
-            if multiproc:
+            if self.parallel_kind == "multiproc":
                 self.pool = mp.Pool(processes=nproc)
             else:
                 self.pool = mt.ThreadPoolExecutor(max_workers=nproc)
@@ -202,14 +207,14 @@ class HStack(LinearOperator):
 
     @nproc.setter
     def nproc(self, nprocnew: int):
-        if self._nproc > 1:
-            if self.multiproc:
+        if self._nproc > 1 and self.pool is not None:
+            if self.parallel_kind == "multiproc":
                 self.pool.close()
                 self.pool.join()
             else:
                 self.pool.shutdown()
         if nprocnew > 1:
-            if self.multiproc:
+            if self.parallel_kind == "multiproc":
                 self.pool = mp.Pool(processes=nprocnew)
             else:
                 self.pool = mt.ThreadPoolExecutor(max_workers=nprocnew)
@@ -266,19 +271,6 @@ class HStack(LinearOperator):
         y = np.hstack(ys)
         return y
 
-    # def _matvec_multithread(self, x: NDArray) -> NDArray:
-    #     ys = list(
-    #         self.pool.map(
-    #             lambda args: _matvec_rmatvec_map(*args),
-    #             [
-    #                 (oper._matvec, x[self.mmops[iop] : self.mmops[iop + 1]])
-    #                 for iop, oper in enumerate(self.ops)
-    #             ],
-    #         )
-    #     )
-    #     y = np.sum(ys, axis=0)
-    #     return y
-
     def _matvec_multithread(self, x: NDArray) -> NDArray:
         y = np.zeros(self.nops, dtype=self.dtype)
         list(
@@ -311,7 +303,7 @@ class HStack(LinearOperator):
         if self.nproc == 1:
             y = self._matvec_serial(x)
         else:
-            if self.multiproc:
+            if self.parallel_kind == "multiproc":
                 y = self._matvec_multiproc(x)
             else:
                 y = self._matvec_multithread(x)
@@ -321,7 +313,7 @@ class HStack(LinearOperator):
         if self.nproc == 1:
             y = self._rmatvec_serial(x)
         else:
-            if self.multiproc:
+            if self.parallel_kind == "multiproc":
                 y = self._rmatvec_multiproc(x)
             else:
                 y = self._rmatvec_multithread(x)
@@ -332,7 +324,7 @@ class HStack(LinearOperator):
         multithreading.
         """
         if self.pool is not None:
-            if self.multiproc:
+            if self.parallel_kind == "multiproc":
                 self.pool.close()
                 self.pool.join()
             else:

--- a/pylops/basicoperators/vstack.py
+++ b/pylops/basicoperators/vstack.py
@@ -1,5 +1,6 @@
 __all__ = ["VStack"]
 
+import concurrent.futures as mt
 import multiprocessing as mp
 
 import numpy as np
@@ -46,8 +47,8 @@ class VStack(LinearOperator):
         :obj:`numpy.ndarray` or :obj:`scipy.sparse` matrices can be passed
         in place of one or more operators.
     nproc : :obj:`int`, optional
-        Number of processes used to evaluate the N operators in parallel using
-        ``multiprocessing``. If ``nproc=1``, work in serial mode.
+        Number of processes/threads used to evaluate the N operators in parallel using
+        ``multiprocessing``/``concurrent.futures``. If ``nproc=1``, work in serial mode.
     forceflat : :obj:`bool`, optional
         .. versionadded:: 2.2.0
 
@@ -58,6 +59,10 @@ class VStack(LinearOperator):
         Type of output vectors of `matvec` and `rmatvec. If ``None``, this is
         inferred directly from the input vectors. Note that this is ignored
         if ``nproc>1``.
+    multiproc : :obj:`bool`, optional
+        .. versionadded:: 2.6.0
+
+        Use multiprocessing (``True``) or multithreading (``False``) when ``nproc>1``.
     dtype : :obj:`str`, optional
         Type of elements in input array.
 
@@ -138,6 +143,7 @@ class VStack(LinearOperator):
         nproc: int = 1,
         forceflat: bool = None,
         inoutengine: Optional[tuple] = None,
+        multiproc: bool = True,
         dtype: Optional[DTypeLike] = None,
     ) -> None:
         self.ops = ops
@@ -160,11 +166,15 @@ class VStack(LinearOperator):
         else:
             dims = (self.mops,)
             forceflat = True
-        # create pool for multiprocessing
+        # create pool for multithreading / multiprocessing
+        self.multiproc = multiproc
         self._nproc = nproc
         self.pool = None
         if self.nproc > 1:
-            self.pool = mp.Pool(processes=nproc)
+            if multiproc:
+                self.pool = mp.Pool(processes=nproc)
+            else:
+                self.pool = mt.ThreadPoolExecutor(max_workers=nproc)
         self.inoutengine = inoutengine
         dtype = _get_dtype(self.ops) if dtype is None else np.dtype(dtype)
         clinear = all([getattr(oper, "clinear", True) for oper in self.ops])
@@ -239,16 +249,58 @@ class VStack(LinearOperator):
         y = np.sum(ys, axis=0)
         return y
 
+    def _matvec_multithread(self, x: NDArray) -> NDArray:
+        ys = list(
+            self.pool.map(
+                lambda args: _matvec_rmatvec_map(*args),
+                [(oper._matvec, x) for iop, oper in enumerate(self.ops)],
+            )
+        )
+        y = np.hstack(ys)
+        return y
+
+    def _rmatvec_multithread(self, x: NDArray) -> NDArray:
+        ys = list(
+            self.pool.map(
+                lambda args: _matvec_rmatvec_map(*args),
+                [
+                    (oper._rmatvec, x[self.nnops[iop] : self.nnops[iop + 1]])
+                    for iop, oper in enumerate(self.ops)
+                ],
+            )
+        )
+
+        y = np.sum(ys, axis=0)
+        return y
+
     def _matvec(self, x: NDArray) -> NDArray:
         if self.nproc == 1:
             y = self._matvec_serial(x)
         else:
-            y = self._matvec_multiproc(x)
+            if self.multiproc:
+                y = self._matvec_multiproc(x)
+            else:
+                y = self._matvec_multithread(x)
         return y
 
     def _rmatvec(self, x: NDArray) -> NDArray:
         if self.nproc == 1:
             y = self._rmatvec_serial(x)
         else:
-            y = self._rmatvec_multiproc(x)
+            if self.multiproc:
+                y = self._rmatvec_multiproc(x)
+            else:
+                y = self._rmatvec_multithread(x)
         return y
+
+    def close(self):
+        """Close the pool of workers used for multiprocessing /
+        multithreading.
+        """
+        if self.pool is not None:
+            if self.multiproc:
+                self.pool.close()
+                self.pool.join()
+            else:
+                self.pool.shutdown()
+            self.pool = None

--- a/pylops/signalprocessing/chirpradon3d.py
+++ b/pylops/signalprocessing/chirpradon3d.py
@@ -49,8 +49,8 @@ class ChirpRadon3D(LinearOperator):
 
         Name of operator (to be used by :func:`pylops.utils.describe.describe`)
     **kwargs_fftw
-            Arbitrary keyword arguments for :py:class:`pyfftw.FTTW`
-            (reccomended: ``flags=('FFTW_ESTIMATE', ), threads=NTHREADS``)
+        Arbitrary keyword arguments for :py:class:`pyfftw.FTTW`
+        (reccomended: ``flags=('FFTW_ESTIMATE', ), threads=NTHREADS``)
 
     Attributes
     ----------

--- a/pylops/utils/multiproc.py
+++ b/pylops/utils/multiproc.py
@@ -1,9 +1,12 @@
 __all__ = ["scalability_test"]
 
+import logging
 import time
 from typing import List, Optional, Tuple
 
 import numpy.typing as npt
+
+logger = logging.getLogger(__name__)
 
 
 def scalability_test(
@@ -11,23 +14,28 @@ def scalability_test(
     x: npt.ArrayLike,
     workers: Optional[List[int]] = None,
     forward: bool = True,
+    ntimes: int = 1,
 ) -> Tuple[List[float], List[float]]:
     r"""Scalability test.
 
     Small auxiliary routine to test the performance of operators using
-    ``multiprocessing``. This helps identifying the maximum number of workers
-    beyond which no performance gain is observed.
+    ``multiprocessing``/``concurrent.futures``. This helps identifying the
+    maximum number of workers beyond which no performance gain is observed.
 
     Parameters
     ----------
     Op : :obj:`pylops.LinearOperator`
-        Operator to test. It must allow for multiprocessing.
+        Operator to test. It must allow for multiprocessing/multithreading.
     x : :obj:`numpy.ndarray`, optional
         Input vector.
     workers : :obj:`list`, optional
         Number of workers to test out. Defaults to `[1, 2, 4]`.
     forward : :obj:`bool`, optional
         Apply forward (``True``) or adjoint (``False``)
+    ntimes : :obj:`int`, optional
+        Number of times the forward/adjoint is applied whilst timing
+        operations. Consider using :math:`n_{times} \ge 10` to obtain
+        a stable measure of the compute times and speedups.
 
     Returns
     -------
@@ -42,17 +50,18 @@ def scalability_test(
     compute_times = []
     speedup = []
     for nworkers in workers:
-        print(f"Working with {nworkers} workers...")
+        logger.info("Working with %d workers...", nworkers)
         # update number of workers in operator
         Op.nproc = nworkers
         # run forward/adjoint computation
-        starttime = time.time()
-        if forward:
-            _ = Op.matvec(x)
-        else:
-            _ = Op.rmatvec(x)
-        elapsedtime = time.time() - starttime
+        starttime = time.perf_counter()
+        for _ in range(ntimes):
+            if forward:
+                _ = Op.matvec(x)
+            else:
+                _ = Op.rmatvec(x)
+        elapsedtime = (time.perf_counter() - starttime) / ntimes
         compute_times.append(elapsedtime)
         speedup.append(compute_times[0] / elapsedtime)
-    Op.pool.close()
+    Op.close()
     return compute_times, speedup

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -102,7 +102,11 @@ class BlendingContinuous(LinearOperator):
         self.dt = dt
         self.times = times
         self.shiftall = shiftall
-        self.nttot = nttot if nttot is not None else g
+        self.nttot = (
+            nttot
+            if nttot is not None
+            else int(np.max(self.times) / self.dt + self.nt + 1)
+        )
         if not self.shiftall:
             # original implementation, where each source is shifted indipendently
             self.PadOp = Pad((self.nr, self.nt), ((0, 0), (0, 1)), dtype=self.dtype)

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -4,6 +4,8 @@ __all__ = [
     "BlendingHalf",
 ]
 
+from typing import Optional
+
 import numpy as np
 
 from pylops import LinearOperator
@@ -36,6 +38,9 @@ class BlendingContinuous(LinearOperator):
     shiftall : :obj:`bool`, optional
         Shift all shots together (``True``) or one at the time (``False``). Defaults to ``shiftall=False`` (original
         implementation), however ``shiftall=True`` should be preferred when ``nr`` is small.
+    nttot : :obj:`int`
+        Total number of time samples in blended data (if ``None``, computed internally
+        based on the the maximum ignition time in ``times``)
     dtype : :obj:`str`, optional
         Operator dtype
     name : :obj:`str`, optional
@@ -43,9 +48,6 @@ class BlendingContinuous(LinearOperator):
 
     Attributes
     ----------
-    ntot : :obj:`int`
-        Total number of time samples in blended data (based on the
-        the maximum ignition time in ``times``)
     PadOp : :obj:`pylops.basicoperators.Pad`
         Padding operator used to add one zero at the end of each
         shot gather to avoid boundary effects when shifting
@@ -89,6 +91,7 @@ class BlendingContinuous(LinearOperator):
         dt: float,
         times: NDArray,
         shiftall: bool = False,
+        nttot: Optional[int] = None,
         dtype: DTypeLike = "float64",
         name: str = "B",
     ) -> None:
@@ -99,7 +102,7 @@ class BlendingContinuous(LinearOperator):
         self.dt = dt
         self.times = times
         self.shiftall = shiftall
-        self.nttot = int(np.max(self.times) / self.dt + self.nt + 1)
+        self.nttot = nttot if nttot is not None else g
         if not self.shiftall:
             # original implementation, where each source is shifted indipendently
             self.PadOp = Pad((self.nr, self.nt), ((0, 0), (0, 1)), dtype=self.dtype)

--- a/pylops/waveeqprocessing/blending.py
+++ b/pylops/waveeqprocessing/blending.py
@@ -45,6 +45,10 @@ class BlendingContinuous(LinearOperator):
         Operator dtype
     name : :obj:`str`, optional
         Name of operator (to be used by :func:`pylops.utils.describe.describe`)
+    **kwargs_fft
+        .. versionadded:: 2.6.0
+
+        Arbitrary keyword arguments to be passed to the Shift operator
 
     Attributes
     ----------
@@ -94,6 +98,7 @@ class BlendingContinuous(LinearOperator):
         nttot: Optional[int] = None,
         dtype: DTypeLike = "float64",
         name: str = "B",
+        **kwargs_fft,
     ) -> None:
         self.dtype = np.dtype(dtype)
         self.nt = nt
@@ -131,6 +136,7 @@ class BlendingContinuous(LinearOperator):
                             sampling=self.dt,
                             real=True,
                             dtype=self.dtype,
+                            **kwargs_fft,
                         )
                     )
         else:
@@ -149,6 +155,7 @@ class BlendingContinuous(LinearOperator):
                 sampling=self.dt,
                 real=True,
                 dtype=self.dtype,
+                **kwargs_fft,
             )
             self.diff = diff
 
@@ -250,6 +257,7 @@ def BlendingGroup(
     nproc: int = 1,
     dtype: DTypeLike = "float64",
     name: str = "B",
+    **kwargs_fft,
 ) -> LinearOperator:
     r"""Group blending operator
 
@@ -284,6 +292,10 @@ def BlendingGroup(
         Operator dtype
     name : :obj:`str`, optional
         Name of operator (to be used by :func:`pylops.utils.describe.describe`)
+    **kwargs_fft
+        .. versionadded:: 2.6.0
+
+        Arbitrary keyword arguments to be passed to the Shift operator
 
     Returns
     -------
@@ -320,7 +332,13 @@ def BlendingGroup(
         Hop = []
         for j in range(group_size):
             ShiftOp = Shift(
-                (nr, nt), times[j, i], axis=1, sampling=dt, real=False, dtype=dtype
+                (nr, nt),
+                times[j, i],
+                axis=1,
+                sampling=dt,
+                real=False,
+                dtype=dtype,
+                **kwargs_fft,
             )
             Hop.append(ShiftOp)
         Bop.append(HStack(Hop))
@@ -342,6 +360,7 @@ def BlendingHalf(
     nproc: int = 1,
     dtype: DTypeLike = "float64",
     name: str = "B",
+    **kwargs_fft,
 ) -> LinearOperator:
     r"""Half blending operator
 
@@ -376,6 +395,10 @@ def BlendingHalf(
         Operator dtype
     name : :obj:`str`, optional
         Name of operator (to be used by :func:`pylops.utils.describe.describe`)
+    **kwargs_fft
+        .. versionadded:: 2.6.0
+
+        Arbitrary keyword arguments to be passed to the Shift operator
 
     Returns
     -------
@@ -412,7 +435,13 @@ def BlendingHalf(
         OpShift = []
         for i in range(n_groups):
             ShiftOp = Shift(
-                (nr, nt), times[j, i], axis=1, sampling=dt, real=False, dtype=dtype
+                (nr, nt),
+                times[j, i],
+                axis=1,
+                sampling=dt,
+                real=False,
+                dtype=dtype,
+                **kwargs_fft,
             )
             OpShift.append(ShiftOp)
         Dop = BlockDiag(OpShift, nproc=nproc)

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -353,7 +353,7 @@ def test_BlockDiag(par):
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_VStack_multiproc_multithread(par):
     """Single and multiprocess/multithreading consistentcy for VStack operator"""
-    for multiproc in [True, False]:
+    for parallel_kind in ["multiproc", "multithread"]:
         np.random.seed(0)
         nproc = 2
         G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
@@ -364,7 +364,7 @@ def test_VStack_multiproc_multithread(par):
         Vmultiop = VStack(
             [MatrixMult(G, dtype=par["dtype"])] * 4,
             nproc=nproc,
-            multiproc=multiproc,
+            parallel_kind=parallel_kind,
             dtype=par["dtype"],
         )
         assert dottest(
@@ -389,7 +389,7 @@ def test_VStack_multiproc_multithread(par):
 @pytest.mark.parametrize("par", [(par2), (par2j)])
 def test_HStack_multiproc_multithread(par):
     """Single and multiprocess/multithreading  consistentcy for HStack operator"""
-    for multiproc in [True, False]:
+    for parallel_kind in ["multiproc", "multithread"]:
         np.random.seed(0)
         nproc = 2
         G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
@@ -400,7 +400,7 @@ def test_HStack_multiproc_multithread(par):
         Hmultiop = HStack(
             [MatrixMult(G, dtype=par["dtype"])] * 4,
             nproc=nproc,
-            multiproc=multiproc,
+            parallel_kind=parallel_kind,
             dtype=par["dtype"],
         )
         assert dottest(
@@ -425,7 +425,7 @@ def test_HStack_multiproc_multithread(par):
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_Block_multiproc_multithread(par):
     """Single and multiprocess/multithreading  consistentcy for Block operator"""
-    for multiproc in [True, False]:
+    for parallel_kind in ["multiproc", "multithread"]:
         np.random.seed(0)
         nproc = 2
         G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
@@ -435,7 +435,9 @@ def test_Block_multiproc_multithread(par):
         y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
 
         Bop = Block(Ghor, dtype=par["dtype"])
-        Bmultiop = Block(Ghor, nproc=nproc, multiproc=multiproc, dtype=par["dtype"])
+        Bmultiop = Block(
+            Ghor, nproc=nproc, parallel_kind=parallel_kind, dtype=par["dtype"]
+        )
         assert dottest(
             Bmultiop,
             4 * par["ny"],
@@ -458,7 +460,7 @@ def test_Block_multiproc_multithread(par):
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
 def test_BlockDiag_multiproc_multithread(par):
     """Single and multiprocess/multithreading consistentcy for BlockDiag operator"""
-    for multiproc in [True, False]:
+    for parallel_kind in ["multiproc", "multithread"]:
         np.random.seed(0)
         nproc = 2
         G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
@@ -469,7 +471,7 @@ def test_BlockDiag_multiproc_multithread(par):
         BDmultiop = BlockDiag(
             [MatrixMult(G, dtype=par["dtype"])] * 4,
             nproc=nproc,
-            multiproc=multiproc,
+            parallel_kind=parallel_kind,
             dtype=par["dtype"],
         )
         assert dottest(

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -351,128 +351,141 @@ def test_BlockDiag(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
-def test_VStack_multiproc(par):
-    """Single and multiprocess consistentcy for VStack operator"""
-    np.random.seed(0)
-    nproc = 2
-    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
-    y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
+def test_VStack_multiproc_multithread(par):
+    """Single and multiprocess/multithreading consistentcy for VStack operator"""
+    for multiproc in [True, False]:
+        np.random.seed(0)
+        nproc = 2
+        G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+        x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+        y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
 
-    Vop = VStack([MatrixMult(G, dtype=par["dtype"])] * 4, dtype=par["dtype"])
-    Vmultiop = VStack(
-        [MatrixMult(G, dtype=par["dtype"])] * 4, nproc=nproc, dtype=par["dtype"]
-    )
-    assert dottest(
-        Vmultiop,
-        4 * par["ny"],
-        par["nx"],
-        complexflag=0 if par["imag"] == 0 else 3,
-        backend=backend,
-    )
-    # forward
-    assert_array_almost_equal(Vop * x, Vmultiop * x, decimal=4)
-    # adjoint
-    assert_array_almost_equal(Vop.H * y, Vmultiop.H * y, decimal=4)
+        Vop = VStack([MatrixMult(G, dtype=par["dtype"])] * 4, dtype=par["dtype"])
+        Vmultiop = VStack(
+            [MatrixMult(G, dtype=par["dtype"])] * 4,
+            nproc=nproc,
+            multiproc=multiproc,
+            dtype=par["dtype"],
+        )
+        assert dottest(
+            Vmultiop,
+            4 * par["ny"],
+            par["nx"],
+            complexflag=0 if par["imag"] == 0 else 3,
+            backend=backend,
+        )
+        # forward
+        assert_array_almost_equal(Vop * x, Vmultiop * x, decimal=4)
+        # adjoint
+        assert_array_almost_equal(Vop.H * y, Vmultiop.H * y, decimal=4)
 
-    # close pool
-    Vmultiop.pool.close()
+        # close pool
+        Vmultiop.close()
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par2), (par2j)])
-def test_HStack_multiproc(par):
-    """Single and multiprocess consistentcy for HStack operator"""
-    np.random.seed(0)
-    nproc = 2
-    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    x = np.ones(4 * par["nx"]) + par["imag"] * np.ones(4 * par["nx"])
-    y = np.ones(par["ny"]) + par["imag"] * np.ones(par["ny"])
+def test_HStack_multiproc_multithread(par):
+    """Single and multiprocess/multithreading  consistentcy for HStack operator"""
+    for multiproc in [True, False]:
+        np.random.seed(0)
+        nproc = 2
+        G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+        x = np.ones(4 * par["nx"]) + par["imag"] * np.ones(4 * par["nx"])
+        y = np.ones(par["ny"]) + par["imag"] * np.ones(par["ny"])
 
-    Hop = HStack([MatrixMult(G, dtype=par["dtype"])] * 4, dtype=par["dtype"])
-    Hmultiop = HStack(
-        [MatrixMult(G, dtype=par["dtype"])] * 4, nproc=nproc, dtype=par["dtype"]
-    )
-    assert dottest(
-        Hmultiop,
-        par["ny"],
-        4 * par["nx"],
-        complexflag=0 if par["imag"] == 0 else 3,
-        backend=backend,
-    )
-    # forward
-    assert_array_almost_equal(Hop * x, Hmultiop * x, decimal=4)
-    # adjoint
-    assert_array_almost_equal(Hop.H * y, Hmultiop.H * y, decimal=4)
+        Hop = HStack([MatrixMult(G, dtype=par["dtype"])] * 4, dtype=par["dtype"])
+        Hmultiop = HStack(
+            [MatrixMult(G, dtype=par["dtype"])] * 4,
+            nproc=nproc,
+            multiproc=multiproc,
+            dtype=par["dtype"],
+        )
+        assert dottest(
+            Hmultiop,
+            par["ny"],
+            4 * par["nx"],
+            complexflag=0 if par["imag"] == 0 else 3,
+            backend=backend,
+        )
+        # forward
+        assert_array_almost_equal(Hop * x, Hmultiop * x, decimal=4)
+        # adjoint
+        assert_array_almost_equal(Hop.H * y, Hmultiop.H * y, decimal=4)
 
-    # close pool
-    Hmultiop.pool.close()
-
-
-@pytest.mark.skipif(
-    int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
-)
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
-def test_Block_multiproc(par):
-    """Single and multiprocess consistentcy for Block operator"""
-    np.random.seed(0)
-    nproc = 2
-    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    Gvert = [MatrixMult(G, dtype=par["dtype"])] * 2
-    Ghor = [Gvert] * 4
-    x = np.ones(2 * par["nx"]) + par["imag"] * np.ones(2 * par["nx"])
-    y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
-
-    Bop = Block(Ghor, dtype=par["dtype"])
-    Bmultiop = Block(Ghor, nproc=nproc, dtype=par["dtype"])
-    assert dottest(
-        Bmultiop,
-        4 * par["ny"],
-        2 * par["nx"],
-        complexflag=0 if par["imag"] == 0 else 3,
-        backend=backend,
-    )
-    # forward
-    assert_array_almost_equal(Bop * x, Bmultiop * x, decimal=3)
-    # adjoint
-    assert_array_almost_equal(Bop.H * y, Bmultiop.H * y, decimal=3)
-
-    # close pool
-    Bmultiop.pool.close()
+        # close pool
+        Hmultiop.close()
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
-def test_BlockDiag_multiproc(par):
-    """Single and multiprocess consistentcy for BlockDiag operator"""
-    np.random.seed(0)
-    nproc = 2
-    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    x = np.ones(4 * par["nx"]) + par["imag"] * np.ones(4 * par["nx"])
-    y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
+def test_Block_multiproc_multithread(par):
+    """Single and multiprocess/multithreading  consistentcy for Block operator"""
+    for multiproc in [True, False]:
+        np.random.seed(0)
+        nproc = 2
+        G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+        Gvert = [MatrixMult(G, dtype=par["dtype"])] * 2
+        Ghor = [Gvert] * 4
+        x = np.ones(2 * par["nx"]) + par["imag"] * np.ones(2 * par["nx"])
+        y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
 
-    BDop = BlockDiag([MatrixMult(G, dtype=par["dtype"])] * 4, dtype=par["dtype"])
-    BDmultiop = BlockDiag(
-        [MatrixMult(G, dtype=par["dtype"])] * 4, nproc=nproc, dtype=par["dtype"]
-    )
-    assert dottest(
-        BDmultiop,
-        4 * par["ny"],
-        4 * par["nx"],
-        complexflag=0 if par["imag"] == 0 else 3,
-        backend=backend,
-    )
-    # forward
-    assert_array_almost_equal(BDop * x, BDmultiop * x, decimal=4)
-    # adjoint
-    assert_array_almost_equal(BDop.H * y, BDmultiop.H * y, decimal=4)
+        Bop = Block(Ghor, dtype=par["dtype"])
+        Bmultiop = Block(Ghor, nproc=nproc, multiproc=multiproc, dtype=par["dtype"])
+        assert dottest(
+            Bmultiop,
+            4 * par["ny"],
+            2 * par["nx"],
+            complexflag=0 if par["imag"] == 0 else 3,
+            backend=backend,
+        )
+        # forward
+        assert_array_almost_equal(Bop * x, Bmultiop * x, decimal=3)
+        # adjoint
+        assert_array_almost_equal(Bop.H * y, Bmultiop.H * y, decimal=3)
 
-    # close pool
-    BDmultiop.pool.close()
+        # close pool
+        Bmultiop.Op.close()
+
+
+@pytest.mark.skipif(
+    int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
+)
+@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+def test_BlockDiag_multiproc_multithread(par):
+    """Single and multiprocess/multithreading consistentcy for BlockDiag operator"""
+    for multiproc in [True, False]:
+        np.random.seed(0)
+        nproc = 2
+        G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+        x = np.ones(4 * par["nx"]) + par["imag"] * np.ones(4 * par["nx"])
+        y = np.ones(4 * par["ny"]) + par["imag"] * np.ones(4 * par["ny"])
+
+        BDop = BlockDiag([MatrixMult(G, dtype=par["dtype"])] * 4, dtype=par["dtype"])
+        BDmultiop = BlockDiag(
+            [MatrixMult(G, dtype=par["dtype"])] * 4,
+            nproc=nproc,
+            multiproc=multiproc,
+            dtype=par["dtype"],
+        )
+        assert dottest(
+            BDmultiop,
+            4 * par["ny"],
+            4 * par["nx"],
+            complexflag=0 if par["imag"] == 0 else 3,
+            backend=backend,
+        )
+        # forward
+        assert_array_almost_equal(BDop * x, BDmultiop * x, decimal=4)
+        # adjoint
+        assert_array_almost_equal(BDop.H * y, BDmultiop.H * y, decimal=4)
+
+        # close pool
+        BDmultiop.close()
 
 
 @pytest.mark.parametrize("par", [(par1j), (par2j)])


### PR DESCRIPTION
This PR introduces support for multithreading (alongside the already present multiprocessing) in the stacking operators. 

The main motivation of this stems from the recently introduced [Python support for free threading](https://docs.python.org/3/howto/free-threading-python.html) (aka Python with GIL disabled). The changes are rather trivial and are tested in https://github.com/PyLops/pylops-free_threading (currently private, only visible to PyLops org. owners).

@cako I wonder if you have already some experience with the new support for real multithreading in Python and want to take a look. The performance comparison between serial/multiprocess/multithreading tells me that there is clearly a benefit (see https://github.com/PyLops/pylops-free_threading/blob/main/pyblockdiag.ipynb and https://github.com/PyLops/pylops-free_threading/blob/main/pyhstack.ipynb) but it looks like that similar benefit can also be seen in python 3.13 with GIL enabled (so not truly with multithreaded code but just threads alternating each other)....