### PR TITLE
fix: pass kind to Laplacian

### DIFF
--- a/pylops/basicoperators/gradient.py
+++ b/pylops/basicoperators/gradient.py
@@ -29,6 +29,10 @@ class Gradient(LinearOperator):
         Derivative kind (``forward``, ``centered``, or ``backward``).
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------

--- a/pylops/basicoperators/laplacian.py
+++ b/pylops/basicoperators/laplacian.py
@@ -21,7 +21,7 @@ class Laplacian(LinearOperator):
     ----------
     dims : :obj:`tuple`
         Number of samples for each dimension.
-    axes : :obj:`int`, optional
+    axes : :obj:`tuple`, optional
         .. versionadded:: 2.0.0
 
         Axes along which the Laplacian is applied.
@@ -37,6 +37,10 @@ class Laplacian(LinearOperator):
         Derivative kind (``forward``, ``centered``, or ``backward``)
     dtype : :obj:`str`, optional
         Type of elements in input array.
+    name : :obj:`str`, optional
+        .. versionadded:: 2.0.0
+
+        Name of operator (to be used by :func:`pylops.utils.describe.describe`)
 
     Attributes
     ----------
@@ -54,7 +58,7 @@ class Laplacian(LinearOperator):
     Raises
     ------
     ValueError
-        If ``axes``. ``weights``, and ``sampling`` do not have the same size
+        If ``axes``, ``weights``, and ``sampling`` do not have the same size
 
     Notes
     -----

--- a/pylops/basicoperators/laplacian.py
+++ b/pylops/basicoperators/laplacian.py
@@ -126,6 +126,6 @@ class Laplacian(LinearOperator):
         l2op *= weights[0]
         for ax, samp, weight in zip(axes[1:], sampling[1:], weights[1:]):
             l2op += weight * SecondDerivative(
-                dims, axis=ax, sampling=samp, edge=edge, dtype=dtype
+                dims, axis=ax, sampling=samp, edge=edge, kind=kind, dtype=dtype
             )
         return l2op

--- a/pylops/basicoperators/secondderivative.py
+++ b/pylops/basicoperators/secondderivative.py
@@ -64,7 +64,7 @@ class SecondDerivative(LinearOperator):
     direction of a multi-dimensional array.
 
     For simplicity, given a one dimensional array, the second-order centered
-    first derivative is:
+    second derivative is:
 
     .. math::
         y[i] = (x[i+1] - 2x[i] + x[i-1]) / \Delta x^2


### PR DESCRIPTION
This PR fixes a nasty bug in `Laplacian` where kind was passed to the first `SecondDerivative` op but not the others... 

A few minor docstring/type hints improvements are also implemented across the derivative suite.