### PR TITLE
feat: extend pwd_slope_estimate to 3d

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -74,6 +74,7 @@ Smoothing and derivatives
 
    Smoothing1D
    Smoothing2D
+   SmoothingND
    FirstDerivative
    SecondDerivative
    Laplacian

--- a/examples/plot_pwdslope.py
+++ b/examples/plot_pwdslope.py
@@ -164,22 +164,27 @@ fig.tight_layout()
 
 ###############################################################################
 # Let's now compute the PWD slopes along both ``y`` and ``x`` directions.
-pwd_slope_fun = partial(
-    pwd_slope_estimate,
+pwd_slope3d_y = pwd_slope_estimate(
+    sigmoid3d.transpose(1, 2, 0),
     niter=5,
     liter=20,
     order=2,
-    nsmooth=(12, 12),
+    nsmooth=(12, 12, 5),
     damp=6e-4,
     smoothing="triangle",
-)
-pwd_slope3d_y = np.concatenate(
-    [pwd_slope_fun(sigmoid3d[i])[None].astype(np.float32) for i in range(ny)]
-)
+    axis=1,
+).transpose(2, 0, 1)
 
-pwd_slope3d_x = np.concatenate(
-    [pwd_slope_fun(sigmoid3d[:, :, i].T)[None].astype(np.float32) for i in range(nx)]
-).transpose(2, 1, 0)
+pwd_slope3d_x = pwd_slope_estimate(
+    sigmoid3d.transpose(1, 2, 0),
+    niter=5,
+    liter=20,
+    order=2,
+    nsmooth=(12, 5, 12),
+    damp=6e-4,
+    smoothing="triangle",
+    axis=2,
+).transpose(2, 0, 1)
 
 ###############################################################################
 v = np.max(np.abs(pwd_slope3d_y))
@@ -209,7 +214,8 @@ create_colorbar(im1, ax=ax[1])
 fig.tight_layout()
 
 ###############################################################################
-# Let's now compute the PWD slopes along both ``y`` and ``x`` directions.
+# Finally we perform structure-aligned smoothing along both ``y`` and ``x``
+# directions.
 PWSmoother2D_ = partial(PWSmoother2D, radius=radius, alpha=alpha, dtype="float32")
 noise3d = np.random.uniform(-1.0, 1.0, size=(ny, nz, nx)).astype(np.float32)
 

--- a/examples/plot_smoothing3d.py
+++ b/examples/plot_smoothing3d.py
@@ -1,0 +1,48 @@
+"""
+3D Smoothing
+============
+
+This example shows how to use the :py:class:`pylops.SmoothingND` operator
+to smooth a three-dimensional input signal along all axes.
+
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+import pylops
+
+plt.close("all")
+
+###############################################################################
+# Define the input parameters: number of samples of input signal (``N1``,
+# ``N2``, and ``N3``) and lenght of the smoothing filter regression coefficients
+# (:math:`n_{smooth,1}`, :math:`n_{smooth,2}` and :math:`n_{smooth,3}`).
+# The input signal is one at the center and zero elsewhere.
+N1, N2, N3 = 11, 21, 15
+nsmooth1, nsmooth2, nsmooth3 = 5, 7, 3
+A = np.zeros((N1, N2, N3))
+A[5, 10, 7] = 1
+
+Sop = pylops.SmoothingND(
+    nsmooth=[nsmooth1, nsmooth2, nsmooth3], dims=[N1, N2, N3], dtype="float64"
+)
+B = Sop * A
+
+###############################################################################
+# After applying smoothing, we will also try to invert it.
+Aest = Sop.div(B.ravel(), niter=2000).reshape(Sop.dims)
+
+fig, axs = plt.subplots(1, 3, figsize=(10, 3))
+im = axs[0].imshow(A[..., 7], interpolation="nearest", vmin=0, vmax=1)
+axs[0].axis("tight")
+axs[0].set_title("Model")
+plt.colorbar(im, ax=axs[0])
+im = axs[1].imshow(B[..., 7], interpolation="nearest", vmin=0, vmax=0.1)
+axs[1].axis("tight")
+axs[1].set_title("Data")
+plt.colorbar(im, ax=axs[1])
+im = axs[2].imshow(Aest[..., 7], interpolation="nearest", vmin=0, vmax=1)
+axs[2].axis("tight")
+axs[2].set_title("Estimated model")
+plt.colorbar(im, ax=axs[2])
+plt.tight_layout()

--- a/pylops/basicoperators/__init__.py
+++ b/pylops/basicoperators/__init__.py
@@ -32,6 +32,7 @@ A list of operators present in pylops.basicoperators :
     Conj                            Conj operator.
     Smoothing1D                     1D Smoothing.
     Smoothing2D	                    2D Smoothing.
+    SmoothingND	                    ND Smoothing.
     FirstDerivative                 First derivative.
     SecondDerivative                Second derivative.
     Laplacian                       Laplacian.
@@ -67,6 +68,7 @@ from .imag import *
 from .conj import *
 from .smoothing1d import *
 from .smoothing2d import *
+from .smoothingnd import *
 from .causalintegration import *
 from .firstderivative import *
 from .secondderivative import *
@@ -103,6 +105,7 @@ __all__ = [
     "Conj",
     "Smoothing1D",
     "Smoothing2D",
+    "SmoothingND",
     "CausalIntegration",
     "FirstDerivative",
     "SecondDerivative",

--- a/pylops/basicoperators/smoothingnd.py
+++ b/pylops/basicoperators/smoothingnd.py
@@ -1,23 +1,23 @@
-__all__ = ["Smoothing2D"]
+__all__ = ["SmoothingND"]
 
 from typing import Union
 
 import numpy as np
 
-from pylops.signalprocessing import Convolve2D
+from pylops.signalprocessing import ConvolveND
 from pylops.utils.typing import DTypeLike, InputDimsLike
 
 
-class Smoothing2D(Convolve2D):
+class SmoothingND(ConvolveND):
     r"""2D Smoothing.
 
-    Apply smoothing to model (and data) along two ``axes`` of a
-    multi-dimensional array.
+    Apply smoothing to model (and data) along  the
+    ``axes`` of a n-dimensional array.
 
     Parameters
     ----------
     nsmooth : :obj:`tuple` or :obj:`list`
-        Length of smoothing operator in 1st and 2nd dimensions
+        Length of smoothing operator in the chosen dimensions
         (must be odd, if even it will be increased by 1).
     dims : :obj:`tuple`
         Number of samples for each dimension
@@ -48,11 +48,11 @@ class Smoothing2D(Convolve2D):
 
     See Also
     --------
-    pylops.signalprocessing.Convolve2D : 2D convolution
+    pylops.signalprocessing.ConvolveND : ND convolution
 
     Notes
     -----
-    The 2D Smoothing operator is a special type of convolutional operator that
+    The ND Smoothing operator is a special type of convolutional operator that
     convolves the input model (or data) with a constant 2d filter of size
     :math:`n_{\text{smooth}, 1} \times n_{\text{smooth}, 2}`:
 
@@ -77,12 +77,11 @@ class Smoothing2D(Convolve2D):
         name: str = "S",
     ):
         nsmooth = list(nsmooth)
-        if nsmooth[0] % 2 == 0:
-            nsmooth[0] += 1
-        if nsmooth[1] % 2 == 0:
-            nsmooth[1] += 1
-        h = np.ones((nsmooth[0], nsmooth[1])) / float(nsmooth[0] * nsmooth[1])
-        offset = [(nsmooth[0] - 1) // 2, (nsmooth[1] - 1) // 2]
+        for i in range(len(nsmooth)):
+            if nsmooth[i] % 2 == 0:
+                nsmooth[i] += 1
+        h = np.ones(nsmooth) / float(np.prod(nsmooth))
+        offset = [(nsm - 1) // 2 for nsm in nsmooth]
         super().__init__(
             dims=dims, h=h, offset=offset, axes=axes, dtype=dtype, name=name
         )

--- a/pylops/basicoperators/smoothingnd.py
+++ b/pylops/basicoperators/smoothingnd.py
@@ -9,7 +9,7 @@ from pylops.utils.typing import DTypeLike, InputDimsLike
 
 
 class SmoothingND(ConvolveND):
-    r"""2D Smoothing.
+    r"""ND Smoothing.
 
     Apply smoothing to model (and data) along  the
     ``axes`` of a n-dimensional array.
@@ -22,8 +22,6 @@ class SmoothingND(ConvolveND):
     dims : :obj:`tuple`
         Number of samples for each dimension
     axes : :obj:`int`, optional
-        .. versionadded:: 2.0.0
-
         Axes along which model (and data) are smoothed.
     dtype : :obj:`str`, optional
         Type of elements in input array.
@@ -53,17 +51,18 @@ class SmoothingND(ConvolveND):
     Notes
     -----
     The ND Smoothing operator is a special type of convolutional operator that
-    convolves the input model (or data) with a constant 2d filter of size
-    :math:`n_{\text{smooth}, 1} \times n_{\text{smooth}, 2}`:
+    convolves the input model (or data) with a constant nd filter of size
+    :math:`n_{\text{smooth}, 1} \times n_{\text{smooth}, 2} \times n_{\text{smooth}, 3}`:
 
-    Its application to a two dimensional input signal is:
+    Its application to a three dimensional input signal is:
 
     .. math::
-        y[i,j] = 1/(n_{\text{smooth}, 1}\cdot n_{\text{smooth}, 2})
+        y[i,j,k] = 1/(n_{\text{smooth}, 1}\cdot n_{\text{smooth}, 2}\cdot n_{\text{smooth}, 3})
         \sum_{l=-(n_{\text{smooth},1}-1)/2}^{(n_{\text{smooth},1}-1)/2}
-        \sum_{m=-(n_{\text{smooth},2}-1)/2}^{(n_{\text{smooth},2}-1)/2} x[l,m]
+        \sum_{m=-(n_{\text{smooth},2}-1)/2}^{(n_{\text{smooth},2}-1)/2}
+        \sum_{n=-(n_{\text{smooth},3}-1)/2}^{(n_{\text{smooth},3}-1)/2} x[l,m,n]
 
-    Note that since the filter is symmetrical, the *Smoothing2D* operator is
+    Note that since the filter is symmetrical, the *Smoothing3D* operator is
     self-adjoint.
 
     """

--- a/pylops/signalprocessing/convolve2d.py
+++ b/pylops/signalprocessing/convolve2d.py
@@ -36,7 +36,7 @@ class Convolve2D(ConvolveND):
 
     Attributes
     ----------
-    nh : :obj:`int`
+    nh : :obj:`tuple`
         Length of the filter
     convolve : :obj:`callable`
         Convolution function

--- a/pylops/signalprocessing/convolvend.py
+++ b/pylops/signalprocessing/convolvend.py
@@ -46,7 +46,7 @@ class ConvolveND(LinearOperator):
 
     Attributes
     ----------
-    nh : :obj:`int`
+    nh : :obj:`tuple`
         Length of the filter
     convolve : :obj:`callable`
         Convolution function

--- a/pylops/utils/_pwd2d_numba.py
+++ b/pylops/utils/_pwd2d_numba.py
@@ -100,13 +100,12 @@ def _conv_allpass_numba(
 ) -> None:
     """Numba kernel for PWD all-pass filtering used in
     :func:`pylops.utils.signalprocessing.pwd_slope_estimate`."""
-    n1, n2 = din.shape
+    n1, n2 = din.shape[:2]
     nw = 1 if order == 1 else 2
 
-    for j in prange(n1):
-        for i in range(n2):
-            u1[j, i] = 0.0
-            u2[j, i] = 0.0
+    # Clear derivative arrays
+    u1[:] = 0.0
+    u2[:] = 0.0
 
     for i1 in prange(nw, n1 - nw):
         for i2 in range(0, n2 - 1):

--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -363,8 +363,9 @@ def pwd_slope_estimate(
     Returns
     -------
     sigma : :obj:`numpy.ndarray`
-        Estimated slope field of shape ``(nz, nx)`` in samples per trace
-        (:math:`\Delta z / \Delta x`).
+        Estimated slope field of size
+        :math:`[n_z \times n_x\,(\times n_y)]` in samples per trace
+        (:math:`\Delta z / \Delta x/y`).
 
     Raises
     ------
@@ -401,6 +402,7 @@ def pwd_slope_estimate(
     u1 = np.zeros_like(sigma)
     u2 = np.zeros_like(sigma)
 
+    # Define smoother
     if smoothing == "triangle":
         Sop = _triangular_smoothing_from_boxcars(
             nsmooth=nsmooth, dims=dims, dtype=dtype
@@ -410,6 +412,7 @@ def pwd_slope_estimate(
     else:
         raise ValueError("smoothing must be either 'triangle' or 'boxcar'")
 
+    # Estimate slopes
     for _ in range(niter):
         _conv_allpass(d, sigma, order, u1, u2)
 


### PR DESCRIPTION
This PR extends `pwd_slope_estimate` to compute slopes of 3d arrays over one of the spatial dimensions. 

As a by-product, the `SmoothingND` operator is also created.