### PR TITLE
CI: move to arm64 in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.10'
-      architecture: 'x64'
+      architecture: 'arm64'
 
   - script: |
       python -m pip install --upgrade pip setuptools wheel django

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
   displayName: 'Mac'
 
   pool:
-    vmImage: 'macOS-latest'
+    vmImage: 'macOS-15-arm64'
 
   variables:
     NUMBA_NUM_THREADS: 1
@@ -56,7 +56,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.10'
+      versionSpec: '3.11'
       architecture: 'arm64'
 
   - script: |
@@ -87,7 +87,7 @@ jobs:
   steps:
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.10'
+      versionSpec: '3.11'
       architecture: 'x64'
 
   - script: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 advanced = [
+    "llvmlite",
     "numba",
     "pyfftw",
     "PyWavelets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 advanced = [
-    "llvmlite",
     "numba",
     "pyfftw",
     "PyWavelets",


### PR DESCRIPTION
This PR fixes the OSX Azure Pipeline by moving to ARM (also bumps python to 3.11 for all pipelines)