### PR TITLE
Fix Intel CI

### DIFF
--- a/.github/workflows/build-mkl.yaml
+++ b/.github/workflows/build-mkl.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/environment-dev-intel-mkl.yml
+++ b/environment-dev-intel-mkl.yml
@@ -14,6 +14,7 @@ dependencies:
   - sympy
   - pymc>=5
   - pytensor
+  - astra-toolbox>=2.3.0
   - matplotlib
   - ipython
   - pytest


### PR DESCRIPTION
Fixes #721 

- Remove Python 3.10 from `build-mkl.yaml`