### PR TITLE
tmp: force torch<2.11 to solve issue in GPU CI

### DIFF
--- a/requirements-dev-gpu.txt
+++ b/requirements-dev-gpu.txt
@@ -1,7 +1,7 @@
 numpy>=2.0.0
 scipy>=1.13.0
 cupy-cuda12x
-torch
+torch<2.11.0
 numba
 sympy
 astra-toolbox>=2.3.0

--- a/tutorials/deblurring.py
+++ b/tutorials/deblurring.py
@@ -28,8 +28,8 @@ Nz, Nx = im.shape
 nh = [15, 25]
 hz = np.exp(-0.1 * np.linspace(-(nh[0] // 2), nh[0] // 2, nh[0]) ** 2)
 hx = np.exp(-0.03 * np.linspace(-(nh[1] // 2), nh[1] // 2, nh[1]) ** 2)
-hz /= np.trapz(hz)  # normalize the integral to 1
-hx /= np.trapz(hx)  # normalize the integral to 1
+hz /= np.trapezoid(hz)  # normalize the integral to 1
+hx /= np.trapezoid(hx)  # normalize the integral to 1
 h = hz[:, np.newaxis] * hx[np.newaxis, :]
 
 fig, ax = plt.subplots(1, 1, figsize=(5, 3))


### PR DESCRIPTION
This PR applies a temporary fix to the GPU Github Action. The problem seems to be with torch (see Claude message below):

```
The runner's NVIDIA driver is 570.195.03 (CUDA 12.8 max). CUDA 13 requires driver >=580.65.06. So torch 2.11 (which pulls CUDA 13) simply can't work with the current driver.

Two options:

Quick fix: pin torch<2.11 in requirements-dev-gpu.txt — already tested this locally, 1739/1739 tests pass on the L40S runner
Proper fix: upgrade NVIDIA driver on the runner nodes to 580+ (or latest 595+), then torch 2.11+ with CUDA 13 will work

The PR's approach of pinning just nvidia-curand-cu12 won't work because torch 2.11 installs ALL CUDA 13 libs as separate packages (nvidia-curand, nvidia-nvjitlink, nvidia-cuda-runtime etc. — all without the -cu12 suffix). CuPy picks those up and hits the driver wall.
[2:15 PM]Built and tested it. Confirmed the issue is torch 2.11 pulling CUDA 13.

With torch<2.11 (got torch 2.10.0, all CUDA 12 libs):

1739 passed, 757 skipped, 16 errors (all from missing astra-toolbox, unrelated)
Zero CUDA errors

Key facts:

Runner driver: 570.195.03, supports CUDA 12.8 max
torch 2.10.0 → nvidia-curand-cu12==10.3.9.90, all libs are cu12
torch 2.11.0 → nvidia-curand==10.4.0.35 (CUDA 13), cuda-toolkit==13.0.2

The PR's fix of pinning nvidia-curand-cu12==10.3.9.90 won't help because torch 2.11 installs the CUDA 13 versions as separate packages (without -cu12 suffix). CuPy then picks up the CUDA 13 runtime and the driver can't handle it.

Fix options:

Pin torch<2.11 in requirements-dev-gpu.txt (simplest)
Upgrade the NVIDIA driver to one supporting CUDA 13 (long-term fix)
Wait for PyTorch to sort out CUDA 12 vs 13 packaging
```

Hopefully in future either the NVIDIA driver are updated to CUDA 13 or torch PyPI install is fixed such that it picks the correct version for the CUDA driver present in the system.