### PR TITLE
Minor improvements for `signalprocessing.Interp` and `signalprocessing.InterpCubicSpline`

### DIFF
--- a/pylops/signalprocessing/_interp_utils.py
+++ b/pylops/signalprocessing/_interp_utils.py
@@ -47,6 +47,7 @@ def _clip_iava_above_last_sample_index(
         # NOTE: ``numpy.nextafter(x, -np.inf)`` gives the closest float-value that is
         #       less than ``x``, i.e., this logic clips ``iava`` to the highest possible
         #       value that is still below the last sample
+        iava = iava.copy()
         iava[np.where(outside)] = np.nextafter(last_sample_index, -np.inf)
 
     _ensure_iava_is_unique(iava=iava)

--- a/pylops/signalprocessing/_interp_utils.py
+++ b/pylops/signalprocessing/_interp_utils.py
@@ -47,7 +47,7 @@ def _clip_iava_above_last_sample_index(
         # NOTE: ``numpy.nextafter(x, -np.inf)`` gives the closest float-value that is
         #       less than ``x``, i.e., this logic clips ``iava`` to the highest possible
         #       value that is still below the last sample
-        iava = iava.copy()
+        iava = iava.copy()  # to avoid silent input mutation
         iava[np.where(outside)] = np.nextafter(last_sample_index, -np.inf)
 
     _ensure_iava_is_unique(iava=iava)

--- a/pylops/signalprocessing/_interp_utils.py
+++ b/pylops/signalprocessing/_interp_utils.py
@@ -28,7 +28,7 @@ def _ensure_iava_is_unique(
 def _clip_iava_above_last_sample_index(
     iava: NDArray,
     sample_size: int,
-) -> None:
+) -> NDArray:
     """
     Ensures that elements in ``iava`` do not exceed the last sample index.
     Elements above the penultimate sample are clipped to the next closest float value
@@ -52,4 +52,4 @@ def _clip_iava_above_last_sample_index(
 
     _ensure_iava_is_unique(iava=iava)
 
-    return
+    return iava

--- a/pylops/signalprocessing/interp.py
+++ b/pylops/signalprocessing/interp.py
@@ -179,7 +179,7 @@ def Interp(
     ValueError
         If the vector ``iava`` contains repeated values.
     NotImplementedError
-        If ``kind`` is not ``nearest``, ``linear`` or ``sinc``
+        If ``kind`` is not ``nearest``, ``linear``, ``sinc``, or ``"cubic_spline"``
 
     See Also
     --------

--- a/pylops/signalprocessing/interp.py
+++ b/pylops/signalprocessing/interp.py
@@ -133,7 +133,7 @@ def Interp(
       polynomial fitted between ``np.floor(iava)`` and ``np.floor(iava) + 1``.
       It offers an excellent tradeoff between accuracy and computational complexity
       and its results oscillate less than those obtained from sinc interpolation.
-      It can also be accessed directly via :class:`pylops.singalprocessing.InterpCubicSpline`.
+      It can also be accessed directly via :class:`pylops.signalprocessing.InterpCubicSpline`.
 
     .. note:: The vector ``iava`` should contain unique values. If the same
       index is repeated twice an error will be raised. This also applies when
@@ -179,7 +179,7 @@ def Interp(
     ValueError
         If the vector ``iava`` contains repeated values.
     NotImplementedError
-        If ``kind`` is not ``nearest``, ``linear``, ``sinc``, or ``"cubic_spline"``
+        If ``kind`` is not ``nearest``, ``linear``, ``sinc``, or ``cubic_spline``
 
     See Also
     --------

--- a/pylops/signalprocessing/interp.py
+++ b/pylops/signalprocessing/interp.py
@@ -47,7 +47,10 @@ def _linearinterp(
 
     # ensure that samples are not beyond the last sample, in that case set to
     # penultimate sample and raise a warning
-    _clip_iava_above_last_sample_index(iava=iava, sample_size=sample_size)
+    iava = _clip_iava_above_last_sample_index(  # type: ignore
+        iava=iava,  # type: ignore
+        sample_size=sample_size,
+    )
 
     # find indices and weights
     iva_l = ncp.floor(iava).astype(int)

--- a/pylops/signalprocessing/interpspline.py
+++ b/pylops/signalprocessing/interpspline.py
@@ -251,7 +251,11 @@ class _BandedLUDecomposition:
         banded_representation[2, ::] = matrix.main_diagonal
         banded_representation[3, 0:-1] = matrix.sub_diagonal
 
-        (lu_banded, pivot_indices, info,) = lapack_factorizer(
+        (
+            lu_banded,
+            pivot_indices,
+            info,
+        ) = lapack_factorizer(
             ab=banded_representation,
             kl=1,
             ku=1,
@@ -388,7 +392,6 @@ class _TridiagonalLUDecomposition:
             )
 
         raise np.linalg.LinAlgError(
-            f"Could not LU-factorize tridiagonal matrix! Got {info=}."
             f"Could not LU-factorize tridiagonal matrix! Got {info=}."
         )
 

--- a/pylops/signalprocessing/interpspline.py
+++ b/pylops/signalprocessing/interpspline.py
@@ -953,7 +953,7 @@ class InterpCubicSpline(LinearOperator):
             x_mod[0 : self.num_cols]
             + self._rmatmat_difference_method(
                 self._lhs_B_matrix_transposed_lu.solve(
-                    rhs=x_mod[self.num_cols : x_mod.size],
+                    rhs=x_mod[self.num_cols :],
                     lapack_solver=self._tridiag_lu_solve,
                 )
             )

--- a/pylops/signalprocessing/interpspline.py
+++ b/pylops/signalprocessing/interpspline.py
@@ -821,7 +821,10 @@ class InterpCubicSpline(LinearOperator):
             )
 
         iava = np.asarray(iava, dtype=np.float64)
-        _clip_iava_above_last_sample_index(iava=iava, sample_size=num_cols)
+        iava = _clip_iava_above_last_sample_index(  # type: ignore
+            iava=iava,
+            sample_size=num_cols,
+        )
 
         if isinstance(bc_type, str) and bc_type.lower() in {"natural"}:
             self.bc_type = bc_type.lower()

--- a/pylops/signalprocessing/interpspline.py
+++ b/pylops/signalprocessing/interpspline.py
@@ -210,7 +210,7 @@ class _BandedLUDecomposition:
     Represents the LU decomposition of a general banded matrix as performed by the
     LAPACK routines ``?gbtrf``.
     This class was implemented for spline interpolations between only 2 data points
-    because the class :class:`_BandedLUDecomposition` uses the LAPACK routines
+    because the class :class:`_TridiagonalLUDecomposition` uses the LAPACK routines
     ``?gttrf`` that cannot handle 2 x 2 tridiagonal matrices.
 
     """

--- a/pytests/test_interpolation_spline.py
+++ b/pytests/test_interpolation_spline.py
@@ -1,3 +1,4 @@
+from math import prod
 from typing import Final, Tuple
 
 import numpy as np
@@ -5,6 +6,7 @@ import pytest
 from scipy.interpolate import CubicSpline
 
 from pylops.signalprocessing import InterpCubicSpline
+from pylops.utils import dottest
 
 TEST_ARRAY_SHAPE: Final[Tuple] = (
     20,
@@ -14,6 +16,75 @@ TEST_ARRAY_SHAPE: Final[Tuple] = (
 )
 TEST_X_RANGE: Final[Tuple[float, float]] = (-5.0, 5.0)
 MIN_NUM_TEST_SAMPLES: Final[int] = 1
+
+
+@pytest.mark.parametrize(
+    "with_complex",
+    [
+        pytest.param(False, id="real"),
+        pytest.param(True, id="complex"),
+    ],
+)
+@pytest.mark.parametrize(
+    "axis",
+    [
+        0,
+        1,
+        2,
+        3,
+        -1,
+        -2,
+        -3,
+    ],
+)
+@pytest.mark.parametrize(
+    "subsample_fraction",
+    [
+        pytest.param(0.5, id="decimation"),
+        pytest.param(5.0, id="upsampling"),
+    ],
+)
+def test_natural_cubic_spline_dottest(
+    subsample_fraction: float,
+    axis: int,
+    with_complex: bool,
+) -> None:
+    """
+    Tests ``pylops.signalprocessing.InterpCubicSpline`` with the ``dottest``.
+
+    """
+
+    # Setup
+
+    num_samples = TEST_ARRAY_SHAPE[axis]
+    x_eval_fractions = np.random.rand(
+        max(
+            round(num_samples * subsample_fraction),
+            MIN_NUM_TEST_SAMPLES,
+        )
+    )
+    x_eval_for_pylops = (num_samples - 1) * x_eval_fractions
+
+    shape_list = list(TEST_ARRAY_SHAPE)
+    shape_list[axis] = x_eval_fractions.size  # type: ignore
+    num_rows = prod(shape_list, start=1)
+    num_columns = prod(TEST_ARRAY_SHAPE, start=1)
+
+    # Test
+
+    splinop = InterpCubicSpline(
+        dims=TEST_ARRAY_SHAPE,
+        iava=x_eval_for_pylops,
+        axis=axis,
+        dtype="complex128" if with_complex else "float64",
+    )
+
+    assert dottest(
+        Op=splinop,
+        nr=num_rows,
+        nc=num_columns,
+        complexflag=0 if not with_complex else 3,
+    )
 
 
 @pytest.mark.parametrize(

--- a/pytests/test_interpolation_spline.py
+++ b/pytests/test_interpolation_spline.py
@@ -18,6 +18,21 @@ TEST_X_RANGE: Final[Tuple[float, float]] = (-5.0, 5.0)
 MIN_NUM_TEST_SAMPLES: Final[int] = 1
 
 
+def test_cubic_spline_raises_on_not_supported_bc_type() -> None:
+    """
+    Tests whether ``pylops.signalprocessing.InterpCubicSpline`` raises a
+    ``NotImplementedError`` for boundary conditions that are not supported.
+
+    """
+
+    with pytest.raises(NotImplementedError):
+        InterpCubicSpline(
+            dims=(5, 2),
+            iava=np.array([0.5, 2.3]),
+            bc_type="erroneous",  # type: ignore
+        )
+
+
 @pytest.mark.parametrize(
     "with_complex",
     [


### PR DESCRIPTION
This pull request provides minor improvements for
- `signalprocessing.Interp`
    1. fixed potential silent mutation of `iava` input
    2. fixed typo in docstring
    3. fixed missing `cubic_spline` in `Raises`
- `signalprocessing.InterpCubicSpline`
    1. fixed typo in auxiliary class docstring
    2. fixed bad index in `_rmatvec` that was silently caught by `numpy` slicing operations preventing out of bound slicing

Besides, a dedicated `dottest` test was added for `signalprocessing.InterpCubicSpline` (adds to the only indirect `dottest` tests for `signalprocessing.Interp(..., kind="cubic_spline")`.
Also, a test for boundary conditions (`bc_type`) that are not supported is added to make sure that `signalprocessing.InterpCubicSpline` raises a `NotImplementedError`.