### PR TITLE
Fix: dtype consistency in operators

### DIFF
--- a/pylops/avo/avo.py
+++ b/pylops/avo/avo.py
@@ -677,7 +677,9 @@ class AVOLinearModelling(LinearOperator):
             dimsd += self.spatdims
         super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
 
-        self.G = self.ncp.concatenate([gs.T[:, self.ncp.newaxis] for gs in Gs], axis=1)
+        self.G = self.ncp.concatenate(
+            [gs.astype(dtype).T[:, self.ncp.newaxis] for gs in Gs], axis=1
+        )
         # add dimensions to G to account for horizonal axes
         for _ in range(len(self.spatdims)):
             self.G = self.G[..., np.newaxis]

--- a/pylops/basicoperators/laplacian.py
+++ b/pylops/basicoperators/laplacian.py
@@ -1,5 +1,6 @@
 __all__ = ["Laplacian"]
 
+import numpy as np
 
 from pylops import LinearOperator
 from pylops.basicoperators import SecondDerivative
@@ -124,13 +125,17 @@ class Laplacian(LinearOperator):
         kind: Tderivkind,
         dtype: DTypeLike,
     ):
+        weights = np.array(weights, dtype=dtype)
+        sampling = np.array(sampling, dtype=dtype)
         l2op = SecondDerivative(
             dims, axis=axes[0], sampling=sampling[0], edge=edge, kind=kind, dtype=dtype
         )
         dims = l2op.dims
         l2op *= weights[0]
         for ax, samp, weight in zip(axes[1:], sampling[1:], weights[1:], strict=True):
-            l2op += weight * SecondDerivative(
+            tmpop = SecondDerivative(
                 dims, axis=ax, sampling=samp, edge=edge, kind=kind, dtype=dtype
             )
+            tmpop *= weight
+            l2op += tmpop
         return l2op

--- a/pylops/basicoperators/smoothing1d.py
+++ b/pylops/basicoperators/smoothing1d.py
@@ -87,7 +87,7 @@ class Smoothing1D(Convolve1D):
     ):
         if nsmooth % 2 == 0:
             nsmooth += 1
-        h = np.ones(nsmooth) / float(nsmooth)
+        h = np.ones(nsmooth, dtype=dtype) / float(nsmooth)
         offset = (nsmooth - 1) // 2
         super().__init__(
             dims=dims, h=h, axis=axis, offset=offset, dtype=dtype, name=name

--- a/pylops/basicoperators/smoothing2d.py
+++ b/pylops/basicoperators/smoothing2d.py
@@ -80,7 +80,9 @@ class Smoothing2D(Convolve2D):
             nsmooth[0] += 1
         if nsmooth[1] % 2 == 0:
             nsmooth[1] += 1
-        h = np.ones((nsmooth[0], nsmooth[1])) / float(nsmooth[0] * nsmooth[1])
+        h = np.ones((nsmooth[0], nsmooth[1]), dtype=dtype) / float(
+            nsmooth[0] * nsmooth[1]
+        )
         offset = [(nsmooth[0] - 1) // 2, (nsmooth[1] - 1) // 2]
         super().__init__(
             dims=dims, h=h, offset=offset, axes=axes, dtype=dtype, name=name

--- a/pylops/basicoperators/smoothingnd.py
+++ b/pylops/basicoperators/smoothingnd.py
@@ -78,7 +78,7 @@ class SmoothingND(ConvolveND):
         for i in range(len(nsmooth)):
             if nsmooth[i] % 2 == 0:
                 nsmooth[i] += 1
-        h = np.ones(nsmooth) / float(np.prod(nsmooth))
+        h = np.ones(nsmooth, dtype=dtype) / float(np.prod(nsmooth))
         offset = [(nsm - 1) // 2 for nsm in nsmooth]
         super().__init__(
             dims=dims, h=h, offset=offset, axes=axes, dtype=dtype, name=name

--- a/pylops/signalprocessing/bilinear.py
+++ b/pylops/signalprocessing/bilinear.py
@@ -132,6 +132,7 @@ class Bilinear(LinearOperator):
         )
 
         ncp = get_array_module(iava)
+
         # check non-unique pairs (works only with numpy arrays)
         _ensure_iava_is_unique(
             iava=to_numpy(iava),
@@ -141,10 +142,10 @@ class Bilinear(LinearOperator):
         # find indices and weights
         self.iava_t = ncp.floor(iava[0]).astype(int)
         self.iava_b = self.iava_t + 1
-        self.weights_tb = iava[0] - self.iava_t
+        self.weights_tb = (iava[0] - self.iava_t).astype(self.dtype)
         self.iava_l = ncp.floor(iava[1]).astype(int)
         self.iava_r = self.iava_l + 1
-        self.weights_lr = iava[1] - self.iava_l
+        self.weights_lr = (iava[1] - self.iava_l).astype(self.dtype)
 
         # expand dims to weights for nd-arrays
         if ndims > 2:

--- a/pylops/signalprocessing/interp.py
+++ b/pylops/signalprocessing/interp.py
@@ -55,7 +55,7 @@ def _linearinterp(
     # find indices and weights
     iva_l = ncp.floor(iava).astype(int)
     iva_r = iva_l + 1
-    weights = iava - iva_l
+    weights = (iava - iva_l).astype(dtype)
 
     # create operators
     Op = Diagonal(1 - weights, dims=dimsd, axis=axis, dtype=dtype) * Restriction(
@@ -81,7 +81,7 @@ def _sincinterp(
     nreg = dims[axis]
     ireg = ncp.arange(nreg)
     sinc = ncp.tile(iava[:, np.newaxis], (1, nreg)) - ncp.tile(ireg, (len(iava), 1))
-    sinc = ncp.sinc(sinc)
+    sinc = ncp.sinc(sinc).astype(dtype)
 
     # identify additional dimensions and create MatrixMult operator
     otherdims = np.array(dims)

--- a/pylops/signalprocessing/nonstatconvolve2d.py
+++ b/pylops/signalprocessing/nonstatconvolve2d.py
@@ -484,7 +484,7 @@ class NonStationaryFilters2D(LinearOperator):
         # the same loop (see https://numba.pydata.org/numba-doc/latest/user/parallel.html?highlight=njit).
         # Until atomic operations are provided we create a temporary filter array and store intermediate
         # results from each ix and reduce them at the end.
-        hstmp = np.zeros((xdims[0], *hs.shape))
+        hstmp = np.zeros((xdims[0], *hs.shape), dtype=x.dtype)
         for ix in prange(xdims[0]):
             for iz in range(xdims[1]):
                 # find extremes of model where to apply h (in case h is going out of model)

--- a/pylops/signalprocessing/seislet.py
+++ b/pylops/signalprocessing/seislet.py
@@ -451,7 +451,7 @@ class Seislet(LinearOperator):
         super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
 
         pad = [(0, ndimpow2 - self.dims[0])] + [(0, 0)] * (len(self.dims) - 1)
-        self.pad = Pad(self.dims, pad)
+        self.pad = Pad(self.dims, pad, dtype=self.dtype)
         self.nx, self.nt = self.dimsd
 
         # define levels
@@ -473,7 +473,9 @@ class Seislet(LinearOperator):
     def _matvec(self, x: NDArray) -> NDArray:
         x = self.pad.matvec(x)
         x = np.reshape(x, self.dimsd)
-        y = np.zeros((np.sum(self.levels_size) + self.levels_size[-1], self.nt))
+        y = np.zeros(
+            (np.sum(self.levels_size) + self.levels_size[-1], self.nt), dtype=self.dtype
+        )
         for ilevel in range(self.level):
             odd = x[1::2]
             even = x[::2]
@@ -519,7 +521,7 @@ class Seislet(LinearOperator):
                     backward=False,
                     adj=True,
                 )
-                y = np.zeros((2 * even.shape[0], self.nt))
+                y = np.zeros((2 * even.shape[0], self.nt), dtype=self.dtype)
                 y[1::2] = odd
                 y[::2] = even
             y = self.pad.rmatvec(y.ravel())
@@ -542,7 +544,7 @@ class Seislet(LinearOperator):
             odd = res + self.predict(
                 even, self.dt, self.dx, self.slopes, repeat=ilevel - 1, backward=False
             )
-            y = np.zeros((2 * even.shape[0], self.nt))
+            y = np.zeros((2 * even.shape[0], self.nt), dtype=self.dtype)
             y[1::2] = odd
             y[::2] = even
         y = self.pad.rmatvec(y.ravel())

--- a/pylops/signalprocessing/sliding1d.py
+++ b/pylops/signalprocessing/sliding1d.py
@@ -199,7 +199,7 @@ class Sliding1D(LinearOperator):
         self.tapertype = tapertype
         self.savetaper = savetaper
         if self.tapertype is not None:
-            tap = taper(nwin, nover, tapertype=self.tapertype)
+            tap = taper(nwin, nover, tapertype=self.tapertype).astype(Op.dtype)
             tapin = tap.copy()
             tapin[:nover] = 1
             tapend = tap.copy()
@@ -247,7 +247,7 @@ class Sliding1D(LinearOperator):
             self.taps = to_cupy_conditional(x, self.taps)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
         if self.simOp:
-            x = self.Op @ x
+            x = self.Op.matvec(x.ravel()).reshape(self.Op.dimsd)
             if self.tapertype is not None:
                 x = self.taps * x
         for iwin0 in range(self.dims[0]):
@@ -270,7 +270,7 @@ class Sliding1D(LinearOperator):
         if self.tapertype is not None:
             ywins = ywins * self.taps
         if self.simOp:
-            y = self.Op.H @ ywins
+            y = self.Op.rmatvec(ywins.ravel())
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):
@@ -284,7 +284,7 @@ class Sliding1D(LinearOperator):
             self.taps = to_cupy_conditional(x, self.taps)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
         if self.simOp:
-            x = self.Op @ x
+            x = self.Op.matvec(x.ravel()).reshape(self.Op.dimsd)
         for iwin0 in range(self.dims[0]):
             if self.simOp:
                 xxwin = x[iwin0]
@@ -311,7 +311,7 @@ class Sliding1D(LinearOperator):
             if self.tapertype is not None:
                 for iwin0 in range(self.dims[0]):
                     ywins = self._apply_taper(ywins, iwin0)
-            y = self.Op.H @ ywins
+            y = self.Op.rmatvec(ywins.ravel())
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):

--- a/pylops/signalprocessing/sliding1d.py
+++ b/pylops/signalprocessing/sliding1d.py
@@ -270,7 +270,7 @@ class Sliding1D(LinearOperator):
         if self.tapertype is not None:
             ywins = ywins * self.taps
         if self.simOp:
-            y = self.Op.rmatvec(ywins.ravel())
+            y = self.Op.rmatvec(ywins.ravel()).reshape(self.dims)
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):

--- a/pylops/signalprocessing/sliding2d.py
+++ b/pylops/signalprocessing/sliding2d.py
@@ -236,7 +236,9 @@ class Sliding2D(LinearOperator):
         self.tapertype = tapertype
         self.savetaper = savetaper
         if self.tapertype is not None:
-            tap = taper2d(dimsd[1], nwin, nover, tapertype=self.tapertype)
+            tap = taper2d(dimsd[1], nwin, nover, tapertype=self.tapertype).astype(
+                Op.dtype
+            )
             tapin = tap.copy()
             tapin[:nover] = 1
             tapend = tap.copy()
@@ -286,7 +288,7 @@ class Sliding2D(LinearOperator):
             self.taps = to_cupy_conditional(x, self.taps)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
         if self.simOp:
-            x = self.Op @ x
+            x = self.Op.matvec(x.ravel()).reshape(self.Op.dimsd)
         for iwin0 in range(self.dims[0]):
             if self.simOp:
                 xx = x[iwin0].reshape(self.nwin, self.dimsd[-1])
@@ -311,7 +313,7 @@ class Sliding2D(LinearOperator):
         if self.tapertype is not None:
             ywins = ywins * self.taps
         if self.simOp:
-            y = self.Op.H @ ywins
+            y = self.Op.rmatvec(ywins.ravel()).reshape(self.dims)
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):
@@ -327,7 +329,7 @@ class Sliding2D(LinearOperator):
             self.taps = to_cupy_conditional(x, self.taps)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
         if self.simOp:
-            x = self.Op @ x
+            x = self.Op.matvec(x.ravel()).reshape(self.Op.dimsd)
         for iwin0 in range(self.dims[0]):
             if self.simOp:
                 xxwin = x[iwin0].reshape(self.nwin, self.dimsd[-1])
@@ -360,7 +362,7 @@ class Sliding2D(LinearOperator):
             if self.tapertype is not None:
                 for iwin0 in range(self.dims[0]):
                     ywins = self._apply_taper(ywins, iwin0)
-            y = self.Op.H @ ywins
+            y = self.Op.rmatvec(ywins.ravel()).reshape(self.dims)
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):

--- a/pylops/signalprocessing/sliding3d.py
+++ b/pylops/signalprocessing/sliding3d.py
@@ -349,7 +349,7 @@ class Sliding3D(LinearOperator):
             self.taps = to_cupy_conditional(x, self.taps)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
         if self.simOp:
-            x = self.Op @ x
+            x = self.Op.matvec(x.ravel()).reshape(self.Op.dimsd)
         for iwin0 in range(self.dims[0]):
             for iwin1 in range(self.dims[1]):
                 if self.simOp:
@@ -382,7 +382,7 @@ class Sliding3D(LinearOperator):
         if self.tapertype is not None:
             ywins = ywins * self.taps
         if self.simOp:
-            y = self.Op.H @ ywins
+            y = self.Op.rmatvec(ywins.ravel()).reshape(self.dims)
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):
@@ -399,7 +399,7 @@ class Sliding3D(LinearOperator):
             self.taps = to_cupy_conditional(x, self.taps)
         y = ncp.zeros(self.dimsd, dtype=self.dtype)
         if self.simOp:
-            x = self.Op @ x
+            x = self.Op.matvec(x.ravel()).reshape(self.Op.dimsd)
         for iwin0 in range(self.dims[0]):
             for iwin1 in range(self.dims[1]):
                 if self.simOp:
@@ -453,7 +453,7 @@ class Sliding3D(LinearOperator):
                 for iwin0 in range(self.dims[0]):
                     for iwin1 in range(self.dims[1]):
                         ywins = self._apply_taper(ywins, iwin0, iwin1)
-            y = self.Op.H @ ywins
+            y = self.Op.rmatvec(ywins.ravel()).reshape(self.dims)
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
             for iwin0 in range(self.dims[0]):

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -301,14 +301,13 @@ class Marchenko:
 
         # Add negative time to reflection data and convert to frequency
         if not np.iscomplexobj(R):
-            dtypec = (np.empty(0, dtype=dtype) + 1j * np.empty(0, dtype=dtype)).dtype
             Rtwosided = np.concatenate(
                 (self.ncp.zeros((self.ns, self.nr, self.nt - 1), dtype=R.dtype), R),
                 axis=-1,
             )
             Rtwosided_fft = np.fft.rfft(Rtwosided, self.nt2, axis=-1) / np.sqrt(
                 self.nt2
-            ).astype(dtypec)
+            ).astype(dtype)
             self.Rtwosided_fft = Rtwosided_fft[..., :nfmax]
         else:
             self.Rtwosided_fft = R

--- a/pylops/waveeqprocessing/marchenko.py
+++ b/pylops/waveeqprocessing/marchenko.py
@@ -301,13 +301,14 @@ class Marchenko:
 
         # Add negative time to reflection data and convert to frequency
         if not np.iscomplexobj(R):
+            dtypec = (np.empty(0, dtype=dtype) + 1j * np.empty(0, dtype=dtype)).dtype
             Rtwosided = np.concatenate(
                 (self.ncp.zeros((self.ns, self.nr, self.nt - 1), dtype=R.dtype), R),
                 axis=-1,
             )
             Rtwosided_fft = np.fft.rfft(Rtwosided, self.nt2, axis=-1) / np.sqrt(
                 self.nt2
-            )
+            ).astype(dtypec)
             self.Rtwosided_fft = Rtwosided_fft[..., :nfmax]
         else:
             self.Rtwosided_fft = R
@@ -427,13 +428,12 @@ class Marchenko:
             shift=-1,
             dtype=self.dtype,
         )
-        Wop = Diagonal(w.T.ravel())
-        Iop = Identity(self.nr * self.nt2)
+        Wop = Diagonal(w.T.ravel(), dtype=self.dtype)
+        Iop = Identity(self.nr * self.nt2, dtype=self.dtype)
         Mop = Block(
-            [[Iop, -1 * Wop * Rop], [-1 * Wop * Rollop * R1op, Iop]]
-        ) * BlockDiag([Wop, Wop])
-        Gop = Block([[Iop, -1 * Rop], [-1 * Rollop * R1op, Iop]])
-
+            [[Iop, -1 * Wop * Rop], [-1 * Wop * Rollop * R1op, Iop]], dtype=self.dtype
+        ) * BlockDiag([Wop, Wop], dtype=self.dtype)
+        Gop = Block([[Iop, -1 * Rop], [-1 * Rollop * R1op, Iop]], dtype=self.dtype)
         if dottest:
             Dottest(
                 Gop,
@@ -443,7 +443,6 @@ class Marchenko:
                 verb=True,
                 backend=get_module_name(self.ncp),
             )
-        if dottest:
             Dottest(
                 Mop,
                 2 * self.ns * self.nt2,
@@ -457,10 +456,14 @@ class Marchenko:
         if G0 is None:
             if self.wav is not None and nfft is not None:
                 G0 = (
-                    directwave(
-                        self.wav, trav, self.nt, self.dt, nfft=nfft, derivative=True
+                    (
+                        directwave(
+                            self.wav, trav, self.nt, self.dt, nfft=nfft, derivative=True
+                        )
                     )
-                ).T
+                    .astype(self.dtype)
+                    .T
+                )
                 G0 = to_cupy_conditional(self.Rtwosided_fft, G0)
             else:
                 msg = "wav and/or nfft are not provided. Provide either G0 or wav and nfft..."
@@ -634,12 +637,12 @@ class Marchenko:
             shift=-1,
             dtype=self.dtype,
         )
-        Wop = Diagonal(w.transpose(2, 0, 1).ravel())
+        Wop = Diagonal(w.transpose(2, 0, 1).ravel(), dtype=self.dtype)
         Iop = Identity(self.nr * nvs * self.nt2)
         Mop = Block(
-            [[Iop, -1 * Wop * Rop], [-1 * Wop * Rollop * R1op, Iop]]
-        ) * BlockDiag([Wop, Wop])
-        Gop = Block([[Iop, -1 * Rop], [-1 * Rollop * R1op, Iop]])
+            [[Iop, -1 * Wop * Rop], [-1 * Wop * Rollop * R1op, Iop]], dtype=self.dtype
+        ) * BlockDiag([Wop, Wop], dtype=self.dtype)
+        Gop = Block([[Iop, -1 * Rop], [-1 * Rollop * R1op, Iop]], dtype=self.dtype)
 
         if dottest:
             Dottest(
@@ -650,7 +653,6 @@ class Marchenko:
                 verb=True,
                 backend=get_module_name(self.ncp),
             )
-        if dottest:
             Dottest(
                 Mop,
                 2 * self.ns * nvs * self.nt2,
@@ -666,15 +668,19 @@ class Marchenko:
                 G0 = np.zeros((self.nr, nvs, self.nt), dtype=self.dtype)
                 for ivs in range(nvs):
                     G0[:, ivs] = (
-                        directwave(
-                            self.wav,
-                            trav[:, ivs],
-                            self.nt,
-                            self.dt,
-                            nfft=nfft,
-                            derivative=True,
+                        (
+                            directwave(
+                                self.wav,
+                                trav[:, ivs],
+                                self.nt,
+                                self.dt,
+                                nfft=nfft,
+                                derivative=True,
+                            )
                         )
-                    ).T
+                        .astype(self.dtype)
+                        .T
+                    )
                 G0 = to_cupy_conditional(self.Rtwosided_fft, G0)
             else:
                 msg = "wav and/or nfft are not provided. Provide either G0 or wav and nfft..."

--- a/pytests/test_avo.py
+++ b/pytests/test_avo.py
@@ -162,6 +162,7 @@ def test_AVOLinearModelling(par, dtype):
     )
 
     d = AVOop * np.asarray(m).astype(dtype)
+    madj = AVOop.H * d
     minv = lsqr(
         AVOop,
         d,
@@ -174,4 +175,5 @@ def test_AVOLinearModelling(par, dtype):
     )[0]
 
     assert d.dtype == dtype
+    assert madj.dtype == dtype
     assert_array_almost_equal(m, minv, decimal=3)

--- a/pytests/test_avo.py
+++ b/pytests/test_avo.py
@@ -141,24 +141,37 @@ def test_zoeppritz_and_approx_multipleangles():
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_AVOLinearModelling(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_AVOLinearModelling(par, dtype):
     """Dot-test and inversion for AVOLinearModelling"""
     AVOop = AVOLinearModelling(
-        np.asarray(theta),
-        vsvp=par["vsvp"] if isinstance(par["vsvp"], float) else np.asarray(par["vsvp"]),
+        np.asarray(theta).astype(dtype),
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else np.asarray(par["vsvp"]).astype(dtype),
         nt0=nt0,
         linearization=par["linearization"],
+        dtype=dtype,
     )
-    assert dottest(AVOop, ntheta * nt0, 3 * nt0, backend=backend)
+    assert dottest(
+        AVOop,
+        ntheta * nt0,
+        3 * nt0,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
+    d = AVOop * np.asarray(m).astype(dtype)
     minv = lsqr(
         AVOop,
-        AVOop * np.asarray(m),
-        x0=np.zeros_like(m),
+        d,
+        x0=np.zeros_like(m).astype(dtype),
         damp=1e-20,
         niter=1000,
         atol=1e-8,
         btol=1e-8,
         show=0,
     )[0]
+
+    assert d.dtype == dtype
     assert_array_almost_equal(m, minv, decimal=3)

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -35,6 +35,13 @@ from pylops.utils import dottest
 
 par1 = {"ny": 11, "nx": 11, "imag": 0, "dtype": "float64"}  # square real
 par2 = {"ny": 21, "nx": 11, "imag": 0, "dtype": "float64"}  # overdetermined real
+par1s = {"ny": 11, "nx": 11, "imag": 0, "dtype": "float32"}  # square real (fp32)
+par2s = {
+    "ny": 21,
+    "nx": 11,
+    "imag": 0,
+    "dtype": "float32",
+}  # overdetermined real (fp32)
 par1j = {"ny": 11, "nx": 11, "imag": 1j, "dtype": "complex128"}  # square complex
 par2j = {
     "ny": 21,
@@ -43,20 +50,41 @@ par2j = {
     "dtype": "complex128",
 }  # overdetermined complex
 par3 = {"ny": 11, "nx": 21, "imag": 0, "dtype": "float64"}  # underdetermined real
+par3s = {
+    "ny": 11,
+    "nx": 21,
+    "imag": 0,
+    "dtype": "float64",
+}  # underdetermined real (fp32)
 
 np.random.seed(10)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s)])
 def test_Regression(par):
     """Dot-test, inversion and apply for Regression operator"""
     np.random.seed(10)
-    order = 4
-    t = np.arange(par["ny"], dtype=np.float64)
-    LRop = Regression(t, order=order, dtype=par["dtype"])
-    assert dottest(LRop, par["ny"], order + 1, backend=backend)
 
-    x = np.array([1.0, 2.0, 0.0, 3.0, -1.0], dtype=np.float64)
+    order = 4
+    t = np.arange(par["ny"], dtype=par["dtype"])
+    LRop = Regression(t, order=order, dtype=par["dtype"])
+    assert dottest(
+        LRop,
+        par["ny"],
+        order + 1,
+        rtol=1e-4 if par["dtype"] == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    x = np.array([1.0, 2.0, 0.0, 3.0, -1.0], dtype=par["dtype"])
+
+    # forward vs apply method
+    y = LRop * x
+    y1 = LRop.apply(t, x)
+    assert y.dtype == par["dtype"]
+    assert_array_almost_equal(y, y1, decimal=3)
+
+    # inversion
     xlsqr = lsqr(
         LRop,
         LRop * x,
@@ -70,20 +98,31 @@ def test_Regression(par):
     )[0]
     assert_array_almost_equal(x, xlsqr, decimal=3)
 
-    y = LRop * x
-    y1 = LRop.apply(t, x)
-    assert_array_almost_equal(y, y1, decimal=3)
 
-
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s)])
 def test_LinearRegression(par):
     """Dot-test and inversion for LinearRegression operator"""
     np.random.seed(10)
-    t = np.arange(par["ny"], dtype=np.float32)
-    LRop = LinearRegression(t, dtype=par["dtype"])
-    assert dottest(LRop, par["ny"], 2, backend=backend)
 
-    x = np.array([1.0, 2.0], dtype=np.float64)
+    t = np.arange(par["ny"], dtype=par["dtype"])
+    LRop = LinearRegression(t, dtype=par["dtype"])
+    assert dottest(
+        LRop,
+        par["ny"],
+        2,
+        rtol=1e-4 if par["dtype"] == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    x = np.array([1.0, 2.0], dtype=par["dtype"])
+
+    # forward vs apply method
+    y = LRop * x
+    y1 = LRop.apply(t, x)
+    assert y.dtype == par["dtype"]
+    assert_array_almost_equal(y, y1, decimal=3)
+
+    # inversion
     xlsqr = lsqr(
         LRop,
         LRop * x,
@@ -97,31 +136,30 @@ def test_LinearRegression(par):
     )[0]
     assert_array_almost_equal(x, xlsqr, decimal=3)
 
-    y = LRop * x
-    y1 = LRop.apply(t, x)
-    assert_array_almost_equal(y, y1, decimal=3)
 
-
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_MatrixMult(par):
     """Dot-test and inversion for MatrixMult operator"""
     np.random.seed(10)
-    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32") + par[
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
         "imag"
-    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
     Gop = MatrixMult(G, dtype=par["dtype"])
     assert dottest(
         Gop,
         par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
+    y = Gop * x
     xlsqr = lsqr(
         Gop,
-        Gop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=300,
@@ -129,18 +167,20 @@ def test_MatrixMult(par):
         btol=1e-8,
         show=0,
     )[0]
+    assert y.dtype == par["dtype"]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_MatrixMult_sparse(par):
     """Dot-test and inversion for MatrixMult operator using sparse
     matrix
     """
     np.random.seed(10)
-    G = rand(par["ny"], par["nx"], density=0.75).astype("float32") + par["imag"] * rand(
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+    G = rand(par["ny"], par["nx"], density=0.75).astype(dtype) + par["imag"] * rand(
         par["ny"], par["nx"], density=0.75
-    ).astype("float32")
+    ).astype(dtype)
 
     Gop = MatrixMult(G, dtype=par["dtype"])
     assert dottest(
@@ -148,13 +188,15 @@ def test_MatrixMult_sparse(par):
         par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 1 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
+    y = Gop * x
     xlsqr = lsqr(
         Gop,
-        Gop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=300,
@@ -162,6 +204,7 @@ def test_MatrixMult_sparse(par):
         btol=1e-8,
         show=0,
     )[0]
+    assert y.dtype == par["dtype"]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
 
@@ -179,28 +222,34 @@ def test_MatrixMult_complexcast(par):
     assert Gop.dtype == "complex64"
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_MatrixMult_repeated(par):
     """Dot-test and inversion for test_MatrixMult operator repeated
     along another dimension
     """
     np.random.seed(10)
-    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32") + par[
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+    G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
         "imag"
-    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
     Gop = MatrixMult(G, otherdims=5, dtype=par["dtype"])
     assert dottest(
         Gop,
         par["ny"] * 5,
         par["nx"] * 5,
         complexflag=0 if par["imag"] == 1 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = (np.ones((par["nx"], 5)) + par["imag"] * np.ones((par["nx"], 5))).ravel()
+    x = (
+        np.ones((par["nx"], 5), dtype=dtype)
+        + par["imag"] * np.ones((par["nx"], 5), dtype=dtype)
+    ).ravel()
+    y = Gop * x
     xlsqr = lsqr(
         Gop,
-        Gop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=300,
@@ -208,26 +257,33 @@ def test_MatrixMult_repeated(par):
         btol=1e-8,
         show=0,
     )[0]
+    assert y.dtype == par["dtype"]
     assert_array_almost_equal(x, xlsqr, decimal=4)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Identity_inplace(par):
     """Dot-test, forward and adjoint for Identity operator"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     Iop = Identity(par["ny"], par["nx"], dtype=par["dtype"], inplace=True)
     assert dottest(
         Iop,
         par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
     y = Iop * x
     x1 = Iop.H * y
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(
         x[: min(par["ny"], par["nx"])], y[: min(par["ny"], par["nx"])], decimal=4
     )
@@ -236,23 +292,29 @@ def test_Identity_inplace(par):
     )
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Identity_noinplace(par):
     """Dot-test, forward and adjoint for Identity operator (not in place)"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     Iop = Identity(par["ny"], par["nx"], dtype=par["dtype"], inplace=False)
     assert dottest(
         Iop,
         par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
     y = Iop * x
     x1 = Iop.H * y
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(
         x[: min(par["ny"], par["nx"])], y[: min(par["ny"], par["nx"])], decimal=4
     )
@@ -265,46 +327,77 @@ def test_Identity_noinplace(par):
     assert x[0] != y[0]
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Zero(par):
     """Dot-test, forward and adjoint for Zero operator"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     Zop = Zero(par["ny"], par["nx"], dtype=par["dtype"])
-    assert dottest(Zop, par["ny"], par["nx"], backend=backend)
+    assert dottest(
+        Zop,
+        par["ny"],
+        par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
     y = Zop * x
     x1 = Zop.H * y
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(y, np.zeros(par["ny"]))
     assert_array_almost_equal(x1, np.zeros(par["nx"]))
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Flip1D(par):
     """Dot-test, forward and adjoint for Flip operator on 1d signal"""
     np.random.seed(10)
-    x = np.arange(par["ny"]) + par["imag"] * np.arange(par["ny"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+    x = np.arange(par["ny"], dtype=dtype) + par["imag"] * np.arange(
+        par["ny"], dtype=dtype
+    )
 
     Fop = Flip(par["ny"], dtype=par["dtype"])
-    assert dottest(Fop, par["ny"], par["ny"], backend=backend)
+    assert dottest(
+        Fop,
+        par["ny"],
+        par["ny"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     y = Fop * x
     xadj = Fop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
     assert_array_equal(x, xadj)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Flip2D(par):
     """Dot-test, forward and adjoint for Flip operator on 2d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     x = {}
-    x["0"] = np.outer(np.arange(par["ny"]), np.ones(par["nx"])) + par[
-        "imag"
-    ] * np.outer(np.arange(par["ny"]), np.ones(par["nx"]))
-    x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"])) + par[
-        "imag"
-    ] * np.outer(np.ones(par["ny"]), np.arange(par["nx"]))
+    x["0"] = np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    ) + par["imag"] * np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )
+    x["1"] = np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    ) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )
 
     for axis in [0, 1]:
         Fop = Flip(
@@ -313,48 +406,45 @@ def test_Flip2D(par):
             dtype=par["dtype"],
         )
         assert dottest(
-            Fop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend
+            Fop,
+            par["ny"] * par["nx"],
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
         )
 
         y = Fop * x[str(axis)].ravel()
         xadj = Fop.H * y.ravel()
         xadj = xadj.reshape(par["ny"], par["nx"])
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
         assert_array_equal(x[str(axis)], xadj)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Flip3D(par):
     """Dot-test, forward and adjoint for Flip operator on 3d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     x = {}
-    x["0"] = np.outer(np.arange(par["ny"]), np.ones(par["nx"]))[
-        :, :, np.newaxis
-    ] * np.ones(par["nx"]) + par["imag"] * np.outer(
-        np.arange(par["ny"]), np.ones(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.ones(
-        par["nx"]
-    )
+    x["0"] = np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype)
 
-    x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"]))[
+    x["1"] = np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype)
+    x["2"] = np.outer(np.ones(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype))[
         :, :, np.newaxis
-    ] * np.ones(par["nx"]) + par["imag"] * np.outer(
-        np.ones(par["ny"]), np.arange(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.ones(
-        par["nx"]
-    )
-    x["2"] = np.outer(np.ones(par["ny"]), np.ones(par["nx"]))[
-        :, :, np.newaxis
-    ] * np.arange(par["nx"]) + par["imag"] * np.outer(
-        np.ones(par["ny"]), np.ones(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.arange(
-        par["nx"]
-    )
+    ] * np.arange(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.arange(par["nx"], dtype=dtype)
 
     for axis in [0, 1, 2]:
         Fop = Flip(
@@ -366,40 +456,62 @@ def test_Flip3D(par):
             Fop,
             par["ny"] * par["nx"] * par["nx"],
             par["ny"] * par["nx"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
         y = Fop * x[str(axis)].ravel()
         xadj = Fop.H * y.ravel()
         xadj = xadj.reshape(par["ny"], par["nx"], par["nx"])
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
         assert_array_equal(x[str(axis)], xadj)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Symmetrize1D(par):
     """Dot-test, forward and inverse for Symmetrize operator on 1d signal"""
     np.random.seed(10)
-    x = np.arange(par["ny"]) + par["imag"] * np.arange(par["ny"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+    x = np.arange(par["ny"], dtype=dtype) + par["imag"] * np.arange(
+        par["ny"], dtype=dtype
+    )
 
     Sop = Symmetrize(par["ny"], dtype=par["dtype"])
-    dottest(Sop, par["ny"] * 2 - 1, par["ny"], verb=True, backend=backend)
+    dottest(
+        Sop,
+        par["ny"] * 2 - 1,
+        par["ny"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     y = Sop * x
     xinv = Sop / y
+    assert y.dtype == par["dtype"]
     assert_array_almost_equal(x, xinv, decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Symmetrize2D(par):
     """Dot-test, forward and inverse for Symmetrize operator on 2d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     x = {}
-    x["0"] = np.outer(np.arange(par["ny"]), np.ones(par["nx"])) + par[
-        "imag"
-    ] * np.outer(np.arange(par["ny"]), np.ones(par["nx"]))
-    x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"])) + par[
-        "imag"
-    ] * np.outer(np.ones(par["ny"]), np.arange(par["nx"]))
+    x["0"] = np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    ) + par["imag"] * np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )
+    x["1"] = np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    ) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )
 
     for axis in [0, 1]:
         Sop = Symmetrize(
@@ -408,9 +520,16 @@ def test_Symmetrize2D(par):
             dtype=par["dtype"],
         )
         y = Sop * x[str(axis)].ravel()
-        assert dottest(Sop, y.size, par["ny"] * par["nx"], backend=backend)
+        assert dottest(
+            Sop,
+            y.size,
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
         xinv = Sop / y
+        assert y.dtype == par["dtype"]
         assert_array_almost_equal(x[str(axis)].ravel(), xinv, decimal=3)
 
 
@@ -418,35 +537,24 @@ def test_Symmetrize2D(par):
 def test_Symmetrize3D(par):
     """Dot-test, forward and adjoint for Symmetrize operator on 3d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     x = {}
-    x["0"] = np.outer(np.arange(par["ny"]), np.ones(par["nx"]))[
-        :, :, np.newaxis
-    ] * np.ones(par["nx"]) + par["imag"] * np.outer(
-        np.arange(par["ny"]), np.ones(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.ones(
-        par["nx"]
-    )
+    x["0"] = np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype)
 
-    x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"]))[
+    x["1"] = np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype)
+    x["2"] = np.outer(np.ones(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype))[
         :, :, np.newaxis
-    ] * np.ones(par["nx"]) + par["imag"] * np.outer(
-        np.ones(par["ny"]), np.arange(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.ones(
-        par["nx"]
-    )
-    x["2"] = np.outer(np.ones(par["ny"]), np.ones(par["nx"]))[
-        :, :, np.newaxis
-    ] * np.arange(par["nx"]) + par["imag"] * np.outer(
-        np.ones(par["ny"]), np.ones(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.arange(
-        par["nx"]
-    )
+    ] * np.arange(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.arange(par["nx"], dtype=dtype)
 
     for axis in [0, 1, 2]:
         Sop = Symmetrize(
@@ -455,9 +563,16 @@ def test_Symmetrize3D(par):
             dtype=par["dtype"],
         )
         y = Sop * x[str(axis)].ravel()
-        assert dottest(Sop, y.size, par["ny"] * par["nx"] * par["nx"], backend=backend)
+        assert dottest(
+            Sop,
+            y.size,
+            par["ny"] * par["nx"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
         xinv = Sop / y
+        assert y.dtype == par["dtype"]
         assert_array_almost_equal(x[str(axis)].ravel(), xinv, decimal=3)
 
 
@@ -512,30 +627,18 @@ def test_Roll3D(par):
         :, :, np.newaxis
     ] * np.ones(par["nx"]) + par["imag"] * np.outer(
         np.arange(par["ny"]), np.ones(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.ones(
-        par["nx"]
-    )
+    )[:, :, np.newaxis] * np.ones(par["nx"])
 
     x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"]))[
         :, :, np.newaxis
     ] * np.ones(par["nx"]) + par["imag"] * np.outer(
         np.ones(par["ny"]), np.arange(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.ones(
-        par["nx"]
-    )
+    )[:, :, np.newaxis] * np.ones(par["nx"])
     x["2"] = np.outer(np.ones(par["ny"]), np.ones(par["nx"]))[
         :, :, np.newaxis
     ] * np.arange(par["nx"]) + par["imag"] * np.outer(
         np.ones(par["ny"]), np.ones(par["nx"])
-    )[
-        :, :, np.newaxis
-    ] * np.arange(
-        par["nx"]
-    )
+    )[:, :, np.newaxis] * np.arange(par["nx"])
 
     for axis in [0, 1, 2]:
         Rop = Roll(

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -702,7 +702,13 @@ def test_Sum2D(par):
         dim_d = [par["ny"], par["nx"]]
         dim_d.pop(axis)
         Sop = Sum(dims=(par["ny"], par["nx"]), axis=axis, dtype=par["dtype"])
-        assert dottest(Sop, npp.prod(dim_d), par["ny"] * par["nx"], backend=backend)
+        assert dottest(
+            Sop,
+            npp.prod(dim_d),
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
         x = np.arange(par["nx"] * par["ny"], dtype=dtype) + par["imag"] * np.arange(
             par["nx"] * par["ny"], dtype=dtype
@@ -763,7 +769,11 @@ def test_Sum3D(par):
         dim_d.pop(axis)
         Sop = Sum(dims=(par["ny"], par["nx"], par["nx"]), axis=axis, dtype=par["dtype"])
         assert dottest(
-            Sop, npp.prod(dim_d), par["ny"] * par["nx"] * par["nx"], backend=backend
+            Sop,
+            npp.prod(dim_d),
+            par["ny"] * par["nx"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
         )
         x = np.arange(par["ny"] * par["nx"] * par["nx"], dtype=dtype) + par[
             "imag"
@@ -851,6 +861,7 @@ def test_Conj(par):
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
         complexflag=complexflag,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -533,7 +533,9 @@ def test_Symmetrize2D(par):
         assert_array_almost_equal(x[str(axis)].ravel(), xinv, decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Symmetrize3D(par):
     """Dot-test, forward and adjoint for Symmetrize operator on 3d signal"""
     np.random.seed(10)
@@ -576,31 +578,51 @@ def test_Symmetrize3D(par):
         assert_array_almost_equal(x[str(axis)].ravel(), xinv, decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Roll1D(par):
     """Dot-test, forward and adjoint for Roll operator on 1d signal"""
     np.random.seed(10)
-    x = np.arange(par["ny"]) + par["imag"] * np.arange(par["ny"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+    x = np.arange(par["ny"], dtype=dtype) + par["imag"] * np.arange(
+        par["ny"], dtype=dtype
+    )
 
     Rop = Roll(par["ny"], shift=2, dtype=par["dtype"])
-    assert dottest(Rop, par["ny"], par["ny"], backend=backend)
+    assert dottest(
+        Rop,
+        par["ny"],
+        par["ny"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     y = Rop * x
     xadj = Rop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
     assert_array_almost_equal(x, xadj, decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Roll2D(par):
     """Dot-test, forward and inverse for Roll operator on 2d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     x = {}
-    x["0"] = np.outer(np.arange(par["ny"]), np.ones(par["nx"])) + par[
-        "imag"
-    ] * np.outer(np.arange(par["ny"]), np.ones(par["nx"]))
-    x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"])) + par[
-        "imag"
-    ] * np.outer(np.ones(par["ny"]), np.arange(par["nx"]))
+    x["0"] = np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    ) + par["imag"] * np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )
+    x["1"] = np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    ) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )
 
     for axis in [0, 1]:
         Rop = Roll(
@@ -611,34 +633,43 @@ def test_Roll2D(par):
         )
         y = Rop * x[str(axis)].ravel()
         assert dottest(
-            Rop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend
+            Rop,
+            par["ny"] * par["nx"],
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
         )
 
         xadj = Rop.H * y
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
         assert_array_almost_equal(x[str(axis)].ravel(), xadj, decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Roll3D(par):
     """Dot-test, forward and adjoint for Roll operator on 3d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     x = {}
-    x["0"] = np.outer(np.arange(par["ny"]), np.ones(par["nx"]))[
-        :, :, np.newaxis
-    ] * np.ones(par["nx"]) + par["imag"] * np.outer(
-        np.arange(par["ny"]), np.ones(par["nx"])
-    )[:, :, np.newaxis] * np.ones(par["nx"])
+    x["0"] = np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype)
 
-    x["1"] = np.outer(np.ones(par["ny"]), np.arange(par["nx"]))[
+    x["1"] = np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.arange(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.ones(par["nx"], dtype=dtype)
+    x["2"] = np.outer(np.ones(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype))[
         :, :, np.newaxis
-    ] * np.ones(par["nx"]) + par["imag"] * np.outer(
-        np.ones(par["ny"]), np.arange(par["nx"])
-    )[:, :, np.newaxis] * np.ones(par["nx"])
-    x["2"] = np.outer(np.ones(par["ny"]), np.ones(par["nx"]))[
-        :, :, np.newaxis
-    ] * np.arange(par["nx"]) + par["imag"] * np.outer(
-        np.ones(par["ny"]), np.ones(par["nx"])
-    )[:, :, np.newaxis] * np.arange(par["nx"])
+    ] * np.arange(par["nx"], dtype=dtype) + par["imag"] * np.outer(
+        np.ones(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
+    )[:, :, np.newaxis] * np.arange(par["nx"], dtype=dtype)
 
     for axis in [0, 1, 2]:
         Rop = Roll(
@@ -652,21 +683,34 @@ def test_Roll3D(par):
             Rop,
             par["ny"] * par["nx"] * par["nx"],
             par["ny"] * par["nx"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
         xinv = Rop.H * y
+        assert y.dtype == par["dtype"]
         assert_array_almost_equal(x[str(axis)].ravel(), xinv, decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Sum2D(par):
     """Dot-test for Sum operator on 2d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     for axis in [0, 1]:
         dim_d = [par["ny"], par["nx"]]
         dim_d.pop(axis)
         Sop = Sum(dims=(par["ny"], par["nx"]), axis=axis, dtype=par["dtype"])
         assert dottest(Sop, npp.prod(dim_d), par["ny"] * par["nx"], backend=backend)
+
+        x = np.arange(par["nx"] * par["ny"], dtype=dtype) + par["imag"] * np.arange(
+            par["nx"] * par["ny"], dtype=dtype
+        )
+        y = Sop * x.ravel()
+        xadj = Sop.H * y
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
@@ -708,9 +752,12 @@ def test_Sum2D_forceflat(par):
     assert Sop.forceflat is None
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Sum3D(par):
     """Dot-test, forward and adjoint for Sum operator on 3d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     for axis in [0, 1, 2]:
         dim_d = [par["ny"], par["nx"], par["nx"]]
         dim_d.pop(axis)
@@ -718,6 +765,13 @@ def test_Sum3D(par):
         assert dottest(
             Sop, npp.prod(dim_d), par["ny"] * par["nx"] * par["nx"], backend=backend
         )
+        x = np.arange(par["ny"] * par["nx"] * par["nx"], dtype=dtype) + par[
+            "imag"
+        ] * np.arange(par["ny"] * par["nx"] * par["nx"], dtype=dtype)
+        y = Sop * x.ravel()
+        xadj = Sop.H * y
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
 
 
 @pytest.mark.parametrize("par", [(par1j), (par2j)])
@@ -781,9 +835,12 @@ def test_Imag(par):
         assert_array_equal(x, 0)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_Conj(par):
     """Dot-test, forward and adjoint for Conj operator"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     Cop = Conj(dims=(par["ny"], par["nx"]), dtype=par["dtype"])
     if np.dtype(par["dtype"]).kind == "c":
         complexflag = 3
@@ -798,26 +855,35 @@ def test_Conj(par):
     )
 
     np.random.seed(10)
-    x = np.random.randn(par["nx"] * par["ny"]) + par["imag"] * np.random.randn(
-        par["nx"] * par["ny"]
-    )
+    x = np.random.randn(par["nx"] * par["ny"]).astype(dtype) + par[
+        "imag"
+    ] * np.random.randn(par["nx"] * par["ny"]).astype(dtype)
     y = Cop * x
     xadj = Cop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
     assert_array_equal(x, xadj)
     assert_array_equal(y, np.conj(x))
     assert_array_equal(xadj, np.conj(y))
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j), (par3)])
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j), (par3), (par3s)]
+)
 def test_ToCupy(par):
     """Forward and adjoint for ToCupy operator (checking that it works also
     when cupy is not available)
     """
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     Top = ToCupy(par["nx"], dtype=par["dtype"])
 
     np.random.seed(10)
-    x = npp.random.randn(par["nx"]) + par["imag"] * npp.random.randn(par["nx"])
+    x = np.random.randn(par["nx"]).astype(dtype) + par["imag"] * np.random.randn(
+        par["nx"]
+    ).astype(dtype)
     y = Top * x
     xadj = Top.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
     assert_array_equal(x, xadj)
     assert_array_equal(y, np.asarray(x))

--- a/pytests/test_basicoperators.py
+++ b/pytests/test_basicoperators.py
@@ -142,6 +142,7 @@ def test_MatrixMult(par):
     """Dot-test and inversion for MatrixMult operator"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
         "imag"
     ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
@@ -178,6 +179,7 @@ def test_MatrixMult_sparse(par):
     """
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     G = rand(par["ny"], par["nx"], density=0.75).astype(dtype) + par["imag"] * rand(
         par["ny"], par["nx"], density=0.75
     ).astype(dtype)
@@ -229,6 +231,7 @@ def test_MatrixMult_repeated(par):
     """
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     G = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
         "imag"
     ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
@@ -268,6 +271,7 @@ def test_Identity_inplace(par):
     """Dot-test, forward and adjoint for Identity operator"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     Iop = Identity(par["ny"], par["nx"], dtype=par["dtype"], inplace=True)
     assert dottest(
         Iop,
@@ -299,6 +303,7 @@ def test_Identity_noinplace(par):
     """Dot-test, forward and adjoint for Identity operator (not in place)"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     Iop = Identity(par["ny"], par["nx"], dtype=par["dtype"], inplace=False)
     assert dottest(
         Iop,
@@ -334,6 +339,7 @@ def test_Zero(par):
     """Dot-test, forward and adjoint for Zero operator"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     Zop = Zero(par["ny"], par["nx"], dtype=par["dtype"])
     assert dottest(
         Zop,
@@ -360,6 +366,7 @@ def test_Flip1D(par):
     """Dot-test, forward and adjoint for Flip operator on 1d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = np.arange(par["ny"], dtype=dtype) + par["imag"] * np.arange(
         par["ny"], dtype=dtype
     )
@@ -387,6 +394,7 @@ def test_Flip2D(par):
     """Dot-test, forward and adjoint for Flip operator on 2d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = {}
     x["0"] = np.outer(
         np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
@@ -428,6 +436,7 @@ def test_Flip3D(par):
     """Dot-test, forward and adjoint for Flip operator on 3d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = {}
     x["0"] = np.outer(
         np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
@@ -475,6 +484,7 @@ def test_Symmetrize1D(par):
     """Dot-test, forward and inverse for Symmetrize operator on 1d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = np.arange(par["ny"], dtype=dtype) + par["imag"] * np.arange(
         par["ny"], dtype=dtype
     )
@@ -501,6 +511,7 @@ def test_Symmetrize2D(par):
     """Dot-test, forward and inverse for Symmetrize operator on 2d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = {}
     x["0"] = np.outer(
         np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
@@ -540,6 +551,7 @@ def test_Symmetrize3D(par):
     """Dot-test, forward and adjoint for Symmetrize operator on 3d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = {}
     x["0"] = np.outer(
         np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
@@ -585,6 +597,7 @@ def test_Roll1D(par):
     """Dot-test, forward and adjoint for Roll operator on 1d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = np.arange(par["ny"], dtype=dtype) + par["imag"] * np.arange(
         par["ny"], dtype=dtype
     )
@@ -612,6 +625,7 @@ def test_Roll2D(par):
     """Dot-test, forward and inverse for Roll operator on 2d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = {}
     x["0"] = np.outer(
         np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
@@ -653,6 +667,7 @@ def test_Roll3D(par):
     """Dot-test, forward and adjoint for Roll operator on 3d signal"""
     np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     x = {}
     x["0"] = np.outer(
         np.arange(par["ny"], dtype=dtype), np.ones(par["nx"], dtype=dtype)
@@ -885,10 +900,11 @@ def test_ToCupy(par):
     """Forward and adjoint for ToCupy operator (checking that it works also
     when cupy is not available)
     """
+    np.random.seed(10)
     dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     Top = ToCupy(par["nx"], dtype=par["dtype"])
 
-    np.random.seed(10)
     x = np.random.randn(par["nx"]).astype(dtype) + par["imag"] * np.random.randn(
         par["nx"]
     ).astype(dtype)

--- a/pytests/test_blending.py
+++ b/pytests/test_blending.py
@@ -14,13 +14,17 @@ import pytest
 from pylops.utils import dottest
 from pylops.waveeqprocessing import BlendingContinuous, BlendingGroup, BlendingHalf
 
-par = {"nt": 101, "ns": 50, "nr": 20, "dtype": "float64"}
+par = {"nt": 101, "ns": 50, "nr": 20}
+
+par1, par2 = par.copy(), par.copy()
+par1["dtype"] = np.float64
+par2["dtype"] = np.float32
 
 d = np.random.normal(0, 1, (par["ns"], par["nr"], par["nt"]))
 dt = 0.004
 
 
-@pytest.mark.parametrize("par", [(par)])
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Blending_continuous(par):
     """Dot-test for continuous Blending operator"""
     npp.random.seed(0)
@@ -44,11 +48,18 @@ def test_Blending_continuous(par):
         Bop,
         Bop.nttot * par["nr"],
         par["nt"] * par["ns"] * par["nr"],
+        rtol=1e-4 if par["dtype"] == np.float32 else 1e-6,
         backend=backend,
     )
 
+    # Forward and adjoint
+    db = Bop * d.astype(par["dtype"])
+    dadj = Bop.H * db
+    assert db.dtype == par["dtype"]
+    assert dadj.dtype == par["dtype"]
 
-@pytest.mark.parametrize("par", [(par)])
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Blending_group(par):
     """Dot-test for group Blending operator"""
     npp.random.seed(0)
@@ -70,11 +81,18 @@ def test_Blending_group(par):
         Bop,
         par["nt"] * n_groups * par["nr"],
         par["nt"] * par["ns"] * par["nr"],
+        rtol=1e-4 if par["dtype"] == np.float32 else 1e-6,
         backend=backend,
     )
 
+    # Forward and adjoint
+    db = Bop * d.astype(par["dtype"])
+    dadj = Bop.H * db
+    assert db.dtype == par["dtype"]
+    assert dadj.dtype == par["dtype"]
 
-@pytest.mark.parametrize("par", [(par)])
+
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_Blending_half(par):
     """Dot-test for half Blending operator"""
     npp.random.seed(0)
@@ -96,5 +114,12 @@ def test_Blending_half(par):
         Bop,
         par["nt"] * n_groups * par["nr"],
         par["nt"] * par["ns"] * par["nr"],
+        rtol=1e-4 if par["dtype"] == np.float32 else 1e-6,
         backend=backend,
     )
+
+    # Forward and adjoint
+    db = Bop * d.astype(par["dtype"])
+    dadj = Bop.H * db
+    assert db.dtype == par["dtype"]
+    assert dadj.dtype == par["dtype"]

--- a/pytests/test_causalintegration.py
+++ b/pytests/test_causalintegration.py
@@ -163,7 +163,6 @@ def test_CausalIntegration1d(par):
                 - t[0] ** 2 / 2.0
                 + par["imag"] * (t**2 / 2.0 - t[0] ** 2 / 2.0)
             )
-
             assert_array_almost_equal(y, yana[rf1:], decimal=4)
 
             # numerical derivative
@@ -171,6 +170,7 @@ def test_CausalIntegration1d(par):
                 par["nt"] - rf1, sampling=par["dt"], dtype=par["dtype"]
             )
             xder = Dop * y.ravel()
+            assert_array_almost_equal(x[:-1], xder[:-1], decimal=4)
 
             # derivative by inversion
             xinv = lsqr(
@@ -183,9 +183,7 @@ def test_CausalIntegration1d(par):
                 conlim=np.inf,
                 show=0,
             )[0]
-
-            assert_array_almost_equal(x[:-1], xder[:-1], decimal=4)
-            assert_array_almost_equal(x, xinv, decimal=4)
+            assert_array_almost_equal(x, xinv, decimal=2 if dtype == np.float32 else 4)
 
 
 @pytest.mark.parametrize(
@@ -251,7 +249,6 @@ def test_CausalIntegration2d(par):
                 * (np.outer(-np.cos(t), np.ones(par["nx"])) + np.cos(t[0]))
             )
             yana = yana.reshape(par["nt"], par["nx"])
-
             assert_array_almost_equal(y, yana, decimal=2)
 
             # numerical derivative
@@ -260,6 +257,7 @@ def test_CausalIntegration2d(par):
             )
             xder = Dop * y.ravel()
             xder = xder.reshape(par["nt"], par["nx"])
+            assert_array_almost_equal(x[:-1], xder[:-1], decimal=2)
 
             # derivative by inversion
             xinv = lsqr(
@@ -273,6 +271,4 @@ def test_CausalIntegration2d(par):
                 show=0,
             )[0]
             xinv = xinv.reshape(par["nt"], par["nx"])
-
-            assert_array_almost_equal(x[:-1], xder[:-1], decimal=2)
             assert_array_almost_equal(x, xinv, decimal=2)

--- a/pytests/test_causalintegration.py
+++ b/pytests/test_causalintegration.py
@@ -47,6 +47,34 @@ par4 = {
     "imag": 0,
     "dtype": "float64",
 }  # odd samples, real, non-unitary step
+par1s = {
+    "nt": 20,
+    "nx": 101,
+    "dt": 1.0,
+    "imag": 0,
+    "dtype": "float32",
+}  # even samples, real (fp32), unitary step
+par2s = {
+    "nt": 21,
+    "nx": 101,
+    "dt": 1.0,
+    "imag": 0,
+    "dtype": "float32",
+}  # odd samples, real (fp32), unitary step
+par3s = {
+    "nt": 20,
+    "nx": 101,
+    "dt": 0.3,
+    "imag": 0,
+    "dtype": "float32",
+}  # even samples, real (fp32), non-unitary step
+par4s = {
+    "nt": 21,
+    "nx": 101,
+    "dt": 0.3,
+    "imag": 0,
+    "dtype": "float32",
+}  # odd samples, real (fp32), non-unitary step
 par1j = {
     "nt": 20,
     "nx": 101,
@@ -80,11 +108,27 @@ np.random.seed(0)
 
 
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par4j)]
+    "par",
+    [
+        (par1),
+        (par2),
+        (par3),
+        (par4),
+        (par1s),
+        (par2s),
+        (par3s),
+        (par4s),
+        (par1j),
+        (par2j),
+        (par3j),
+        (par4j),
+    ],
 )
 def test_CausalIntegration1d(par):
     """Dot-test and inversion for CausalIntegration operator for 1d signals"""
-    t = np.arange(par["nt"]) * par["dt"]
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    t = np.arange(par["nt"], dtype=dtype) * par["dt"]
     x = t + par["imag"] * t
 
     for kind, rf in itertools.product(("full", "half", "trapezoidal"), (False, True)):
@@ -102,6 +146,7 @@ def test_CausalIntegration1d(par):
             par["nt"] - rf1,
             par["nt"],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -110,6 +155,8 @@ def test_CausalIntegration1d(par):
         if kind != "full" and not rf:
             # numerical integration
             y = Cop * x
+            assert y.dtype == par["dtype"]
+
             # analytical integration
             yana = (
                 t**2 / 2.0
@@ -142,14 +189,30 @@ def test_CausalIntegration1d(par):
 
 
 @pytest.mark.parametrize(
-    "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par4j)]
+    "par",
+    [
+        (par1),
+        (par2),
+        (par3),
+        (par4),
+        (par1s),
+        (par2s),
+        (par3s),
+        (par4s),
+        (par1j),
+        (par2j),
+        (par3j),
+        (par4j),
+    ],
 )
 def test_CausalIntegration2d(par):
     """Dot-test and inversion for CausalIntegration operator for 2d signals"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     dt = 0.2 * par["dt"]  # need lower frequency in sinusoids for stability
-    t = np.arange(par["nt"]) * dt
-    x = np.outer(np.sin(t), np.ones(par["nx"])) + par["imag"] * np.outer(
-        np.sin(t), np.ones(par["nx"])
+    t = np.arange(par["nt"], dtype=dtype) * dt
+    x = np.outer(np.sin(t), np.ones(par["nx"], dtype=dtype)) + par["imag"] * np.outer(
+        np.sin(t), np.ones(par["nx"], dtype=dtype)
     )
 
     for kind, rf in itertools.product(("full", "half", "trapezoidal"), (False, True)):
@@ -168,6 +231,7 @@ def test_CausalIntegration2d(par):
             (par["nt"] - rf1) * par["nx"],
             par["nt"] * par["nx"],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -177,6 +241,7 @@ def test_CausalIntegration2d(par):
             # numerical integration
             y = Cop * x.ravel()
             y = y.reshape(par["nt"], par["nx"])
+            assert y.dtype == par["dtype"]
 
             # analytical integration
             yana = (

--- a/pytests/test_chirpradon.py
+++ b/pytests/test_chirpradon.py
@@ -54,7 +54,8 @@ par2f = {
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_ChirpRadon2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_ChirpRadon2D(par, dtype):
     """Dot-test, forward, analytical inverse and sparse inverse
     for ChirpRadon2D operator
     """
@@ -78,26 +79,44 @@ def test_ChirpRadon2D(par):
     ]
 
     # Create axis
-    t, t2, hx, _ = makeaxis(parmod)
+    t, _, hx, _ = makeaxis(parmod)
 
     # Create wavelet
-    wav, _, wav_c = ricker(t[:41], f0=parmod["f0"])
+    wav, _, _ = ricker(t[:41], f0=parmod["f0"])
 
     # Generate model
-    x = np.asarray(linear2d(hx, t, 1500.0, t0, theta, amp, wav)[1])
-    Rop = ChirpRadon2D(np.asarray(t), np.asarray(hx), par["pxmax"], dtype="float64")
-    assert dottest(Rop, par["nhx"] * par["nt"], par["nhx"] * par["nt"], backend=backend)
+    x = np.asarray(linear2d(hx, t, 1500.0, t0, theta, amp, wav)[1].astype(dtype))
+    Rop = ChirpRadon2D(
+        np.asarray(t.astype(dtype)),
+        np.asarray(hx.astype(dtype)),
+        par["pxmax"],
+        dtype=dtype,
+    )
+    assert dottest(
+        Rop,
+        par["nhx"] * par["nt"],
+        par["nhx"] * par["nt"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
+    # Forward, adjoint inverse dtype check
     y = Rop * x.ravel()
+    xadj = Rop.H * y
     xinvana = Rop.inverse(y)
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert xinvana.dtype == dtype
     assert_array_almost_equal(x.ravel(), xinvana, decimal=3)
 
+    # Sparse inverse
     xinv, _, _ = fista(Rop, y, niter=30, eps=1e0)
     assert_array_almost_equal(x.ravel(), xinv, decimal=3)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1f), (par2f)])
-def test_ChirpRadon3D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_ChirpRadon3D(par, dtype):
     """Dot-test, forward, analytical inverse and sparse inverse
     for ChirpRadon3D operator
     """
@@ -130,33 +149,42 @@ def test_ChirpRadon3D(par):
     ]
 
     # Create axis
-    t, t2, hx, hy = makeaxis(parmod)
+    t, _, hx, hy = makeaxis(parmod)
 
     # Create wavelet
-    wav, _, wav_c = ricker(t[:41], f0=parmod["f0"])
+    wav, _, _ = ricker(t[:41], f0=parmod["f0"])
 
     # Generate model
-    x = np.asarray(linear3d(hy, hx, t, 1500.0, t0, theta, phi, amp, wav)[1])
+    x = np.asarray(
+        linear3d(hy, hx, t, 1500.0, t0, theta, phi, amp, wav)[1].astype(dtype)
+    )
 
     Rop = ChirpRadon3D(
-        np.asarray(t),
-        np.asarray(hy),
-        np.asarray(hx),
+        np.asarray(t.astype(dtype)),
+        np.asarray(hy.astype(dtype)),
+        np.asarray(hx.astype(dtype)),
         (par["pymax"], par["pxmax"]),
         engine=par["engine"],
-        dtype="float64",
+        dtype=dtype,
         **dict(flags=("FFTW_ESTIMATE",), threads=2),
     )
     assert dottest(
         Rop,
         par["nhy"] * par["nhx"] * par["nt"],
         par["nhy"] * par["nhx"] * par["nt"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
+    # Forward, adjoint inverse dtype check
     y = Rop * x.ravel()
+    xadj = Rop.H * y
     xinvana = Rop.inverse(y)
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert xinvana.dtype == dtype
     assert_array_almost_equal(x.ravel(), xinvana, decimal=3)
 
+    # Sparse inverse
     xinv, _, _ = fista(Rop, y, niter=30, eps=1e0)
     assert_array_almost_equal(x.ravel(), xinv, decimal=3)

--- a/pytests/test_combine.py
+++ b/pytests/test_combine.py
@@ -28,6 +28,13 @@ from pylops.utils import dottest
 
 par1 = {"ny": 101, "nx": 101, "imag": 0, "dtype": "float64"}  # square real
 par2 = {"ny": 301, "nx": 101, "imag": 0, "dtype": "float64"}  # overdetermined real
+par1s = {"ny": 101, "nx": 101, "imag": 0, "dtype": "float32"}  # square real (fp32)
+par2s = {
+    "ny": 301,
+    "nx": 101,
+    "imag": 0,
+    "dtype": "float32",
+}  # overdetermined real (fp32)
 par1j = {"ny": 101, "nx": 101, "imag": 1j, "dtype": "complex128"}  # square imag
 par2j = {"ny": 301, "nx": 101, "imag": 1j, "dtype": "complex128"}  # overdetermined imag
 
@@ -60,13 +67,19 @@ def test_HStack_incosistent_rows(par):
         )
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_VStack(par):
     """Dot-test and inversion for VStack operator"""
     np.random.seed(0)
-    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
 
     Vop = VStack(
         [MatrixMult(G1, dtype=par["dtype"]), MatrixMult(G2, dtype=par["dtype"])],
@@ -77,8 +90,13 @@ def test_VStack(par):
         2 * par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Vop * x
+    xadj = Vop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     xlsqr = lsqr(
         Vop,
@@ -99,8 +117,13 @@ def test_VStack(par):
         2 * par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Vop * x
+    xadj = Vop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use scipy matrix directly in the definition of the operator
     G1 = sp_random(par["ny"], par["nx"], density=0.4).astype("float32")
@@ -110,8 +133,13 @@ def test_VStack(par):
         2 * par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Vop * x
+    xadj = Vop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use Zero operator directly in the definition of the operator
     G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
@@ -127,17 +155,30 @@ def test_VStack(par):
         2 * par["ny"],
         par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Vop * x
+    xadj = Vop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
 
-@pytest.mark.parametrize("par", [(par2), (par2j)])
+@pytest.mark.parametrize("par", [(par2), (par2s), (par2j)])
 def test_HStack(par):
     """Dot-test and inversion for HStack operator with numpy array as input"""
     np.random.seed(0)
-    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
-    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
-    x = np.ones(2 * par["nx"]) + par["imag"] * np.ones(2 * par["nx"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    x = np.ones(2 * par["nx"], dtype=dtype) + par["imag"] * np.ones(
+        2 * par["nx"], dtype=dtype
+    )
 
     Hop = HStack(
         [MatrixMult(G1, dtype=par["dtype"]), MatrixMult(G2, dtype=par["dtype"])],
@@ -148,8 +189,13 @@ def test_HStack(par):
         par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Hop * x
+    xadj = Hop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     xlsqr = lsqr(
         Hop,
@@ -169,8 +215,13 @@ def test_HStack(par):
         par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = H1op * x
+    xadj = Hop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use scipy matrix directly in the definition of the operator
     G1 = sp_random(par["ny"], par["nx"], density=0.4).astype("float32")
@@ -180,8 +231,13 @@ def test_HStack(par):
         par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = H2op * x
+    xadj = H2op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use Zero operator directly in the definition of the operator
     G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype("float32")
@@ -197,20 +253,36 @@ def test_HStack(par):
         par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = H3op * x
+    xadj = H3op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_Block(par):
     """Dot-test and inversion for Block operator"""
     np.random.seed(0)
-    G11 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    G12 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    G21 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    G22 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
-    x = np.ones(2 * par["nx"]) + par["imag"] * np.ones(2 * par["nx"])
+    G11 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G12 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G21 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G22 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    x = np.ones(2 * par["nx"], dtype=dtype) + par["imag"] * np.ones(
+        2 * par["nx"], dtype=dtype
+    )
 
     Bop = Block(
         [
@@ -224,8 +296,13 @@ def test_Block(par):
         2 * par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Bop * x
+    xadj = Bop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     xlsqr = lsqr(
         Bop,
@@ -252,8 +329,13 @@ def test_Block(par):
         2 * par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = B1op * x
+    xadj = B1op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use scipy matrix directly in the definition of the operator
     G11 = sp_random(par["ny"], par["nx"], density=0.4).astype("float32")
@@ -270,7 +352,12 @@ def test_Block(par):
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
         backend=backend,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
+    y = B2op * x
+    xadj = B2op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use Zero operator directly in the definition of the operator
     G11 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
@@ -289,17 +376,30 @@ def test_Block(par):
         2 * par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = B2op * x
+    xadj = B2op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_BlockDiag(par):
     """Dot-test and inversion for BlockDiag operator"""
     np.random.seed(0)
-    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    x = np.ones(2 * par["nx"]) + par["imag"] * np.ones(2 * par["nx"])
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    x = np.ones(2 * par["nx"], dtype=dtype) + par["imag"] * np.ones(
+        2 * par["nx"], dtype=dtype
+    )
 
     BDop = BlockDiag(
         [MatrixMult(G1, dtype=par["dtype"]), MatrixMult(G2, dtype=par["dtype"])],
@@ -310,8 +410,13 @@ def test_BlockDiag(par):
         2 * par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = BDop * x
+    xadj = BDop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     xlsqr = lsqr(
         BDop,
@@ -332,8 +437,13 @@ def test_BlockDiag(par):
         2 * par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = BD1op * x
+    xadj = BD1op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     # use scipy matrix directly in the definition of the operator
     G2 = sp_random(par["ny"], par["nx"], density=0.4).astype("float32")
@@ -343,8 +453,13 @@ def test_BlockDiag(par):
         2 * par["ny"],
         2 * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = BD2op * x
+    xadj = BD2op.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
 
 @pytest.mark.skipif(

--- a/pytests/test_convolve.py
+++ b/pytests/test_convolve.py
@@ -135,16 +135,33 @@ par2_3d = {
 @pytest.mark.parametrize(
     "par", [(par1_1d), (par2_1d), (par3_1d), (par4_1d), (par5_1d), (par6_1d)]
 )
-def test_Convolve1D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Convolve1D(par, dtype):
     """Dot-test and inversion for Convolve1D operator"""
     np.random.seed(10)
     # 1D
     if par["axis"] == 0:
-        Cop = Convolve1D(par["nx"], h=h1, offset=par["offset"], dtype="float64")
-        assert dottest(Cop, par["nx"], par["nx"], backend=backend)
+        Cop = Convolve1D(
+            par["nx"], h=h1.astype(dtype), offset=par["offset"], dtype=dtype
+        )
+        assert dottest(
+            Cop,
+            par["nx"],
+            par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
-        x = np.zeros(par["nx"])
+        x = np.zeros(par["nx"], dtype=dtype)
         x[par["nx"] // 2] = 1.0
+
+        # Forward and adjoint dtype check
+        y = Cop * x
+        xadj = Cop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
+
+        # Inverse
         xlsqr = lsqr(
             Cop,
             Cop * x,
@@ -161,20 +178,32 @@ def test_Convolve1D(par):
     if par["axis"] < 2:
         Cop = Convolve1D(
             (par["ny"], par["nx"]),
-            h=h1,
+            h=h1.astype(dtype),
             offset=par["offset"],
             axis=par["axis"],
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
-            Cop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend
+            Cop,
+            par["ny"] * par["nx"],
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
         )
 
-        x = np.zeros((par["ny"], par["nx"]))
+        x = np.zeros((par["ny"], par["nx"]), dtype=dtype)
         x[
             int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
             int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
         ] = 1.0
+
+        # Forward and adjoint dtype check
+        y = Cop * x
+        xadj = Cop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
+
+        # Inverse
         xlsqr = lsqr(
             Cop,
             Cop * x.ravel(),
@@ -190,24 +219,33 @@ def test_Convolve1D(par):
     # 1D on 3D
     Cop = Convolve1D(
         (par["nz"], par["ny"], par["nx"]),
-        h=h1,
+        h=h1.astype(dtype),
         offset=par["offset"],
         axis=par["axis"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Cop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.zeros((par["nz"], par["ny"], par["nx"]))
+    x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
     x[
         int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
         int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
     ] = 1.0
+
+    # Forward and adjoint dtype check
+    y = Cop * x
+    xadj = Cop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+
+    # Inverse
     xlsqr = lsqr(
         Cop,
         Cop * x.ravel(),
@@ -224,16 +262,30 @@ def test_Convolve1D(par):
 @pytest.mark.parametrize(
     "par", [(par1_1d), (par2_1d), (par3_1d), (par4_1d), (par5_1d), (par6_1d)]
 )
-def test_Convolve1D_long(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Convolve1D_long(par, dtype):
     """Dot-test and inversion for Convolve1D operator with long filter"""
     np.random.seed(10)
     # 1D
     if par["axis"] == 0:
-        x = np.zeros(par["nx"])
+        x = np.zeros(par["nx"], dtype=dtype)
         x[par["nx"] // 2] = 1.0
-        Xop = Convolve1D(nfilt[0], h=x, offset=nfilt[0] // 2, dtype="float64")
-        assert dottest(Xop, par["nx"], nfilt[0], backend=backend)
+        Xop = Convolve1D(nfilt[0], h=x, offset=nfilt[0] // 2, dtype=dtype)
+        assert dottest(
+            Xop,
+            par["nx"],
+            nfilt[0],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
+        # Forward and adjoint dtype check
+        y = Xop * h1.astype(dtype)
+        h1adj = Xop.H * y
+        assert y.dtype == dtype
+        assert h1adj.dtype == dtype
+
+        # Inverse
         h1lsqr = lsqr(
             Xop, Xop * h1, damp=1e-20, niter=200, atol=1e-8, btol=1e-8, show=0
         )[0]
@@ -243,25 +295,38 @@ def test_Convolve1D_long(par):
 @pytest.mark.parametrize(
     "par", [(par1_2d), (par2_2d), (par3_2d), (par4_2d), (par5_2d), (par6_2d)]
 )
-def test_Convolve2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Convolve2D(par, dtype):
     """Dot-test and inversion for Convolve2D operator"""
     # 2D on 2D
     if par["axis"] == 2:
         Cop = Convolve2D(
             (par["ny"], par["nx"]),
-            h=h2,
+            h=h2.astype(dtype),
             offset=par["offset"],
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
-            Cop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend
+            Cop,
+            par["ny"] * par["nx"],
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
         )
 
-        x = np.zeros((par["ny"], par["nx"]))
+        x = np.zeros((par["ny"], par["nx"]), dtype=dtype)
         x[
             int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
             int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
         ] = 1.0
+
+        # Forward and adjoint dtype check
+        y = Cop * x
+        xadj = Cop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
+
+        # Inverse
         xlsqr = lsqr(
             Cop,
             Cop * x.ravel(),
@@ -279,7 +344,7 @@ def test_Convolve2D(par):
     axes.remove(par["axis"])
     Cop = Convolve2D(
         (par["nz"], par["ny"], par["nx"]),
-        h=h2,
+        h=h2.astype(dtype),
         offset=par["offset"],
         axes=axes,
         dtype="float64",
@@ -288,15 +353,24 @@ def test_Convolve2D(par):
         Cop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.zeros((par["nz"], par["ny"], par["nx"]))
+    x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
     x[
         int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
         int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
     ] = 1.0
+
+    # Forward and adjoint dtype check
+    y = Cop * x
+    xadj = Cop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+
+    # Inverse
     xlsqr = lsqr(
         Cop,
         Cop * x.ravel(),
@@ -312,29 +386,38 @@ def test_Convolve2D(par):
 
 
 @pytest.mark.parametrize("par", [(par1_3d), (par2_3d)])
-def test_Convolve3D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Convolve3D(par, dtype):
     """Dot-test and inversion for ConvolveND operator"""
     # 3D on 3D
     Cop = ConvolveND(
         (par["nz"], par["ny"], par["nx"]),
-        h=h3,
+        h=h3.astype(dtype),
         offset=par["offset"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Cop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.zeros((par["nz"], par["ny"], par["nx"]))
+    x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
     x[
         int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
         int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
     ] = 1.0
+
+    # Forward and adjoint dtype check
     y = Cop * x
+    xadj = Cop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+
+    # Inverse
     xlsqr = lsqr(
         Cop, y, x0=np.zeros_like(x), damp=1e-20, niter=400, atol=1e-8, btol=1e-8, show=0
     )[0]
@@ -344,14 +427,29 @@ def test_Convolve3D(par):
     # 3D on 4D (only modelling)
     Cop = ConvolveND(
         (par["nz"], par["ny"], par["nx"], par["nt"]),
-        h=h3,
+        h=h3.astype(dtype),
         offset=par["offset"],
         axes=[0, 1, 2],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Cop,
         par["nz"] * par["ny"] * par["nx"] * par["nt"],
         par["nz"] * par["ny"] * par["nx"] * par["nt"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    # Forward and adjoint dtype check
+    x = np.zeros((par["nz"], par["ny"], par["nx"], par["nt"]), dtype=dtype)
+    x[
+        int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
+        int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
+        int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
+        int(par["nt"] / 2 - 3) : int(par["nt"] / 2 + 3),
+    ] = 1.0
+
+    y = Cop * x
+    xadj = Cop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype

--- a/pytests/test_dct.py
+++ b/pytests/test_dct.py
@@ -28,11 +28,11 @@ def test_DCT1D(par, dtype):
             par["ny"],
             par["ny"],
             complexflag=0,
-            rtol=1e-3 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
         )
 
         y = Dct.H * (Dct * t)
-        np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
+        np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -55,11 +55,11 @@ def test_DCT2D(par, dtype):
                 par["nx"] * par["ny"],
                 par["nx"] * par["ny"],
                 complexflag=0,
-                rtol=1e-3 if dtype == np.float32 else 1e-6,
+                rtol=5e-4 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
+            np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -80,11 +80,11 @@ def test_DCT3D(par, dtype):
                 par["nx"] * par["nx"] * par["nx"],
                 par["nx"] * par["nx"] * par["nx"],
                 complexflag=0,
-                rtol=1e-3 if dtype == np.float32 else 1e-6,
+                rtol=5e-4 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
+            np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -102,8 +102,8 @@ def test_DCT_workers(par, dtype):
         par["ny"],
         par["ny"],
         complexflag=0,
-        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = Dct.H * (Dct * t)
-    np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
+    np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)

--- a/pytests/test_dct.py
+++ b/pytests/test_dct.py
@@ -6,88 +6,104 @@ import pytest
 from pylops.signalprocessing import DCT
 from pylops.utils import dottest
 
-par1 = {"ny": 11, "nx": 11, "imag": 0, "dtype": "float64"}
-par2 = {"ny": 11, "nx": 21, "imag": 0, "dtype": "float64"}
-par3 = {"ny": 21, "nx": 21, "imag": 0, "dtype": "float64"}
+par1 = {"ny": 11, "nx": 11}
+par2 = {"ny": 11, "nx": 21}
+par3 = {"ny": 20, "nx": 20}
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par3)])
-def test_DCT1D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_DCT1D(par, dtype):
     """Dot test for Discrete Cosine Transform Operator 1D"""
 
-    t = np.arange(par["ny"]) + 1
+    t = np.arange(par["ny"], dtype=dtype) + 1.0
 
-    for type in [1, 2, 3, 4]:
-        Dct = DCT(dims=(par["ny"],), type=type, dtype=par["dtype"])
-        assert dottest(Dct, par["ny"], par["ny"], rtol=1e-6, complexflag=0, verb=True)
+    for dct_type in (1, 2, 3, 4):
+        Dct = DCT(dims=(par["ny"],), type=dct_type, dtype=dtype)
+        assert dottest(
+            Dct,
+            par["ny"],
+            par["ny"],
+            complexflag=0,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+        )
 
         y = Dct.H * (Dct * t)
-        np.testing.assert_allclose(t, y)
+        np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3)])
-def test_DCT2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_DCT2D(par, dtype):
     """Dot test for Discrete Cosine Transform Operator 2D"""
 
-    t = np.outer(np.arange(par["ny"]) + 1, np.arange(par["nx"]) + 1)
+    t = np.outer(
+        np.arange(par["ny"], dtype=dtype) + 1.0, np.arange(par["nx"], dtype=dtype) + 1.0
+    )
 
-    for type in [1, 2, 3, 4]:
+    for dct_type in (1, 2, 3, 4):
         for axes in [0, 1]:
-            Dct = DCT(dims=t.shape, type=type, axes=axes, dtype=par["dtype"])
+            Dct = DCT(dims=t.shape, type=dct_type, axes=axes, dtype=dtype)
             assert dottest(
                 Dct,
                 par["nx"] * par["ny"],
                 par["nx"] * par["ny"],
-                rtol=1e-6,
                 complexflag=0,
-                verb=True,
+                rtol=1e-4 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y)
+            np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3)])
-def test_DCT3D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_DCT3D(par, dtype):
     """Dot test for Discrete Cosine Transform Operator 3D"""
 
     t = np.random.rand(par["nx"], par["nx"], par["nx"])
 
-    for type in [1, 2, 3, 4]:
+    for dct_type in (1, 2, 3, 4):
         for axes in [0, 1, 2]:
-            Dct = DCT(dims=t.shape, type=type, axes=axes, dtype=par["dtype"])
+            Dct = DCT(dims=t.shape, type=dct_type, axes=axes, dtype=dtype)
             assert dottest(
                 Dct,
                 par["nx"] * par["nx"] * par["nx"],
                 par["nx"] * par["nx"] * par["nx"],
-                rtol=1e-6,
                 complexflag=0,
-                verb=True,
+                rtol=1e-4 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y)
+            np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par3)])
-def test_DCT_workers(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_DCT_workers(par, dtype):
     """Dot test for Discrete Cosine Transform Operator with workers"""
     t = np.arange(par["ny"]) + 1
 
-    Dct = DCT(dims=(par["ny"],), type=1, dtype=par["dtype"], workers=2)
-    assert dottest(Dct, par["ny"], par["ny"], rtol=1e-6, complexflag=0, verb=True)
+    Dct = DCT(dims=(par["ny"],), type=1, dtype=dtype, workers=2)
+    assert dottest(
+        Dct,
+        par["ny"],
+        par["ny"],
+        complexflag=0,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+    )
 
     y = Dct.H * (Dct * t)
-    np.testing.assert_allclose(t, y)
+    np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)

--- a/pytests/test_dct.py
+++ b/pytests/test_dct.py
@@ -28,11 +28,11 @@ def test_DCT1D(par, dtype):
             par["ny"],
             par["ny"],
             complexflag=0,
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
         )
 
         y = Dct.H * (Dct * t)
-        np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
+        np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -55,11 +55,11 @@ def test_DCT2D(par, dtype):
                 par["nx"] * par["ny"],
                 par["nx"] * par["ny"],
                 complexflag=0,
-                rtol=1e-4 if dtype == np.float32 else 1e-6,
+                rtol=5e-4 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
+            np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -80,11 +80,11 @@ def test_DCT3D(par, dtype):
                 par["nx"] * par["nx"] * par["nx"],
                 par["nx"] * par["nx"] * par["nx"],
                 complexflag=0,
-                rtol=1e-4 if dtype == np.float32 else 1e-6,
+                rtol=5e-4 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
+            np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -102,8 +102,8 @@ def test_DCT_workers(par, dtype):
         par["ny"],
         par["ny"],
         complexflag=0,
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = Dct.H * (Dct * t)
-    np.testing.assert_allclose(t, y, rtol=1e-4 if dtype == np.float32 else 1e-6)
+    np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)

--- a/pytests/test_dct.py
+++ b/pytests/test_dct.py
@@ -28,11 +28,11 @@ def test_DCT1D(par, dtype):
             par["ny"],
             par["ny"],
             complexflag=0,
-            rtol=5e-4 if dtype == np.float32 else 1e-6,
+            rtol=1e-3 if dtype == np.float32 else 1e-6,
         )
 
         y = Dct.H * (Dct * t)
-        np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
+        np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -55,11 +55,11 @@ def test_DCT2D(par, dtype):
                 par["nx"] * par["ny"],
                 par["nx"] * par["ny"],
                 complexflag=0,
-                rtol=5e-4 if dtype == np.float32 else 1e-6,
+                rtol=1e-3 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
+            np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -80,11 +80,11 @@ def test_DCT3D(par, dtype):
                 par["nx"] * par["nx"] * par["nx"],
                 par["nx"] * par["nx"] * par["nx"],
                 complexflag=0,
-                rtol=5e-4 if dtype == np.float32 else 1e-6,
+                rtol=1e-3 if dtype == np.float32 else 1e-6,
             )
 
             y = Dct.H * (Dct * t)
-            np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
+            np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)
 
 
 @pytest.mark.skipif(
@@ -102,8 +102,8 @@ def test_DCT_workers(par, dtype):
         par["ny"],
         par["ny"],
         complexflag=0,
-        rtol=5e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
     )
 
     y = Dct.H * (Dct * t)
-    np.testing.assert_allclose(t, y, rtol=5e-4 if dtype == np.float32 else 1e-6)
+    np.testing.assert_allclose(t, y, rtol=1e-3 if dtype == np.float32 else 1e-6)

--- a/pytests/test_derivative.py
+++ b/pytests/test_derivative.py
@@ -101,8 +101,9 @@ np.random.seed(10)
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_FirstDerivative_centered(par):
-    """Dot-test and forward for FirstDerivative operator (centered stencil)"""
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_FirstDerivative_centered(par, dtype):
+    """Dot-test and forward/adjoint for FirstDerivative operator (centered stencil)"""
     np.random.seed(10)
     for order in (3, 5):
         # 1d
@@ -111,13 +112,22 @@ def test_FirstDerivative_centered(par):
             sampling=par["dx"],
             edge=par["edge"],
             order=order,
-            dtype="float64",
+            dtype=dtype,
         )
-        assert dottest(D1op, par["nx"], par["nx"], backend=backend)
+        assert dottest(
+            D1op,
+            par["nx"],
+            par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
-        x = (par["dx"] * np.arange(par["nx"])) ** 2
-        yana = 2 * par["dx"] * np.arange(par["nx"])
+        x = (par["dx"] * np.arange(par["nx"], dtype=dtype)) ** 2
+        yana = 2 * par["dx"] * np.arange(par["nx"], dtype=dtype)
         y = D1op * x
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
             y[order // 2 : -order // 2], yana[order // 2 : -order // 2], decimal=1
         )
@@ -129,21 +139,32 @@ def test_FirstDerivative_centered(par):
             sampling=par["dy"],
             edge=par["edge"],
             order=order,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        x = np.outer((par["dy"] * np.arange(par["ny"])) ** 2, np.ones(par["nx"]))
-        yana = np.outer(2 * par["dy"] * np.arange(par["ny"]), np.ones(par["nx"]))
-        y = D1op * x.ravel()
-        y = y.reshape(par["ny"], par["nx"])
+        x = np.outer(
+            (par["dy"] * np.arange(par["ny"], dtype=dtype)) ** 2,
+            np.ones(par["nx"], dtype=dtype),
+        )
+        yana = np.outer(
+            2 * par["dy"] * np.arange(par["ny"], dtype=dtype),
+            np.ones(par["nx"], dtype=dtype),
+        )
+        y = D1op * x
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
-            y[order // 2 : -order // 2], yana[order // 2 : -order // 2], decimal=1
+            y.reshape(par["ny"], par["nx"])[order // 2 : -order // 2],
+            yana[order // 2 : -order // 2],
+            decimal=1,
         )
 
         # 2d - derivative on 2nd direction
@@ -153,21 +174,25 @@ def test_FirstDerivative_centered(par):
             sampling=par["dx"],
             edge=par["edge"],
             order=order,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        x = np.outer((par["dy"] * np.arange(par["ny"])) ** 2, np.ones(par["nx"]))
-        yana = np.zeros((par["ny"], par["nx"]))
+        yana = np.zeros((par["ny"], par["nx"]), dtype=dtype)
         y = D1op * x.ravel()
-        y = y.reshape(par["ny"], par["nx"])
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
-            y[order // 2 : -order // 2], yana[order // 2 : -order // 2], decimal=1
+            y.reshape(par["ny"], par["nx"])[order // 2 : -order // 2],
+            yana[order // 2 : -order // 2],
+            decimal=1,
         )
 
         # 3d - derivative on 1st direction
@@ -177,25 +202,32 @@ def test_FirstDerivative_centered(par):
             sampling=par["dz"],
             edge=par["edge"],
             order=order,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
         x = np.outer(
-            (par["dz"] * np.arange(par["nz"])) ** 2, np.ones((par["ny"], par["nx"]))
+            (par["dz"] * np.arange(par["nz"], dtype=dtype)) ** 2,
+            np.ones((par["ny"], par["nx"]), dtype=dtype),
         ).reshape(par["nz"], par["ny"], par["nx"])
         yana = np.outer(
-            2 * par["dz"] * np.arange(par["nz"]), np.ones((par["ny"], par["nx"]))
+            2 * par["dz"] * np.arange(par["nz"], dtype=dtype),
+            np.ones((par["ny"], par["nx"]), dtype=dtype),
         ).reshape(par["nz"], par["ny"], par["nx"])
         y = D1op * x.ravel()
-        y = y.reshape(par["nz"], par["ny"], par["nx"])
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
-            y[order // 2 : -order // 2], yana[order // 2 : -order // 2], decimal=1
+            y.reshape(par["nz"], par["ny"], par["nx"])[order // 2 : -order // 2],
+            yana[order // 2 : -order // 2],
+            decimal=1,
         )
 
         # 3d - derivative on 2nd direction
@@ -205,23 +237,25 @@ def test_FirstDerivative_centered(par):
             sampling=par["dy"],
             edge=par["edge"],
             order=order,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        x = np.outer(
-            (par["dz"] * np.arange(par["nz"])) ** 2, np.ones((par["ny"], par["nx"]))
-        ).reshape(par["nz"], par["ny"], par["nx"])
-        yana = np.zeros((par["nz"], par["ny"], par["nx"]))
+        yana = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
         y = D1op * x.ravel()
-        y = y.reshape(par["nz"], par["ny"], par["nx"])
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
-            y[order // 2 : -order // 2], yana[order // 2 : -order // 2], decimal=1
+            y.reshape(par["nz"], par["ny"], par["nx"])[order // 2 : -order // 2],
+            yana[order // 2 : -order // 2],
+            decimal=1,
         )
 
         # 3d - derivative on 3rd direction
@@ -231,38 +265,56 @@ def test_FirstDerivative_centered(par):
             sampling=par["dx"],
             edge=par["edge"],
             order=order,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        yana = np.zeros((par["nz"], par["ny"], par["nx"]))
+        yana = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
         y = D1op * x.ravel()
-        y = y.reshape(par["nz"], par["ny"], par["nx"])
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
-            y[order // 2 : -order // 2], yana[order // 2 : -order // 2], decimal=1
+            y.reshape(par["nz"], par["ny"], par["nx"])[order // 2 : -order // 2],
+            yana[order // 2 : -order // 2],
+            decimal=1,
         )
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_FirstDerivative_forwaback(par):
-    """Dot-test for FirstDerivative operator (forward and backward
-    stencils). Note that the analytical expression cannot be validated in this
-    case
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_FirstDerivative_forwaback(par, dtype):
+    """Dot-test for FirstDerivative operator and forward/adjoint
+    (forward and backward stencils). Note that the analytical
+    expression cannot be validated in this case
     """
     np.random.seed(10)
     for kind in ("forward", "backward"):
         # 1d
         D1op = FirstDerivative(
-            par["nx"], sampling=par["dx"], edge=par["edge"], kind=kind, dtype="float64"
+            par["nx"], sampling=par["dx"], edge=par["edge"], kind=kind, dtype=dtype
         )
-        assert dottest(D1op, par["nx"], par["nx"], backend=backend)
+        assert dottest(
+            D1op,
+            par["nx"],
+            par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
+
+        x = (par["dx"] * np.arange(par["nx"])) ** 2
+        y = D1op * x
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 2d - derivative on 1st direction
         D1op = FirstDerivative(
@@ -271,14 +323,24 @@ def test_FirstDerivative_forwaback(par):
             sampling=par["dy"],
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+
+        x = np.outer(
+            (par["dy"] * np.arange(par["ny"], dtype=dtype)) ** 2,
+            np.ones(par["nx"], dtype=dtype),
+        )
+        y = D1op * x
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 2d - derivative on 2nd direction
         D1op = FirstDerivative(
@@ -287,14 +349,20 @@ def test_FirstDerivative_forwaback(par):
             sampling=par["dx"],
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+
+        y = D1op * x.ravel()
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d - derivative on 1st direction
         D1op = FirstDerivative(
@@ -303,14 +371,24 @@ def test_FirstDerivative_forwaback(par):
             sampling=par["dz"],
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+
+        x = np.outer(
+            (par["dz"] * np.arange(par["nz"], dtype=dtype)) ** 2,
+            np.ones((par["ny"], par["nx"]), dtype=dtype),
+        ).reshape(par["nz"], par["ny"], par["nx"])
+        y = D1op * x.ravel()
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d - derivative on 2nd direction
         D1op = FirstDerivative(
@@ -319,14 +397,20 @@ def test_FirstDerivative_forwaback(par):
             sampling=par["dy"],
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+
+        y = D1op * x.ravel()
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d - derivative on 3rd direction
         D1op = FirstDerivative(
@@ -335,42 +419,58 @@ def test_FirstDerivative_forwaback(par):
             sampling=par["dx"],
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+
+        y = D1op * x.ravel()
+        xadj = D1op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_SecondDerivative_centered(par):
-    """Dot-test and forward for SecondDerivative operator (centered stencil)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_SecondDerivative_centered(par, dtype):
+    """Dot-test and forward/adjoint for SecondDerivative operator (centered stencil)
     The test is based on the fact that the central stencil is exact for polynomials of
     degree 3.
     """
     np.random.seed(10)
-    x = par["dx"] * np.arange(par["nx"])
-    y = par["dy"] * np.arange(par["ny"])
-    z = par["dz"] * np.arange(par["nz"])
+    x = par["dx"] * np.arange(par["nx"], dtype=dtype)
+    y = par["dy"] * np.arange(par["ny"], dtype=dtype)
+    z = par["dz"] * np.arange(par["nz"], dtype=dtype)
 
     xx, yy = np.meshgrid(x, y)  # produces arrays of size (ny,nx)
     xxx, yyy, zzz = np.meshgrid(x, y, z)  # produces arrays of size (ny,nx,nz)
 
     # 1d
     D2op = SecondDerivative(
-        par["nx"], sampling=par["dx"], edge=par["edge"], dtype="float64"
+        par["nx"], sampling=par["dx"], edge=par["edge"], dtype=dtype
     )
-    assert dottest(D2op, par["nx"], par["nx"], backend=backend)
+    assert dottest(
+        D2op,
+        par["nx"],
+        par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # polynomial f(x) = x^3, f''(x) = 6x
     f = x**3
     dfana = 6 * x
     df = D2op * f
+    fadj = D2op.H * df
+    assert df.dtype == dtype
+    assert fadj.dtype == dtype
     assert_array_almost_equal(df[1:-1], dfana[1:-1], decimal=1)
 
     # 2d - derivative on 1st direction
@@ -379,17 +479,26 @@ def test_SecondDerivative_centered(par):
         axis=0,
         sampling=par["dy"],
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
-
-    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend)
+    assert dottest(
+        D2op,
+        par["ny"] * par["nx"],
+        par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # polynomial f(x,y) = y^3, f_{yy}(x,y) = 6y
     f = yy**3
     dfana = 6 * yy
     df = D2op * f.ravel()
-    df = df.reshape(par["ny"], par["nx"])
-    assert_array_almost_equal(df[1:-1, :], dfana[1:-1, :], decimal=1)
+    fadj = D2op.H * df
+    assert df.dtype == dtype
+    assert fadj.dtype == dtype
+    assert_array_almost_equal(
+        df.reshape(par["ny"], par["nx"])[1:-1, :], dfana[1:-1, :], decimal=1
+    )
 
     # 2d - derivative on 2nd direction
     D2op = SecondDerivative(
@@ -397,17 +506,26 @@ def test_SecondDerivative_centered(par):
         axis=1,
         sampling=par["dx"],
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
-
-    assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend)
+    assert dottest(
+        D2op,
+        par["ny"] * par["nx"],
+        par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # polynomial f(x,y) = x^3, f_{xx}(x,y) = 6x
     f = xx**3
     dfana = 6 * xx
     df = D2op * f.ravel()
-    df = df.reshape(par["ny"], par["nx"])
-    assert_array_almost_equal(df[:, 1:-1], dfana[:, 1:-1], decimal=1)
+    fadj = D2op.H * df
+    assert df.dtype == dtype
+    assert fadj.dtype == dtype
+    assert_array_almost_equal(
+        df.reshape(par["ny"], par["nx"])[:, 1:-1], dfana[:, 1:-1], decimal=1
+    )
 
     # 3d - derivative on 1st direction
     D2op = SecondDerivative(
@@ -415,13 +533,13 @@ def test_SecondDerivative_centered(par):
         axis=0,
         sampling=par["dy"],
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
-
     assert dottest(
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -429,9 +547,14 @@ def test_SecondDerivative_centered(par):
     f = yyy**3
     dfana = 6 * yyy
     df = D2op * f.ravel()
-    df = df.reshape(par["ny"], par["nx"], par["nz"])
-
-    assert_array_almost_equal(df[1:-1, :, :], dfana[1:-1, :, :], decimal=1)
+    fadj = D2op.H * df
+    assert df.dtype == dtype
+    assert fadj.dtype == dtype
+    assert_array_almost_equal(
+        df.reshape(par["ny"], par["nx"], par["nz"])[1:-1, :, :],
+        dfana[1:-1, :, :],
+        decimal=1,
+    )
 
     # 3d - derivative on 2nd direction
     D2op = SecondDerivative(
@@ -439,13 +562,13 @@ def test_SecondDerivative_centered(par):
         axis=1,
         sampling=par["dx"],
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
-
     assert dottest(
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -453,9 +576,14 @@ def test_SecondDerivative_centered(par):
     f = xxx**3
     dfana = 6 * xxx
     df = D2op * f.ravel()
-    df = df.reshape(par["ny"], par["nx"], par["nz"])
-
-    assert_array_almost_equal(df[:, 1:-1, :], dfana[:, 1:-1, :], decimal=1)
+    fadj = D2op.H * df
+    assert df.dtype == dtype
+    assert fadj.dtype == dtype
+    assert_array_almost_equal(
+        df.reshape(par["ny"], par["nx"], par["nz"])[:, 1:-1, :],
+        dfana[:, 1:-1, :],
+        decimal=1,
+    )
 
     # 3d - derivative on 3rd direction
     D2op = SecondDerivative(
@@ -463,13 +591,13 @@ def test_SecondDerivative_centered(par):
         axis=2,
         sampling=par["dz"],
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
-
     assert dottest(
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["ny"] * par["nx"] * par["nz"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -477,25 +605,31 @@ def test_SecondDerivative_centered(par):
     f = zzz**3
     dfana = 6 * zzz
     df = D2op * f.ravel()
-    df = df.reshape(par["ny"], par["nx"], par["nz"])
-
-    assert_array_almost_equal(df[:, :, 1:-1], dfana[:, :, 1:-1], decimal=1)
+    fadj = D2op.H * df
+    assert df.dtype == dtype
+    assert fadj.dtype == dtype
+    assert_array_almost_equal(
+        df.reshape(par["ny"], par["nx"], par["nz"])[:, :, 1:-1],
+        dfana[:, :, 1:-1],
+        decimal=1,
+    )
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_SecondDerivative_forwaback(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_SecondDerivative_forwaback(par, dtype):
     """Dot-test for SecondDerivative operator (forward and backward stencils).
     Note that the analytical expression cannot be validated in this case
     """
     np.random.seed(10)
-    x = par["dx"] * np.arange(par["nx"])
-    y = par["dy"] * np.arange(par["ny"])
-    z = par["dz"] * np.arange(par["nz"])
+    x = par["dx"] * np.arange(par["nx"], dtype=dtype)
+    y = par["dy"] * np.arange(par["ny"], dtype=dtype)
+    z = par["dz"] * np.arange(par["nz"], dtype=dtype)
 
-    xx, yy = np.meshgrid(x, y)  # produces arrays of size (ny,nx)
-    xxx, yyy, zzz = np.meshgrid(x, y, z)  # produces arrays of size (ny,nx,nz)
+    xx, _ = np.meshgrid(x, y)  # produces arrays of size (ny,nx)
+    xxx, _, _ = np.meshgrid(x, y, z)  # produces arrays of size (ny,nx,nz)
 
     for _ in ("forward", "backward"):
         # 1d
@@ -504,9 +638,19 @@ def test_SecondDerivative_forwaback(par):
             sampling=par["dx"],
             edge=par["edge"],
             kind="forward",
-            dtype="float64",
+            dtype=dtype,
         )
-        assert dottest(D2op, par["nx"], par["nx"], backend=backend)
+        assert dottest(
+            D2op,
+            par["nx"],
+            par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
+        y = D2op * x
+        xadj = D2op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 2d - derivative on 1st direction
         D2op = SecondDerivative(
@@ -515,15 +659,19 @@ def test_SecondDerivative_forwaback(par):
             sampling=par["dy"],
             edge=par["edge"],
             kind="forward",
-            dtype="float64",
+            dtype=dtype,
         )
-
         assert dottest(
             D2op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = D2op * xx.ravel()
+        xadj = D2op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 2d - derivative on 2nd direction
         D2op = SecondDerivative(
@@ -532,15 +680,19 @@ def test_SecondDerivative_forwaback(par):
             sampling=par["dx"],
             edge=par["edge"],
             kind="forward",
-            dtype="float64",
+            dtype=dtype,
         )
-
         assert dottest(
             D2op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = D2op * xx.ravel()
+        xadj = D2op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d - derivative on 1st direction
         D2op = SecondDerivative(
@@ -549,15 +701,19 @@ def test_SecondDerivative_forwaback(par):
             sampling=par["dy"],
             edge=par["edge"],
             kind="forward",
-            dtype="float64",
+            dtype=dtype,
         )
-
         assert dottest(
             D2op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = D2op * xxx.ravel()
+        xadj = D2op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d - derivative on 2nd direction
         D2op = SecondDerivative(
@@ -566,15 +722,19 @@ def test_SecondDerivative_forwaback(par):
             sampling=par["dx"],
             edge=par["edge"],
             kind="forward",
-            dtype="float64",
+            dtype=dtype,
         )
-
         assert dottest(
             D2op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = D2op * xxx.ravel()
+        xadj = D2op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d - derivative on 3rd direction
         D2op = SecondDerivative(
@@ -583,23 +743,31 @@ def test_SecondDerivative_forwaback(par):
             sampling=par["dz"],
             edge=par["edge"],
             kind="forward",
-            dtype="float64",
+            dtype=dtype,
         )
-
         assert dottest(
             D2op,
             par["nz"] * par["ny"] * par["nx"],
             par["ny"] * par["nx"] * par["nz"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = D2op * xxx.ravel()
+        xadj = D2op.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_Laplacian(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Laplacian(par, dtype):
     """Dot-test for Laplacian operator"""
     np.random.seed(10)
+    xx = np.ones((par["ny"], par["nx"]), dtype=dtype)
+    xxx = np.ones((par["nz"], par["ny"], par["nx"]), dtype=dtype)
+
     # 2d - symmetrical
     Dlapop = Laplacian(
         (par["ny"], par["nx"]),
@@ -607,11 +775,19 @@ def test_Laplacian(par):
         weights=(1, 1),
         sampling=(par["dy"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
-        Dlapop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend
+        Dlapop,
+        par["ny"] * par["nx"],
+        par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
+    y = Dlapop * xx.ravel()
+    xadj = Dlapop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
     # 2d - asymmetrical
     Dlapop = Laplacian(
@@ -620,11 +796,19 @@ def test_Laplacian(par):
         weights=(1, 2),
         sampling=(par["dy"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
-        Dlapop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend
+        Dlapop,
+        par["ny"] * par["nx"],
+        par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
+    y = Dlapop * xx.ravel()
+    xadj = Dlapop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
     # 3d - symmetrical on 1st and 2nd direction
     Dlapop = Laplacian(
@@ -633,14 +817,19 @@ def test_Laplacian(par):
         weights=(1, 1),
         sampling=(par["dy"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Dlapop * xxx.ravel()
+    xadj = Dlapop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
     # 3d - symmetrical on 1st and 2nd direction
     Dlapop = Laplacian(
@@ -649,14 +838,19 @@ def test_Laplacian(par):
         weights=(1, 1),
         sampling=(par["dy"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Dlapop * xxx.ravel()
+    xadj = Dlapop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
     # 3d - symmetrical on all directions
     Dlapop = Laplacian(
@@ -665,22 +859,31 @@ def test_Laplacian(par):
         weights=(1, 1, 1),
         sampling=(par["dz"], par["dx"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Dlapop * xxx.ravel()
+    xadj = Dlapop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_Gradient(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Gradient(par, dtype):
     """Dot-test for Gradient operator"""
     np.random.seed(10)
+    xx = np.ones((par["ny"], par["nx"]), dtype=dtype)
+    xxx = np.ones((par["nz"], par["ny"], par["nx"]), dtype=dtype)
+
     for kind in ("forward", "centered", "backward"):
         # 2d
         Gop = Gradient(
@@ -688,14 +891,19 @@ def test_Gradient(par):
             sampling=(par["dy"], par["dx"]),
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             Gop,
             2 * par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = Gop * xx.ravel()
+        xadj = Gop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d
         Gop = Gradient(
@@ -703,71 +911,104 @@ def test_Gradient(par):
             sampling=(par["dz"], par["dy"], par["dx"]),
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             Gop,
             3 * par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = Gop * xxx.ravel()
+        xadj = Gop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_FirstDirectionalDerivative(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_FirstDirectionalDerivative(par, dtype):
     """Dot-test for FirstDirectionalDerivative operator"""
     np.random.seed(10)
+    xx = np.ones((par["ny"], par["nx"]), dtype=dtype)
+    xxx = np.ones((par["nz"], par["ny"], par["nx"]), dtype=dtype)
+
     for kind in ("forward", "centered", "backward"):
         # 2d
         Fdop = FirstDirectionalDerivative(
             (par["ny"], par["nx"]),
-            v=np.sqrt(2.0) / 2.0 * np.ones(2),
+            v=(np.sqrt(2.0) / 2.0 * np.ones(2)).astype(dtype),
             sampling=(par["dy"], par["dx"]),
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             Fdop,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = Fdop * xx.ravel()
+        xadj = Fdop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
         # 3d
         Fdop = FirstDirectionalDerivative(
             (par["nz"], par["ny"], par["nx"]),
-            v=np.ones(3) / np.sqrt(3),
+            v=(np.ones(3) / np.sqrt(3)).astype(dtype),
             sampling=(par["dz"], par["dy"], par["dx"]),
             edge=par["edge"],
             kind=kind,
-            dtype="float64",
+            dtype=dtype,
         )
         assert dottest(
             Fdop,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
+        y = Fdop * xxx.ravel()
+        xadj = Fdop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_SecondDirectionalDerivative(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_SecondDirectionalDerivative(par, dtype):
     """Dot-test for test_SecondDirectionalDerivative operator"""
     np.random.seed(10)
+    xx = np.ones((par["ny"], par["nx"]), dtype=dtype)
+    xxx = np.ones((par["nz"], par["ny"], par["nx"]), dtype=dtype)
+
     # 2d
     Fdop = SecondDirectionalDerivative(
         (par["ny"], par["nx"]),
         v=np.sqrt(2.0) / 2.0 * np.ones(2),
         sampling=(par["dy"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
-    assert dottest(Fdop, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend)
+    assert dottest(
+        Fdop,
+        par["ny"] * par["nx"],
+        par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+    y = Fdop * xx.ravel()
+    xadj = Fdop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
     # 3d
     Fdop = SecondDirectionalDerivative(
@@ -775,31 +1016,35 @@ def test_SecondDirectionalDerivative(par):
         v=np.ones(3) / np.sqrt(3),
         sampling=(par["dz"], par["dy"], par["dx"]),
         edge=par["edge"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Fdop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+    y = Fdop * xxx.ravel()
+    xadj = Fdop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )
-def test_SecondDirectionalDerivative_verticalderivative(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_SecondDirectionalDerivative_verticalderivative(par, dtype):
     """Compare vertical derivative for SecondDirectionalDerivative operator
     and SecondDerivative
     """
     np.random.seed(10)
-    Fop = FirstDerivative(
-        (par["ny"], par["nx"]), axis=0, edge=par["edge"], dtype="float64"
-    )
+    Fop = FirstDerivative((par["ny"], par["nx"]), axis=0, edge=par["edge"], dtype=dtype)
     F2op = Fop.H * Fop
 
     F2dop = SecondDirectionalDerivative(
-        (par["ny"], par["nx"]), v=np.array([1, 0]), edge=par["edge"], dtype="float64"
+        (par["ny"], par["nx"]), v=np.array([1, 0]), edge=par["edge"], dtype=dtype
     )
 
     x = np.random.normal(0.0, 1.0, (par["ny"], par["nx"]))

--- a/pytests/test_derivative.py
+++ b/pytests/test_derivative.py
@@ -118,7 +118,7 @@ def test_FirstDerivative_centered(par, dtype):
             D1op,
             par["nx"],
             par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -145,7 +145,7 @@ def test_FirstDerivative_centered(par, dtype):
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -180,7 +180,7 @@ def test_FirstDerivative_centered(par, dtype):
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -208,7 +208,7 @@ def test_FirstDerivative_centered(par, dtype):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -243,7 +243,7 @@ def test_FirstDerivative_centered(par, dtype):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -271,7 +271,7 @@ def test_FirstDerivative_centered(par, dtype):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -306,7 +306,7 @@ def test_FirstDerivative_forwaback(par, dtype):
             D1op,
             par["nx"],
             par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -329,7 +329,7 @@ def test_FirstDerivative_forwaback(par, dtype):
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -355,7 +355,7 @@ def test_FirstDerivative_forwaback(par, dtype):
             D1op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -377,7 +377,7 @@ def test_FirstDerivative_forwaback(par, dtype):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -403,7 +403,7 @@ def test_FirstDerivative_forwaback(par, dtype):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -425,7 +425,7 @@ def test_FirstDerivative_forwaback(par, dtype):
             D1op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -460,7 +460,7 @@ def test_SecondDerivative_centered(par, dtype):
         D2op,
         par["nx"],
         par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -485,7 +485,7 @@ def test_SecondDerivative_centered(par, dtype):
         D2op,
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -512,7 +512,7 @@ def test_SecondDerivative_centered(par, dtype):
         D2op,
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -539,7 +539,7 @@ def test_SecondDerivative_centered(par, dtype):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -568,7 +568,7 @@ def test_SecondDerivative_centered(par, dtype):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -597,7 +597,7 @@ def test_SecondDerivative_centered(par, dtype):
         D2op,
         par["nz"] * par["ny"] * par["nx"],
         par["ny"] * par["nx"] * par["nz"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -644,7 +644,7 @@ def test_SecondDerivative_forwaback(par, dtype):
             D2op,
             par["nx"],
             par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = D2op * x
@@ -665,7 +665,7 @@ def test_SecondDerivative_forwaback(par, dtype):
             D2op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = D2op * xx.ravel()
@@ -686,7 +686,7 @@ def test_SecondDerivative_forwaback(par, dtype):
             D2op,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = D2op * xx.ravel()
@@ -707,7 +707,7 @@ def test_SecondDerivative_forwaback(par, dtype):
             D2op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = D2op * xxx.ravel()
@@ -728,7 +728,7 @@ def test_SecondDerivative_forwaback(par, dtype):
             D2op,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = D2op * xxx.ravel()
@@ -749,7 +749,7 @@ def test_SecondDerivative_forwaback(par, dtype):
             D2op,
             par["nz"] * par["ny"] * par["nx"],
             par["ny"] * par["nx"] * par["nz"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = D2op * xxx.ravel()
@@ -781,7 +781,7 @@ def test_Laplacian(par, dtype):
         Dlapop,
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Dlapop * xx.ravel()
@@ -802,7 +802,7 @@ def test_Laplacian(par, dtype):
         Dlapop,
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Dlapop * xx.ravel()
@@ -823,7 +823,7 @@ def test_Laplacian(par, dtype):
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Dlapop * xxx.ravel()
@@ -844,7 +844,7 @@ def test_Laplacian(par, dtype):
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Dlapop * xxx.ravel()
@@ -865,7 +865,7 @@ def test_Laplacian(par, dtype):
         Dlapop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Dlapop * xxx.ravel()
@@ -897,7 +897,7 @@ def test_Gradient(par, dtype):
             Gop,
             2 * par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = Gop * xx.ravel()
@@ -917,7 +917,7 @@ def test_Gradient(par, dtype):
             Gop,
             3 * par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = Gop * xxx.ravel()
@@ -950,7 +950,7 @@ def test_FirstDirectionalDerivative(par, dtype):
             Fdop,
             par["ny"] * par["nx"],
             par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = Fdop * xx.ravel()
@@ -971,7 +971,7 @@ def test_FirstDirectionalDerivative(par, dtype):
             Fdop,
             par["nz"] * par["ny"] * par["nx"],
             par["nz"] * par["ny"] * par["nx"],
-            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            rtol=5e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
         y = Fdop * xxx.ravel()
@@ -1002,7 +1002,7 @@ def test_SecondDirectionalDerivative(par, dtype):
         Fdop,
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Fdop * xx.ravel()
@@ -1022,7 +1022,7 @@ def test_SecondDirectionalDerivative(par, dtype):
         Fdop,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=5e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Fdop * xxx.ravel()

--- a/pytests/test_diagonal.py
+++ b/pytests/test_diagonal.py
@@ -16,24 +16,47 @@ from pylops.basicoperators import Diagonal
 from pylops.optimization.basic import lsqr
 from pylops.utils import dottest
 
-par1 = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float32"}  # real
-par2 = {"ny": 21, "nx": 11, "nt": 20, "imag": 1j, "dtype": "complex64"}  # complex
+par1 = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float32"}  # real (fp32)
+par1s = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float64"}  # real (fp64)
+par1j = {
+    "ny": 21,
+    "nx": 11,
+    "nt": 20,
+    "imag": 1j,
+    "dtype": "complex128",
+}  # complex (cp128)
 
 np.random.seed(10)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Diagonal_1dsignal(par):
     """Dot-test and inversion for Diagonal operator for 1d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for ddim in (par["nx"], par["nt"]):
-        d = np.arange(ddim) + 1.0 + par["imag"] * (np.arange(ddim) + 1.0)
+        d = (
+            np.arange(ddim, dtype=dtype)
+            + 1.0
+            + par["imag"] * (np.arange(ddim, dtype=dtype) + 1.0)
+        )
 
         Dop = Diagonal(d, dtype=par["dtype"])
         assert dottest(
-            Dop, ddim, ddim, complexflag=0 if par["imag"] == 0 else 3, backend=backend
+            Dop,
+            ddim,
+            ddim,
+            complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
         )
 
-        x = np.ones(ddim) + par["imag"] * np.ones(ddim)
+        x = np.ones(ddim, dtype=dtype) + par["imag"] * np.ones(ddim, dtype=dtype)
+        y = Dop * x
+        xadj = Dop.H * y
+        assert y.dtype == Dop.dtype
+        assert xadj.dtype == par["dtype"]
+
         xlsqr = lsqr(
             Dop,
             Dop * x,
@@ -44,15 +67,19 @@ def test_Diagonal_1dsignal(par):
             btol=1e-8,
             show=0,
         )[0]
+        assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
-        assert_array_almost_equal(x, xlsqr, decimal=4)
 
-
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Diagonal_2dsignal(par):
     """Dot-test and inversion for Diagonal operator for 2d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     for idim, ddim in enumerate((par["nx"], par["nt"])):
-        d = np.arange(ddim) + 1.0 + par["imag"] * (np.arange(ddim) + 1.0)
+        d = (
+            np.arange(ddim, dtype=dtype)
+            + 1.0
+            + par["imag"] * (np.arange(ddim, dtype=dtype) + 1.0)
+        )
 
         Dop = Diagonal(d, dims=(par["nx"], par["nt"]), axis=idim, dtype=par["dtype"])
         assert dottest(
@@ -60,6 +87,7 @@ def test_Diagonal_2dsignal(par):
             par["nx"] * par["nt"],
             par["nx"] * par["nt"],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
@@ -80,11 +108,17 @@ def test_Diagonal_2dsignal(par):
         assert_array_almost_equal(x.ravel(), xlsqr.ravel(), decimal=4)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Diagonal_3dsignal(par):
     """Dot-test and inversion for Diagonal operator for 3d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for idim, ddim in enumerate((par["ny"], par["nx"], par["nt"])):
-        d = np.arange(ddim) + 1.0 + par["imag"] * (np.arange(ddim) + 1.0)
+        d = (
+            np.arange(ddim, dtype=dtype)
+            + 1.0
+            + par["imag"] * (np.arange(ddim, dtype=dtype) + 1.0)
+        )
 
         Dop = Diagonal(
             d, dims=(par["ny"], par["nx"], par["nt"]), axis=idim, dtype=par["dtype"]
@@ -94,12 +128,18 @@ def test_Diagonal_3dsignal(par):
             par["ny"] * par["nx"] * par["nt"],
             par["ny"] * par["nx"] * par["nt"],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        x = np.ones((par["ny"], par["nx"], par["nt"])) + par["imag"] * np.ones(
-            (par["ny"], par["nx"], par["nt"])
-        )
+        x = np.ones((par["ny"], par["nx"], par["nt"]), dtype=dtype) + par[
+            "imag"
+        ] * np.ones((par["ny"], par["nx"], par["nt"]), dtype=dtype)
+        y = Dop * x
+        xadj = Dop.H * y
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
+
         xlsqr = lsqr(
             Dop,
             Dop * x.ravel(),
@@ -110,15 +150,22 @@ def test_Diagonal_3dsignal(par):
             btol=1e-8,
             show=0,
         )[0]
+        assert_array_almost_equal(
+            x.ravel(), xlsqr.ravel(), decimal=2 if dtype == np.float32 else 4
+        )
 
-        assert_array_almost_equal(x.ravel(), xlsqr.ravel(), decimal=4)
 
-
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Diagonal_2dsignal_unflattened(par):
     """Dot-test and inversion for Diagonal operator for unflattened 2d signal (v2 behaviour)"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for idim, ddim in enumerate((par["nx"], par["nt"])):
-        d = np.arange(ddim) + 1.0 + par["imag"] * (np.arange(ddim) + 1.0)
+        d = (
+            np.arange(ddim, dtype=dtype)
+            + 1.0
+            + par["imag"] * (np.arange(ddim, dtype=dtype) + 1.0)
+        )
 
         Dop = Diagonal(d, dims=(par["nx"], par["nt"]), axis=idim, dtype=par["dtype"])
         assert dottest(
@@ -126,12 +173,18 @@ def test_Diagonal_2dsignal_unflattened(par):
             par["nx"] * par["nt"],
             par["nx"] * par["nt"],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        x = np.ones((par["nx"], par["nt"])) + par["imag"] * np.ones(
-            (par["nx"], par["nt"])
+        x = np.ones((par["nx"], par["nt"]), dtype=dtype) + par["imag"] * np.ones(
+            (par["nx"], par["nt"]), dtype=dtype
         )
+        y = Dop * x
+        xadj = Dop.H * y
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
+
         xlsqr = lsqr(
             Dop,
             Dop * x,
@@ -142,15 +195,20 @@ def test_Diagonal_2dsignal_unflattened(par):
             btol=1e-8,
             show=0,
         )[0]
+        assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
-        assert_array_almost_equal(x, xlsqr, decimal=4)
 
-
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Diagonal_3dsignal_unflattened(par):
     """Dot-test and inversion for Diagonal operator unflattened 3d signal (v2 behaviour)"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for idim, ddim in enumerate((par["ny"], par["nx"], par["nt"])):
-        d = np.arange(ddim) + 1.0 + par["imag"] * (np.arange(ddim) + 1.0)
+        d = (
+            np.arange(ddim, dtype=dtype)
+            + 1.0
+            + par["imag"] * (np.arange(ddim, dtype=dtype) + 1.0)
+        )
 
         Dop = Diagonal(
             d, dims=(par["ny"], par["nx"], par["nt"]), axis=idim, dtype=par["dtype"]
@@ -160,12 +218,18 @@ def test_Diagonal_3dsignal_unflattened(par):
             par["ny"] * par["nx"] * par["nt"],
             par["ny"] * par["nx"] * par["nt"],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
             backend=backend,
         )
 
-        x = np.ones((par["ny"], par["nx"], par["nt"])) + par["imag"] * np.ones(
-            (par["ny"], par["nx"], par["nt"])
-        )
+        x = np.ones((par["ny"], par["nx"], par["nt"]), dtype=dtype) + par[
+            "imag"
+        ] * np.ones((par["ny"], par["nx"], par["nt"]), dtype=dtype)
+        y = Dop * x
+        xadj = Dop.H * y
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
+
         xlsqr = lsqr(
             Dop,
             Dop * x,
@@ -176,5 +240,4 @@ def test_Diagonal_3dsignal_unflattened(par):
             btol=1e-8,
             show=0,
         )[0]
-
-        assert_array_almost_equal(x, xlsqr, decimal=4)
+        assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)

--- a/pytests/test_dwts.py
+++ b/pytests/test_dwts.py
@@ -8,17 +8,38 @@ from scipy.sparse.linalg import lsqr
 from pylops.signalprocessing import DWT, DWT2D, DWTND
 from pylops.utils import dottest
 
-par1 = {"ny": 7, "nx": 9, "nt": 10, "imag": 0, "dtype": "float32"}  # real
-par2 = {"ny": 7, "nx": 9, "nt": 10, "imag": 1j, "dtype": "complex64"}  # complex
-par3 = {"ny": 7, "nx": 9, "nz": 9, "nt": 10, "imag": 0, "dtype": "float32"}  # real 4D
-par4 = {
+par1 = {
+    "ny": 7,
+    "nx": 9,
+    "nz": 9,
+    "nt": 10,
+    "imag": 0,
+    "dtype": "float32",
+}  # real (fp32)
+par2 = {
+    "ny": 7,
+    "nx": 9,
+    "nz": 9,
+    "nt": 10,
+    "imag": 0,
+    "dtype": "float64",
+}  # real (fp64)
+par3 = {
     "ny": 7,
     "nx": 9,
     "nz": 9,
     "nt": 10,
     "imag": 1j,
     "dtype": "complex64",
-}  # complex 4D
+}  # complex (cp64)
+par4 = {
+    "ny": 7,
+    "nx": 9,
+    "nz": 9,
+    "nt": 10,
+    "imag": 1j,
+    "dtype": "complex128",
+}  # complex (cp128)
 
 np.random.seed(10)
 
@@ -36,188 +57,278 @@ def test_unknown_wavelet(par):
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWT_1dsignal(par):
     """Dot-test and inversion for DWT operator for 1d signal"""
-    DWTop = DWT(dims=[par["nt"]], axis=0, wavelet="haar", level=3)
-    x = np.random.normal(0.0, 1.0, par["nt"]) + par["imag"] * np.random.normal(
-        0.0, 1.0, par["nt"]
-    )
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    DWTop = DWT(dims=[par["nt"]], axis=0, wavelet="haar", level=3, dtype=par["dtype"])
+    x = np.random.normal(0.0, 1.0, par["nt"]).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0.0, 1.0, par["nt"]).astype(dtype)
 
     assert dottest(
-        DWTop, DWTop.shape[0], DWTop.shape[1], complexflag=0 if par["imag"] == 0 else 3
+        DWTop,
+        DWTop.shape[0],
+        DWTop.shape[1],
+        complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = DWTop * x
     xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-    xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
-    assert_array_almost_equal(x, xadj, decimal=8)
-    assert_array_almost_equal(x, xinv, decimal=8)
+    xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+    assert_array_almost_equal(x, xadj, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWT_2dsignal(par):
     """Dot-test and inversion for DWT operator for 2d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for axis in [0, 1]:
-        DWTop = DWT(dims=(par["nt"], par["nx"]), axis=axis, wavelet="haar", level=3)
-        x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"])) + par[
+        DWTop = DWT(
+            dims=(par["nt"], par["nx"]),
+            axis=axis,
+            wavelet="haar",
+            level=3,
+            dtype=par["dtype"],
+        )
+        x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"])).astype(dtype) + par[
             "imag"
-        ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"]))
+        ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"])).astype(dtype)
 
         assert dottest(
             DWTop,
             DWTop.shape[0],
             DWTop.shape[1],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
         )
 
         y = DWTop * x.ravel()
         xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
 
-        assert_array_almost_equal(x.ravel(), xadj, decimal=8)
-        assert_array_almost_equal(x.ravel(), xinv, decimal=8)
+        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert_array_almost_equal(
+            x.ravel(), xadj, decimal=4 if dtype == np.float32 else 8
+        )
+        assert_array_almost_equal(
+            x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8
+        )
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWT_3dsignal(par):
     """Dot-test and inversion for DWT operator for 3d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
     for axis in [0, 1, 2]:
         DWTop = DWT(
-            dims=(par["nt"], par["nx"], par["ny"]), axis=axis, wavelet="haar", level=3
+            dims=(par["nt"], par["nx"], par["ny"]),
+            axis=axis,
+            wavelet="haar",
+            level=3,
+            dtype=par["dtype"],
         )
-        x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"])) + par[
-            "imag"
-        ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"]))
+        x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"])).astype(
+            dtype
+        ) + par["imag"] * np.random.normal(
+            0.0, 1.0, (par["nt"], par["nx"], par["ny"])
+        ).astype(dtype)
 
         assert dottest(
             DWTop,
             DWTop.shape[0],
             DWTop.shape[1],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
         )
 
         y = DWTop * x.ravel()
         xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
 
-        assert_array_almost_equal(x.ravel(), xadj, decimal=8)
-        assert_array_almost_equal(x.ravel(), xinv, decimal=8)
+        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert_array_almost_equal(
+            x.ravel(), xadj, decimal=4 if dtype == np.float32 else 8
+        )
+        assert_array_almost_equal(
+            x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8
+        )
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWT2D_2dsignal(par):
     """Dot-test and inversion for DWT2D operator for 2d signal"""
-    DWTop = DWT2D(dims=(par["nt"], par["nx"]), axes=(0, 1), wavelet="haar", level=3)
-    x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"])) + par[
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    DWTop = DWT2D(
+        dims=(par["nt"], par["nx"]),
+        axes=(0, 1),
+        wavelet="haar",
+        level=3,
+        dtype=par["dtype"],
+    )
+    x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"])).astype(dtype) + par[
         "imag"
-    ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"]))
+    ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"])).astype(dtype)
 
     assert dottest(
-        DWTop, DWTop.shape[0], DWTop.shape[1], complexflag=0 if par["imag"] == 0 else 3
+        DWTop,
+        DWTop.shape[0],
+        DWTop.shape[1],
+        complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = DWTop * x.ravel()
     xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-    xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
-    assert_array_almost_equal(x.ravel(), xadj, decimal=8)
-    assert_array_almost_equal(x.ravel(), xinv, decimal=8)
+    xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+    assert_array_almost_equal(x.ravel(), xadj, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWT2D_3dsignal(par):
     """Dot-test and inversion for DWT operator for 3d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for axes in [(0, 1), (0, 2), (1, 2)]:
         DWTop = DWT2D(
-            dims=(par["nt"], par["nx"], par["ny"]), axes=axes, wavelet="haar", level=3
+            dims=(par["nt"], par["nx"], par["ny"]),
+            axes=axes,
+            wavelet="haar",
+            level=3,
+            dtype=par["dtype"],
         )
-        x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"])) + par[
-            "imag"
-        ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"]))
+        x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"])).astype(
+            dtype
+        ) + par["imag"] * np.random.normal(
+            0.0, 1.0, (par["nt"], par["nx"], par["ny"])
+        ).astype(dtype)
 
         assert dottest(
             DWTop,
             DWTop.shape[0],
             DWTop.shape[1],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
         )
 
         y = DWTop * x.ravel()
         xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
 
-        assert_array_almost_equal(x.ravel(), xadj, decimal=8)
-        assert_array_almost_equal(x.ravel(), xinv, decimal=8)
+        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert_array_almost_equal(
+            x.ravel(), xadj, decimal=4 if dtype == np.float32 else 8
+        )
+        assert_array_almost_equal(
+            x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8
+        )
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par3), (par4)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWTND_3dsignal(par):
     """Dot-test and inversion for DWTND operator for 3d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     DWTop = DWTND(
-        dims=(par["nt"], par["nx"], par["ny"]), axes=(0, 1, 2), wavelet="haar", level=3
+        dims=(par["nt"], par["nx"], par["ny"]),
+        axes=(0, 1, 2),
+        wavelet="haar",
+        level=3,
+        dtype=par["dtype"],
     )
-    x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"])) + par[
-        "imag"
-    ] * np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"]))
+    x = np.random.normal(0.0, 1.0, (par["nt"], par["nx"], par["ny"])).astype(
+        dtype
+    ) + par["imag"] * np.random.normal(
+        0.0, 1.0, (par["nt"], par["nx"], par["ny"])
+    ).astype(dtype)
 
     assert dottest(
-        DWTop, DWTop.shape[0], DWTop.shape[1], complexflag=0 if par["imag"] == 0 else 3
+        DWTop,
+        DWTop.shape[0],
+        DWTop.shape[1],
+        complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = DWTop * x.ravel()
     xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-    xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
-    assert_array_almost_equal(x.ravel(), xadj, decimal=8)
-    assert_array_almost_equal(x.ravel(), xinv, decimal=8)
+    xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+    assert_array_almost_equal(x.ravel(), xadj, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par3), (par4)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_DWTND_4dsignal(par):
     """Dot-test and inversion for DWTND operator for 4d signal"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     for axes in [(0, 1, 2), (0, 2, 3), (1, 2, 3), (0, 1, 3), (0, 1, 2, 3)]:
         DWTop = DWTND(
             dims=(par["nt"], par["nx"], par["ny"], par["nz"]),
             axes=axes,
             wavelet="haar",
             level=3,
+            dtype=par["dtype"],
         )
         x = np.random.normal(
             0.0, 1.0, (par["nt"], par["nx"], par["ny"], par["nz"])
-        ) + par["imag"] * np.random.normal(
+        ).astype(dtype) + par["imag"] * np.random.normal(
             0.0, 1.0, (par["nt"], par["nx"], par["ny"], par["nz"])
-        )
+        ).astype(dtype)
 
         assert dottest(
             DWTop,
             DWTop.shape[0],
             DWTop.shape[1],
             complexflag=0 if par["imag"] == 0 else 3,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
         )
 
         y = DWTop * x.ravel()
         xadj = DWTop.H * y  # adjoint is same as inverse for dwt
-        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert y.dtype == par["dtype"]
+        assert xadj.dtype == par["dtype"]
 
-        assert_array_almost_equal(x.ravel(), xadj, decimal=8)
-        assert_array_almost_equal(x.ravel(), xinv, decimal=8)
+        xinv = lsqr(DWTop, y, damp=1e-10, iter_lim=10, atol=1e-8, btol=1e-8, show=0)[0]
+        assert_array_almost_equal(
+            x.ravel(), xadj, decimal=4 if dtype == np.float32 else 8
+        )
+        assert_array_almost_equal(
+            x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8
+        )

--- a/pytests/test_eigs.py
+++ b/pytests/test_eigs.py
@@ -15,30 +15,33 @@ from pylops.basicoperators import MatrixMult
 from pylops.optimization.eigs import power_iteration
 from pylops.utils.backend import to_numpy
 
-par1 = {"n": 21, "imag": 0, "dtype": "float32"}  # square, real
-par2 = {"n": 21, "imag": 1j, "dtype": "complex64"}  # square, complex
+par1 = {"n": 21, "imag": 0, "dtype": "float32"}  # real (fp32)
+par2 = {"n": 21, "imag": 0, "dtype": "float64"}  # real (fp64)
+par3 = {"n": 21, "imag": 1j, "dtype": "complex64"}  # complex (cp64)
+par4 = {"n": 21, "imag": 1j, "dtype": "complex128"}  # complex (cp128)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
 def test_power_iteration(par):
     """Max eigenvalue computation with power iteration method vs. numpy.linalg.eig"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
-    A = np.random.randn(par["n"], par["n"]) + par["imag"] * np.random.randn(
-        par["n"], par["n"]
-    )
+    A = np.random.randn(par["n"], par["n"]).astype(dtype) + par[
+        "imag"
+    ] * np.random.randn(par["n"], par["n"]).astype(dtype)
     A1 = np.conj(A.T) @ A
 
     # non-symmetric
-    Aop = MatrixMult(A)
+    Aop = MatrixMult(A, dtype=par["dtype"])
     eig = power_iteration(Aop, niter=200, tol=0, backend=backend)[0]
     eig_np = npp.max(npp.abs(npp.linalg.eig(to_numpy(A))[0]))
-
+    assert eig.dtype == par["dtype"]
     assert np.abs(np.abs(eig) - eig_np) < 1e-3
 
     # symmetric
-    A1op = MatrixMult(A1)
+    A1op = MatrixMult(A1, dtype=par["dtype"])
     eig = power_iteration(A1op, niter=200, tol=0, backend=backend)[0]
     eig_np = npp.max(npp.abs(npp.linalg.eig(to_numpy(A1))[0]))
-
+    assert eig.dtype == par["dtype"]
     assert np.abs(np.abs(eig) - eig_np) < 1e-3

--- a/pytests/test_estimators.py
+++ b/pytests/test_estimators.py
@@ -72,7 +72,7 @@ def test_trace_hutchpp(par):
     assert type(trace_true) == npp.dtype(dtype)
 
     trace_expl = Aop.trace(backend=backend)
-    assert to_numpy(trace_expl).dtype == np.dtype(dtype)
+    assert to_numpy(trace_expl).dtype == npp.dtype(dtype)
     assert_almost_equal(trace_true, trace_expl, decimal=5)
 
     # Hutch++
@@ -82,7 +82,7 @@ def test_trace_hutchpp(par):
         sampler=sampler,
         backend=backend,
     )
-    assert to_numpy(trace_est).dtype == np.dtype(dtype)
+    assert to_numpy(trace_est).dtype == npp.dtype(dtype)
     assert_almost_equal(trace_true, trace_est, decimal=5)
 
 
@@ -99,7 +99,7 @@ def test_trace_nahutchpp(par):
     assert type(trace_true) == npp.dtype(dtype)
 
     trace_expl = Aop.trace(backend=backend)
-    assert to_numpy(trace_expl).dtype == np.dtype(dtype)
+    assert to_numpy(trace_expl).dtype == npp.dtype(dtype)
     assert_almost_equal(trace_true, trace_expl, decimal=5)
 
     # NA-Hutch++
@@ -109,5 +109,5 @@ def test_trace_nahutchpp(par):
         sampler=sampler,
         backend=backend,
     )
-    assert to_numpy(trace_est).dtype == np.dtype(dtype)
+    assert to_numpy(trace_est).dtype == npp.dtype(dtype)
     assert_almost_equal(trace_true, trace_est, decimal=-1)

--- a/pytests/test_fredholm.py
+++ b/pytests/test_fredholm.py
@@ -83,15 +83,18 @@ par6 = {
 def test_Fredholm1(par):
     """Dot-test and inversion for Fredholm1 operator"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
-    _F = np.arange(par["nsl"] * par["nx"] * par["ny"]).reshape(
-        par["nsl"], par["nx"], par["ny"]
+    _F = (
+        np.arange(par["nsl"] * par["nx"] * par["ny"])
+        .reshape(par["nsl"], par["nx"], par["ny"])
+        .astype(dtype)
     )
     F = _F - par["imag"] * _F
 
-    x = np.ones((par["nsl"], par["ny"], par["nz"])) + par["imag"] * np.ones(
-        (par["nsl"], par["ny"], par["nz"])
-    )
+    x = np.ones((par["nsl"], par["ny"], par["nz"]), dtype=dtype) + par[
+        "imag"
+    ] * np.ones((par["nsl"], par["ny"], par["nz"]), dtype=dtype)
 
     Fop = Fredholm1(
         F,
@@ -105,8 +108,15 @@ def test_Fredholm1(par):
         par["nsl"] * par["nx"] * par["nz"],
         par["nsl"] * par["ny"] * par["nz"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    y = Fop @ x.ravel()
+    xadj = Fop.H @ y
+    assert y.dtype == Fop.dtype
+    assert xadj.dtype == par["dtype"]
+
     xlsqr = lsqr(
         Fop,
         Fop * x.ravel(),

--- a/pytests/test_functionoperator.py
+++ b/pytests/test_functionoperator.py
@@ -79,6 +79,8 @@ def test_FunctionOperator(par):
 
     F_x = Fop @ x
     FH_y = Fop.H @ y
+    assert F_x.dtype == par["dtype"]
+    assert FH_y.dtype == par["dtype"]
 
     G_x = np.asarray(G @ x)
     GH_y = np.asarray(np.conj(G.T) @ y)
@@ -125,6 +127,7 @@ def test_FunctionOperator_NoAdjoint(par):
 
     F_x = Fop @ x
     G_x = np.asarray(G @ x)
+    assert F_x.dtype == par["dtype"]
     assert_array_equal(F_x, G_x)
 
     # check error is raised when applying the adjoint

--- a/pytests/test_interpolation.py
+++ b/pytests/test_interpolation.py
@@ -20,7 +20,6 @@ class InterpolationTestParameters:
     x_num: int
     t_num: int
     imag: complex
-    dtype: Literal["float64", "complex128"]
     kind: Literal["nearest", "linear", "sinc", "cubic_spline"]
 
 
@@ -30,7 +29,6 @@ par1 = pytest.param(
         x_num=11,
         t_num=20,
         imag=0,
-        dtype="float64",
         kind="nearest",
     ),
     id="nearest - real",
@@ -41,7 +39,6 @@ par2 = pytest.param(
         x_num=11,
         t_num=20,
         imag=1j,
-        dtype="complex128",
         kind="nearest",
     ),
     id="nearest - complex",
@@ -52,7 +49,6 @@ par3 = pytest.param(
         x_num=11,
         t_num=20,
         imag=0,
-        dtype="float64",
         kind="linear",
     ),
     id="linear - real",
@@ -63,7 +59,6 @@ par4 = pytest.param(
         x_num=11,
         t_num=20,
         imag=1j,
-        dtype="complex128",
         kind="linear",
     ),
     id="linear - complex",
@@ -74,7 +69,6 @@ par5 = pytest.param(
         x_num=11,
         t_num=20,
         imag=0,
-        dtype="float64",
         kind="sinc",
     ),
     id="sinc - real",
@@ -85,7 +79,6 @@ par6 = pytest.param(
         x_num=11,
         t_num=20,
         imag=1j,
-        dtype="complex128",
         kind="sinc",
     ),
     id="sinc - complex",
@@ -96,7 +89,6 @@ par7 = pytest.param(
         x_num=11,
         t_num=20,
         imag=0,
-        dtype="float64",
         kind="cubic_spline",
     ),
     id="cubic natural spline - real",
@@ -107,7 +99,6 @@ par8 = pytest.param(
         x_num=11,
         t_num=20,
         imag=1j,
-        dtype="complex128",
         kind="cubic_spline",
     ),
     id="cubic natural spline - complex",
@@ -160,32 +151,52 @@ def test_sincinterp():
         (par8),
     ],
 )
-def test_Interp_1dsignal(par: InterpolationTestParameters):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Interp_1dsignal(par: InterpolationTestParameters, dtype: np.dtype):
     """Dot-test and forward for Interp operator for 1d signal"""
     np.random.seed(1)
-    x = np.random.normal(0, 1, par.x_num) + par.imag * np.random.normal(0, 1, par.x_num)
+    dtype = dtype if par.kind != "cubic_spline" else np.float64
+    dtype1 = (np.empty(0, dtype=dtype) + par.imag * np.empty(0, dtype=dtype)).dtype
+
+    x = np.random.normal(0, 1, par.x_num).astype(dtype) + par.imag * np.random.normal(
+        0, 1, par.x_num
+    ).astype(dtype)
 
     Nsub = int(np.round(par.x_num * SUBSAMPLING_PERCENTAGE))
     iava = np.sort(np.random.permutation(np.arange(par.x_num))[:Nsub])
 
     # fixed indeces
-    Iop, _ = Interp(par.x_num, iava, kind=par.kind, dtype=par.dtype)
-    assert dottest(Iop, Nsub, par.x_num, complexflag=0 if par.imag == 0 else 3)
+    Iop, _ = Interp(par.x_num, iava, kind=par.kind, dtype=dtype1)
+    assert dottest(
+        Iop,
+        Nsub,
+        par.x_num,
+        complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+    )
 
     # decimal indeces
-    Idecop, _ = Interp(par.x_num, iava + 0.3, kind=par.kind, dtype=par.dtype)
-    assert dottest(Iop, Nsub, par.x_num, complexflag=0 if par.imag == 0 else 3)
+    Idecop, _ = Interp(par.x_num, iava + 0.3, kind=par.kind, dtype=dtype1)
+    assert dottest(
+        Iop,
+        Nsub,
+        par.x_num,
+        complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+    )
 
     # repeated indeces
     with pytest.raises(ValueError, match="repeated"):
         iava_rep = iava.copy()
         iava_rep[-2] = 0
         iava_rep[-1] = 0
-        _, _ = Interp(par.x_num, iava_rep + 0.3, kind=par.kind, dtype=par.dtype)
+        _, _ = Interp(par.x_num, iava_rep + 0.3, kind=par.kind, dtype=dtype)
 
     # forward
     y = Iop * x
     ydec = Idecop * x
+    assert y.dtype == dtype1
+    assert ydec.dtype == dtype1
 
     assert_array_almost_equal(y, x[iava])
     if par.kind == "nearest":
@@ -205,12 +216,16 @@ def test_Interp_1dsignal(par: InterpolationTestParameters):
         (par8),
     ],
 )
-def test_Interp_2dsignal(par: InterpolationTestParameters):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Interp_2dsignal(par: InterpolationTestParameters, dtype: np.dtype):
     """Dot-test and forward for Restriction operator for 2d signal"""
     np.random.seed(1)
-    x = np.random.normal(0, 1, (par.x_num, par.t_num)) + par.imag * np.random.normal(
-        0, 1, (par.x_num, par.t_num)
-    )
+    dtype = dtype if par.kind != "cubic_spline" else np.float64
+    dtype1 = (np.empty(0, dtype=dtype) + par.imag * np.empty(0, dtype=dtype)).dtype
+
+    x = np.random.normal(0, 1, (par.x_num, par.t_num)).astype(
+        dtype
+    ) + par.imag * np.random.normal(0, 1, (par.x_num, par.t_num)).astype(dtype)
 
     # 1st direction
     Nsub = int(np.round(par.x_num * SUBSAMPLING_PERCENTAGE))
@@ -222,13 +237,14 @@ def test_Interp_2dsignal(par: InterpolationTestParameters):
         iava,
         axis=0,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Iop,
         Nsub * par.t_num,
         par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -237,7 +253,7 @@ def test_Interp_2dsignal(par: InterpolationTestParameters):
         iava + 0.3,
         axis=0,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
 
     # repeated indeces
@@ -250,7 +266,7 @@ def test_Interp_2dsignal(par: InterpolationTestParameters):
             iava_rep + 0.3,
             axis=0,
             kind=par.kind,
-            dtype=par.dtype,
+            dtype=dtype1,
         )
 
     y = (Iop * x.ravel()).reshape(Nsub, par.t_num)
@@ -270,13 +286,14 @@ def test_Interp_2dsignal(par: InterpolationTestParameters):
         iava,
         axis=1,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Iop,
         par.x_num * Nsub,
         par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -285,13 +302,14 @@ def test_Interp_2dsignal(par: InterpolationTestParameters):
         iava + 0.3,
         axis=1,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Idecop,
         par.x_num * Nsub,
         par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = (Iop * x.ravel()).reshape(par.x_num, Nsub)
@@ -315,12 +333,18 @@ def test_Interp_2dsignal(par: InterpolationTestParameters):
         (par8),
     ],
 )
-def test_Interp_3dsignal(par: InterpolationTestParameters):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Interp_3dsignal(par: InterpolationTestParameters, dtype: np.dtype):
     """Dot-test and forward  for Interp operator for 3d signal"""
     np.random.seed(1)
-    x = np.random.normal(
-        0, 1, (par.y_num, par.x_num, par.t_num)
-    ) + par.imag * np.random.normal(0, 1, (par.y_num, par.x_num, par.t_num))
+    dtype = dtype if par.kind != "cubic_spline" else np.float64
+    dtype1 = (np.empty(0, dtype=dtype) + par.imag * np.empty(0, dtype=dtype)).dtype
+
+    x = np.random.normal(0, 1, (par.y_num, par.x_num, par.t_num)).astype(
+        dtype
+    ) + par.imag * np.random.normal(0, 1, (par.y_num, par.x_num, par.t_num)).astype(
+        dtype
+    )
 
     # 1st direction
     Nsub = int(np.round(par.y_num * SUBSAMPLING_PERCENTAGE))
@@ -332,13 +356,14 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
         iava,
         axis=0,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Iop,
         Nsub * par.x_num * par.t_num,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -347,13 +372,14 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
         iava + 0.3,
         axis=0,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Idecop,
         Nsub * par.x_num * par.t_num,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # repeated indeces
@@ -366,7 +392,7 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
             iava_rep + 0.3,
             axis=0,
             kind=par.kind,
-            dtype=par.dtype,
+            dtype=dtype,
         )
 
     y = (Iop * x.ravel()).reshape(Nsub, par.x_num, par.t_num)
@@ -386,13 +412,14 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
         iava,
         axis=1,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Iop,
         par.y_num * Nsub * par.t_num,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -401,13 +428,14 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
         iava + 0.3,
         axis=1,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Idecop,
         par.y_num * Nsub * par.t_num,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = (Iop * x.ravel()).reshape(par.y_num, Nsub, par.t_num)
@@ -427,13 +455,14 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
         iava,
         axis=2,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Iop,
         par.y_num * par.x_num * Nsub,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -442,13 +471,14 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
         iava + 0.3,
         axis=2,
         kind=par.kind,
-        dtype=par.dtype,
+        dtype=dtype1,
     )
     assert dottest(
         Idecop,
         par.y_num * par.x_num * Nsub,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     y = (Iop * x.ravel()).reshape(par.y_num, par.x_num, Nsub)
@@ -460,18 +490,25 @@ def test_Interp_3dsignal(par: InterpolationTestParameters):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_Bilinear_2dsignal(par: InterpolationTestParameters):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Bilinear_2dsignal(par: InterpolationTestParameters, dtype: np.dtype):
     """Dot-test and forward for Interp operator for 2d signal"""
     np.random.seed(1)
-    x = np.random.normal(0, 1, (par.x_num, par.t_num)) + par.imag * np.random.normal(
-        0, 1, (par.x_num, par.t_num)
-    )
+    dtype1 = (np.empty(0, dtype=dtype) + par.imag * np.empty(0, dtype=dtype)).dtype
+
+    x = np.random.normal(0, 1, (par.x_num, par.t_num)).astype(
+        dtype1
+    ) + par.imag * np.random.normal(0, 1, (par.x_num, par.t_num)).astype(dtype1)
 
     # fixed indeces
     iava = np.vstack((np.arange(0, 10), np.arange(0, 10)))
-    Iop = Bilinear(iava, dims=(par.x_num, par.t_num), dtype=par.dtype)
+    Iop = Bilinear(iava, dims=(par.x_num, par.t_num), dtype=dtype1)
     assert dottest(
-        Iop, 10, par.x_num * par.t_num, complexflag=0 if par.imag == 0 else 3
+        Iop,
+        10,
+        par.x_num * par.t_num,
+        complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -482,39 +519,48 @@ def test_Bilinear_2dsignal(par: InterpolationTestParameters):
             np.random.uniform(0, par.t_num - 1, Nsub),
         )
     )
-    Idecop = Bilinear(iavadec, dims=(par.x_num, par.t_num), dtype=par.dtype)
+    Idecop = Bilinear(iavadec, dims=(par.x_num, par.t_num), dtype=dtype1)
     assert dottest(
-        Idecop, Nsub, par.x_num * par.t_num, complexflag=0 if par.imag == 0 else 3
+        Idecop,
+        Nsub,
+        par.x_num * par.t_num,
+        complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # repeated indeces
     with pytest.raises(ValueError, match="repeated"):
         iava_rep = iava.copy()
         iava_rep[::, -1] = iava_rep[::, 0]
-        _, _ = Bilinear(iava_rep, dims=(par.x_num, par.t_num), dtype=par.dtype)
+        _, _ = Bilinear(iava_rep, dims=(par.x_num, par.t_num), dtype=dtype1)
 
     y = Iop * x.ravel()
     assert_array_almost_equal(y, x[iava[0], iava[1]])
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_Bilinear_2dsignal_flatten(par: InterpolationTestParameters):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Bilinear_2dsignal_flatten(par: InterpolationTestParameters, dtype: np.dtype):
     """Dot-test and forward for Interp operator for 2d signal with forceflat"""
     np.random.seed(1)
+    dtype1 = (np.empty(0, dtype=dtype) + par.imag * np.empty(0, dtype=dtype)).dtype
+
     dims = (par.x_num, par.t_num)
     flat_dims = par.x_num * par.t_num
     dimsd = 10
 
-    x = np.random.normal(0, 1, dims) + par.imag * np.random.normal(0, 1, dims)
+    x = np.random.normal(0, 1, dims).astype(dtype1) + par.imag * np.random.normal(
+        0, 1, dims
+    ).astype(dtype1)
 
     iava = np.vstack((np.arange(0, dimsd), np.arange(0, dimsd)))
-    Iop_True = Bilinear(iava, dims=dims, dtype=par.dtype, forceflat=True)
+    Iop_True = Bilinear(iava, dims=dims, dtype=dtype1, forceflat=True)
     y = Iop_True @ x
     xadj = Iop_True.H @ y
     assert y.shape == (dimsd,)
     assert xadj.shape == (flat_dims,)
 
-    Iop_None = Bilinear(iava, dims=dims, dtype=par.dtype)
+    Iop_None = Bilinear(iava, dims=dims, dtype=dtype1)
     y = Iop_None @ x
     xadj = Iop_None.H @ y
     assert y.shape == (dimsd,)
@@ -522,21 +568,27 @@ def test_Bilinear_2dsignal_flatten(par: InterpolationTestParameters):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_Bilinear_3dsignal(par: InterpolationTestParameters):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Bilinear_3dsignal(par: InterpolationTestParameters, dtype: np.dtype):
     """Dot-test and forward for Interp operator for 3d signal"""
     np.random.seed(1)
-    x = np.random.normal(
-        0, 1, (par.y_num, par.x_num, par.t_num)
-    ) + par.imag * np.random.normal(0, 1, (par.y_num, par.x_num, par.t_num))
+    dtype1 = (np.empty(0, dtype=dtype) + par.imag * np.empty(0, dtype=dtype)).dtype
+
+    x = np.random.normal(0, 1, (par.y_num, par.x_num, par.t_num)).astype(
+        dtype1
+    ) + par.imag * np.random.normal(0, 1, (par.y_num, par.x_num, par.t_num)).astype(
+        dtype1
+    )
 
     # fixed indeces
     iava = np.vstack((np.arange(0, 10), np.arange(0, 10)))
-    Iop = Bilinear(iava, dims=(par.y_num, par.x_num, par.t_num), dtype=par.dtype)
+    Iop = Bilinear(iava, dims=(par.y_num, par.x_num, par.t_num), dtype=dtype1)
     assert dottest(
         Iop,
         10 * par.t_num,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # decimal indeces
@@ -547,21 +599,20 @@ def test_Bilinear_3dsignal(par: InterpolationTestParameters):
             np.random.uniform(0, par.x_num - 1, Nsub),
         )
     )
-    Idecop = Bilinear(iavadec, dims=(par.y_num, par.x_num, par.t_num), dtype=par.dtype)
+    Idecop = Bilinear(iavadec, dims=(par.y_num, par.x_num, par.t_num), dtype=dtype1)
     assert dottest(
         Idecop,
         Nsub * par.t_num,
         par.y_num * par.x_num * par.t_num,
         complexflag=0 if par.imag == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
     # repeated indeces
     with pytest.raises(ValueError, match="repeated"):
         iava_rep = iava.copy()
         iava_rep[::, -1] = iava_rep[::, 0]
-        _, _ = Bilinear(
-            iava_rep, dims=(par.y_num, par.x_num, par.t_num), dtype=par.dtype
-        )
+        _, _ = Bilinear(iava_rep, dims=(par.y_num, par.x_num, par.t_num), dtype=dtype1)
 
     y = Iop * x.ravel()
     assert_array_almost_equal(y, x[iava[0], iava[1]].ravel())

--- a/pytests/test_interpolation_spline.py
+++ b/pytests/test_interpolation_spline.py
@@ -1,5 +1,5 @@
 from math import prod
-from typing import Final, Tuple
+from typing import Final
 
 import numpy as np
 import pytest

--- a/pytests/test_jaxoperator.py
+++ b/pytests/test_jaxoperator.py
@@ -40,6 +40,8 @@ def test_JaxOperator(par):
     # jax operator
     yjnp = Jop * xjnp
     xadjnp = Jop.rmatvecad(xjnp, yjnp)
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     assert_array_equal(y, np.array(yjnp))
     assert_array_equal(xadj, np.array(xadjnp))
@@ -63,5 +65,7 @@ def test_JaxOperator_batch(par):
 
     y = Mop.matmat(x.T).T
     yjnp = auto_batch_matvec(xjnp)
+    assert y.dtype == par["dtype"]
+    assert yjnp.dtype == par["dtype"]
 
     assert_array_almost_equal(y, np.array(yjnp), decimal=5)

--- a/pytests/test_kirchhoff.py
+++ b/pytests/test_kirchhoff.py
@@ -220,16 +220,19 @@ def test_traveltime_table():
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par1d), (par2d), (par3d)])
-def test_kirchhoff2d(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_kirchhoff2d(par, dtype):
     """Dot-test for Kirchhoff operator"""
     if backend == "cupy" and par["mode"] == "byot":
         pytest.skip("cuda engine not available for single trav table")
-    vel = v0 * np.ones((PAR["nx"], PAR["nz"]))
+    vel = v0 * np.ones((PAR["nx"], PAR["nz"]), dtype=dtype)
 
     if par["mode"] == "byot":
         trav_srcs, trav_recs, _, _, _, _ = Kirchhoff._traveltime_table(
             z, x, s2d, r2d, v0, mode="analytic"
         )
+        trav_srcs = trav_srcs.astype(dtype)
+        trav_recs = trav_recs.astype(dtype)
         trav = trav_srcs.reshape(
             PAR["nx"] * PAR["nz"], PAR["nsx"], 1
         ) + trav_recs.reshape(PAR["nx"] * PAR["nz"], 1, PAR["nrx"])
@@ -241,19 +244,20 @@ def test_kirchhoff2d(par):
 
     if skfmm_enabled or par["mode"] != "eikonal":
         Dop = Kirchhoff(
-            z,
-            x,
-            t,
-            s2d,
-            r2d,
+            z.astype(dtype),
+            x.astype(dtype),
+            t.astype(dtype),
+            s2d.astype(dtype),
+            r2d.astype(dtype),
             vel if par["mode"] == "eikonal" else v0,
-            np.asarray(wav),
+            np.asarray(wav.astype(dtype)),
             wavc,
             y=None,
             trav=trav,
             amp=amp,
             mode=par["mode"],
             engine="numpy" if backend == "numpy" else "cuda",
+            dtype=dtype,
         )
         if par["mode"] == "byot":
             Dop.trav = np.asarray(Dop.trav)
@@ -269,20 +273,30 @@ def test_kirchhoff2d(par):
             PAR["nsx"] * PAR["nrx"] * PAR["nt"],
             PAR["nz"] * PAR["nx"],
             backend=backend,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
         )
+
+        xx = np.random.normal(0, 1, PAR["nx"] * PAR["nz"]).astype(dtype)
+        yy = Dop * xx
+        xadj = Dop.H * yy
+        assert yy.dtype == dtype
+        assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3)])
-def test_kirchhoff3d(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_kirchhoff3d(par, dtype):
     """Dot-test for Kirchhoff operator"""
     if backend == "cupy" and par["mode"] == "byot":
         pytest.skip("cuda engine not available for single trav table")
-    vel = v0 * np.ones((PAR["ny"], PAR["nx"], PAR["nz"]))
+    vel = v0 * np.ones((PAR["ny"], PAR["nx"], PAR["nz"]), dtype=dtype)
 
     if par["mode"] == "byot":
         trav_srcs, trav_recs, _, _, _, _ = Kirchhoff._traveltime_table(
             z, x, s3d, r3d, v0, y=y, mode="analytic"
         )
+        trav_srcs = trav_srcs.astype(dtype)
+        trav_recs = trav_recs.astype(dtype)
         trav = trav_srcs.reshape(
             PAR["ny"] * PAR["nx"] * PAR["nz"], PAR["nsy"] * PAR["nsx"], 1
         ) + trav_recs.reshape(
@@ -297,18 +311,19 @@ def test_kirchhoff3d(par):
 
     if skfmm_enabled or par["mode"] != "eikonal":
         Dop = Kirchhoff(
-            z,
-            x,
-            t,
-            s3d,
-            r3d,
+            z.astype(dtype),
+            x.astype(dtype),
+            t.astype(dtype),
+            s3d.astype(dtype),
+            r3d.astype(dtype),
             vel if par["mode"] == "eikonal" else v0,
-            wav,
+            np.asarray(wav.astype(dtype)),
             wavc,
-            y=y,
+            y=y.astype(dtype),
             trav=trav,
             mode=par["mode"],
             engine="numpy" if backend == "numpy" else "cuda",
+            dtype=dtype,
         )
         if par["mode"] == "byot":
             Dop.trav = np.asarray(Dop.trav)
@@ -321,7 +336,14 @@ def test_kirchhoff3d(par):
             PAR["nsx"] * PAR["nrx"] * PAR["nsy"] * PAR["nry"] * PAR["nt"],
             PAR["nz"] * PAR["nx"] * PAR["ny"],
             backend=backend,
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
         )
+
+        xx = np.random.normal(0, 1, PAR["ny"] * PAR["nx"] * PAR["nz"]).astype(dtype)
+        yy = Dop * xx
+        xadj = Dop.H * yy
+        assert yy.dtype == dtype
+        assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize(

--- a/pytests/test_kronecker.py
+++ b/pytests/test_kronecker.py
@@ -16,19 +16,34 @@ from pylops.basicoperators import FirstDerivative, Identity, Kronecker, MatrixMu
 from pylops.optimization.basic import lsqr
 from pylops.utils import dottest
 
-par1 = {"ny": 11, "nx": 11, "imag": 0, "dtype": "float64"}  # square real
-par2 = {"ny": 21, "nx": 11, "imag": 0, "dtype": "float64"}  # overdetermined real
+par1 = {"ny": 11, "nx": 11, "imag": 0, "dtype": "float64"}  # square real (fp64)
+par2 = {"ny": 21, "nx": 11, "imag": 0, "dtype": "float64"}  # overdetermined real (fp64)
+par1s = {"ny": 11, "nx": 11, "imag": 0, "dtype": "float32"}  # square real (fp32)
+par2s = {
+    "ny": 21,
+    "nx": 11,
+    "imag": 0,
+    "dtype": "float32",
+}  # overdetermined real (fp32)
 par1j = {"ny": 11, "nx": 11, "imag": 1j, "dtype": "complex128"}  # square imag
 par2j = {"ny": 21, "nx": 11, "imag": 1j, "dtype": "complex128"}  # overdetermined imag
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_Kroneker(par):
     """Dot-test, inversion and comparison with np.kron for Kronecker operator"""
     np.random.seed(10)
-    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(par["dtype"])
-    x = np.ones(par["nx"] ** 2) + par["imag"] * np.ones(par["nx"] ** 2)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    G1 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    G2 = np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype) + par[
+        "imag"
+    ] * np.random.normal(0, 10, (par["ny"], par["nx"])).astype(dtype)
+    x = np.ones(par["nx"] ** 2, dtype=dtype) + par["imag"] * np.ones(
+        par["nx"] ** 2, dtype=dtype
+    )
 
     Kop = Kronecker(
         MatrixMult(G1, dtype=par["dtype"]),
@@ -42,6 +57,10 @@ def test_Kroneker(par):
         complexflag=0 if par["imag"] == 0 else 3,
         backend=backend,
     )
+    y = Kop * x
+    xadj = Kop.H * y
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
 
     if backend == "numpy":  # cupy is not accurate enough for square systems
         xlsqr = lsqr(
@@ -49,7 +68,7 @@ def test_Kroneker(par):
             Kop * x,
             x0=np.zeros_like(x),
             damp=1e-20,
-            niter=300,
+            niter=1000,
             atol=0,
             btol=0,
             conlim=np.inf,
@@ -61,23 +80,25 @@ def test_Kroneker(par):
     assert_array_almost_equal(np.kron(G1, G2), Kop * np.eye(par["nx"] ** 2), decimal=3)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s)])
 def test_Kroneker_Derivative(par):
     """Use Kronecker operator to apply the Derivative operator over one axis
     and compare with FirstDerivative(... axis=axis)
     """
-    Dop = FirstDerivative(par["ny"], sampling=1, edge=True, dtype="float32")
+    Dop = FirstDerivative(par["ny"], sampling=1, edge=True, dtype=par["dtype"])
     D2op = FirstDerivative(
-        (par["ny"], par["nx"]), axis=0, sampling=1, edge=True, dtype="float32"
+        (par["ny"], par["nx"]), axis=0, sampling=1, edge=True, dtype=par["dtype"]
     )
 
     Kop = Kronecker(Dop, Identity(par["nx"], dtype=par["dtype"]), dtype=par["dtype"])
 
-    x = np.zeros((par["ny"], par["nx"])) + par["imag"] * np.zeros(
-        (par["ny"], par["nx"])
-    )
+    x = np.zeros((par["ny"], par["nx"]), dtype=par["dtype"])
     x[par["ny"] // 2, par["nx"] // 2] = 1
 
-    y = D2op * x.ravel()
     yk = Kop * x.ravel()
+    xadjk = Kop.H * yk
+    assert yk.dtype == par["dtype"]
+    assert xadjk.dtype == par["dtype"]
+
+    y = D2op * x.ravel()
     assert_array_equal(y, yk)

--- a/pytests/test_kronecker.py
+++ b/pytests/test_kronecker.py
@@ -55,6 +55,7 @@ def test_Kroneker(par):
         par["ny"] ** 2,
         par["nx"] ** 2,
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Kop * x

--- a/pytests/test_marchenko.py
+++ b/pytests/test_marchenko.py
@@ -97,54 +97,82 @@ par4 = {"niter": 10, "prescaled": False, "fftengine": "fftw", "kwargs_fft": None
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_Marchenko_freq(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Marchenko_freq(par, dtype):
     """Solve marchenko equations using input Rs in frequency domain"""
+    dtypec = (np.empty(0, dtype=dtype) + 1j * np.empty(0, dtype=dtype)).dtype
+
     if par["prescaled"]:
         Rtwosided_fft_sc = np.sqrt(2 * nt - 1) * dt * dr * np.asarray(Rtwosided_fft)
     else:
         Rtwosided_fft_sc = np.asarray(Rtwosided_fft)
+    Rtwosided_fft_sc = Rtwosided_fft_sc.astype(dtypec)
+
     MarchenkoWM = Marchenko(
         Rtwosided_fft_sc,
         nt=nt,
         dt=dt,
         dr=dr,
         nfmax=nfmax,
-        wav=wav,
+        wav=wav.astype(dtype),
         toff=toff,
         nsmooth=nsmooth,
         prescaled=par["prescaled"],
         fftengine=par["fftengine"] if backend == "numpy" else "numpy",
         kwargs_fft=par["kwargs_fft"] if backend == "numpy" else None,
+        dtype=dtype,
     )
 
     solver_dict = (
         dict(iter_lim=par["niter"]) if backend == "numpy" else dict(niter=par["niter"])
     )
-    _, _, _, g_inv_minus, g_inv_plus = MarchenkoWM.apply_onepoint(
-        trav, G0=np.asarray(g0sub).T, rtm=True, greens=True, dottest=True, **solver_dict
+    _, _, p0_minus, g_inv_minus, g_inv_plus = MarchenkoWM.apply_onepoint(
+        trav.astype(dtype),
+        G0=np.asarray(g0sub.astype(dtype)).T,
+        rtm=True,
+        greens=True,
+        dottest=True if dtype == np.float64 else False,
+        **solver_dict,
     )
     ginvsub = (g_inv_minus + g_inv_plus)[:, nt - 1 :].T
     ginvsub_norm = ginvsub / ginvsub.max()
     gsub_norm = np.asarray(gsub / gsub.max())
+    assert p0_minus.dtype == dtype
+    assert ginvsub.dtype == dtype
     assert np.linalg.norm(gsub_norm - ginvsub_norm) / np.linalg.norm(gsub_norm) < 1e-1
 
 
 @pytest.mark.parametrize("par", [(par1)])
-def test_Marchenko_time(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Marchenko_time(par, dtype):
     """Solve marchenko equations using input Rs in time domain"""
     MarchenkoWM = Marchenko(
-        np.asarray(R), dt=dt, dr=dr, nfmax=nfmax, wav=wav, toff=toff, nsmooth=nsmooth
+        np.asarray(R.astype(dtype)),
+        dt=dt,
+        dr=dr,
+        nfmax=nfmax,
+        wav=wav.astype(dtype),
+        toff=toff,
+        nsmooth=nsmooth,
+        dtype=dtype,
     )
 
     solver_dict = (
         dict(iter_lim=par["niter"]) if backend == "numpy" else dict(niter=par["niter"])
     )
-    _, _, _, g_inv_minus, g_inv_plus = MarchenkoWM.apply_onepoint(
-        trav, G0=np.asarray(g0sub).T, rtm=True, greens=True, dottest=True, **solver_dict
+    _, _, p0_minus, g_inv_minus, g_inv_plus = MarchenkoWM.apply_onepoint(
+        trav.astype(dtype),
+        G0=np.asarray(g0sub.astype(dtype)).T,
+        rtm=True,
+        greens=True,
+        dottest=True if dtype == np.float64 else False,
+        **solver_dict,
     )
     ginvsub = (g_inv_minus + g_inv_plus)[:, nt - 1 :].T
     ginvsub_norm = ginvsub / ginvsub.max()
     gsub_norm = np.asarray(gsub / gsub.max())
+    assert p0_minus.dtype == dtype
+    assert ginvsub.dtype == dtype
     assert np.linalg.norm(gsub_norm - ginvsub_norm) / np.linalg.norm(gsub_norm) < 1e-1
 
 
@@ -170,21 +198,36 @@ def test_Marchenko_time_ana(par):
 
 
 @pytest.mark.parametrize("par", [(par1)])
-def test_Marchenko_timemulti_ana(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Marchenko_timemulti_ana(par, dtype):
     """Solve marchenko equations using input Rs in time domain with multiple
     points
     """
     MarchenkoWM = Marchenko(
-        np.asarray(R), dt=dt, dr=dr, nfmax=nfmax, wav=wav, toff=toff, nsmooth=nsmooth
+        np.asarray(R.astype(dtype)),
+        dt=dt,
+        dr=dr,
+        nfmax=nfmax,
+        wav=wav.astype(dtype),
+        toff=toff,
+        nsmooth=nsmooth,
+        dtype=dtype,
     )
 
     solver_dict = (
         dict(iter_lim=par["niter"]) if backend == "numpy" else dict(niter=par["niter"])
     )
-    _, _, g_inv_minus, g_inv_plus = MarchenkoWM.apply_multiplepoints(
-        trav_multi, nfft=2**11, rtm=False, greens=True, dottest=True, **solver_dict
+    _, _, p0_minus, g_inv_minus, g_inv_plus = MarchenkoWM.apply_multiplepoints(
+        trav_multi.astype(dtype),
+        nfft=2**11,
+        rtm=True,
+        greens=True,
+        dottest=True if dtype == np.float64 else False,
+        **solver_dict,
     )
     ginvsub = (g_inv_minus + g_inv_plus)[:, 1, nt - 1 :].T
     ginvsub_norm = ginvsub / ginvsub.max()
     gsub_norm = np.asarray(gsub / gsub.max())
+    assert p0_minus.dtype == dtype
+    assert ginvsub.dtype == dtype
     assert np.linalg.norm(gsub_norm - ginvsub_norm) / np.linalg.norm(gsub_norm) < 1e-1

--- a/pytests/test_mri.py
+++ b/pytests/test_mri.py
@@ -9,37 +9,31 @@ from pylops.utils import dottest, mkl_fft_enabled
 par1 = {
     "ny": 32,
     "nx": 64,
-    "dtype": "complex128",
     "fft_engine": "numpy",
 }  # even input, numpy engine
 par2 = {
     "ny": 32,
     "nx": 64,
-    "dtype": "complex128",
     "fft_engine": "scipy",
 }  # even input, scipy engine
 par3 = {
     "ny": 32,
     "nx": 64,
-    "dtype": "complex128",
     "fft_engine": "mkl_fft",
 }  # even input, mkl_fft engine
 par4 = {
     "ny": 33,
     "nx": 65,
-    "dtype": "complex128",
     "fft_engine": "numpy",
 }  # odd input, numpy engine
 par5 = {
     "ny": 33,
     "nx": 65,
-    "dtype": "complex128",
     "fft_engine": "scipy",
 }  # even input, scipy engine
 par6 = {
     "ny": 33,
     "nx": 65,
-    "dtype": "complex128",
     "fft_engine": "mkl_fft",
 }  # odd input, mkl_fft engine
 
@@ -108,36 +102,41 @@ def test_MRI2D_invalid_fft_engine():
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_MRI2D_mask_array(par):
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_MRI2D_mask_array(par, dtype):
     """Dot-test and forward/adjoint for MRI2D operator with numpy array mask"""
     if par["fft_engine"] == "mkl_fft" and not mkl_fft_enabled:
         pytest.skip("mkl_fft is not installed")
     np.random.seed(10)
+    rdtype = np.empty(0, dtype=dtype).real.dtype
 
     # Create a random mask
     mask = np.zeros((par["ny"], par["nx"]), dtype=bool)
     nselected = int(par["ny"] * par["nx"] * 0.3)
     indices = np.random.choice(par["ny"] * par["nx"], nselected, replace=False)
     mask.flat[indices] = True
-    mask = mask.astype(par["dtype"])
+    mask = mask.astype(dtype)
 
     Mop = MRI2D(
         dims=(par["ny"], par["nx"]),
         mask=mask,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=dtype,
     )
     assert dottest(
         Mop,
         par["ny"] * par["nx"],
         par["ny"] * par["nx"],
         complexflag=2,
+        rtol=1e-4 if dtype == np.complex64 else 1e-6,
     )
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"]))
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(rdtype)
     y = Mop * x.ravel()
     xadj = Mop.H * y
 
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert y.shape[0] == par["ny"] * par["nx"]
     assert xadj.shape[0] == par["ny"] * par["nx"]
 
@@ -146,11 +145,13 @@ def test_MRI2D_mask_array(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_MRI2D_vertical_reg(par):
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_MRI2D_vertical_reg(par, dtype):
     """Dot-test and forward/adjoint for MRI2D operator with vertical-reg mask"""
     if par["fft_engine"] == "mkl_fft" and not mkl_fft_enabled:
         pytest.skip("mkl_fft is not installed")
     np.random.seed(10)
+    rdtype = np.empty(0, dtype=dtype).real.dtype
 
     nlines = 16
     Mop = MRI2D(
@@ -159,7 +160,7 @@ def test_MRI2D_vertical_reg(par):
         nlines=nlines,
         perc_center=0.0,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=dtype,
     )
     assert len(Mop.mask) == nlines
     assert dottest(
@@ -167,12 +168,15 @@ def test_MRI2D_vertical_reg(par):
         par["ny"] * nlines,
         par["ny"] * par["nx"],
         complexflag=2,
+        rtol=1e-4 if dtype == np.complex64 else 1e-6,
     )
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"]))
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(rdtype)
     y = Mop * x.ravel()
     xadj = Mop.H * y
 
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert y.shape[0] == par["ny"] * nlines
     assert xadj.shape[0] == par["ny"] * par["nx"]
 
@@ -194,7 +198,7 @@ def test_MRI2D_vertical_mask_regularity(par):
         nlines=nlines,
         perc_center=0.0,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=np.complex128,
     )
     mask_indices = Mop.mask
 
@@ -209,11 +213,13 @@ def test_MRI2D_vertical_mask_regularity(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_MRI2D_vertical_uni(par):
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_MRI2D_vertical_uni(par, dtype):
     """Dot-test and forward/adjoint for MRI2D operator with vertical-uni mask"""
     if par["fft_engine"] == "mkl_fft" and not mkl_fft_enabled:
         pytest.skip("mkl_fft is not installed")
     np.random.seed(10)
+    rdtype = np.empty(0, dtype=dtype).real.dtype
 
     nlines = 16
     perc_center = 0.1
@@ -223,7 +229,7 @@ def test_MRI2D_vertical_uni(par):
         nlines=nlines,
         perc_center=perc_center,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=dtype,
     )
     nlines_total = nlines + int(perc_center * par["nx"])
     assert len(Mop.mask) == nlines_total
@@ -232,12 +238,15 @@ def test_MRI2D_vertical_uni(par):
         par["ny"] * (nlines + int(perc_center * par["nx"])),
         par["ny"] * par["nx"],
         complexflag=2,
+        rtol=1e-4 if dtype == np.complex64 else 1e-6,
     )
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"]))
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(rdtype)
     y = Mop * x.ravel()
     xadj = Mop.H * y
 
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert y.shape[0] == par["ny"] * nlines_total
     assert xadj.shape[0] == par["ny"] * par["nx"]
 
@@ -246,11 +255,13 @@ def test_MRI2D_vertical_uni(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_MRI2D_vertical_uni_no_center(par):
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_MRI2D_vertical_uni_no_center(par, dtype):
     """Test MRI2D operator with vertical mask and no center lines"""
     if par["fft_engine"] == "mkl_fft" and not mkl_fft_enabled:
         pytest.skip("mkl_fft is not installed")
     np.random.seed(10)
+    rdtype = np.empty(0, dtype=dtype).real.dtype
 
     nlines = 16
     Mop = MRI2D(
@@ -259,7 +270,7 @@ def test_MRI2D_vertical_uni_no_center(par):
         nlines=nlines,
         perc_center=0.0,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=dtype,
     )
 
     assert dottest(
@@ -267,13 +278,16 @@ def test_MRI2D_vertical_uni_no_center(par):
         par["ny"] * nlines,
         par["ny"] * par["nx"],
         complexflag=2,
+        rtol=1e-4 if dtype == np.complex64 else 1e-6,
     )
     assert len(Mop.mask) == nlines
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"]))
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(rdtype)
     y = Mop * x.ravel()
     xadj = Mop.H * y
 
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert y.shape[0] == par["ny"] * nlines
     assert xadj.shape[0] == par["ny"] * par["nx"]
 
@@ -282,11 +296,13 @@ def test_MRI2D_vertical_uni_no_center(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_MRI2D_radial_reg(par):
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_MRI2D_radial_reg(par, dtype):
     """Dot-test and forward/adjoint for MRI2D operator with radial-reg mask"""
     if par["fft_engine"] == "mkl_fft" and not mkl_fft_enabled:
         pytest.skip("mkl_fft is not installed")
     np.random.seed(10)
+    rdtype = np.empty(0, dtype=dtype).real.dtype
 
     nlines = 8
     Mop = MRI2D(
@@ -294,7 +310,7 @@ def test_MRI2D_radial_reg(par):
         mask="radial-reg",
         nlines=nlines,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=dtype,
     )
 
     # For radial masks, output size depends on the number of points in the mask
@@ -304,13 +320,16 @@ def test_MRI2D_radial_reg(par):
         npoints,
         par["ny"] * par["nx"],
         complexflag=2,
+        rtol=1e-4 if dtype == np.complex64 else 1e-6,
     )
     assert Mop.mask.shape[0] == 2  # x and y coordinates
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"]))
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(rdtype)
     y = Mop * x
     xadj = Mop.H * y
 
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert y.size == npoints
     assert xadj.shape == (par["ny"], par["nx"])
 
@@ -319,11 +338,13 @@ def test_MRI2D_radial_reg(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_MRI2D_radial_uni(par):
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_MRI2D_radial_uni(par, dtype):
     """Dot-test and forward/adjoint for MRI2D operator with radial-uni mask"""
     if par["fft_engine"] == "mkl_fft" and not mkl_fft_enabled:
         pytest.skip("mkl_fft is not installed")
     np.random.seed(10)
+    rdtype = np.empty(0, dtype=dtype).real.dtype
 
     nlines = 8
     Mop = MRI2D(
@@ -331,7 +352,7 @@ def test_MRI2D_radial_uni(par):
         mask="radial-uni",
         nlines=nlines,
         fft_engine=par["fft_engine"],
-        dtype=par["dtype"],
+        dtype=dtype,
     )
 
     # For radial masks, output size depends on the number of points in the mask
@@ -341,12 +362,15 @@ def test_MRI2D_radial_uni(par):
         npoints,
         par["ny"] * par["nx"],
         complexflag=2,
+        rtol=1e-4 if dtype == np.complex64 else 1e-6,
     )
     assert Mop.mask.shape[0] == 2  # x and y coordinates
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"]))
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(rdtype)
     y = Mop * x
     xadj = Mop.H * y
 
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert y.size == npoints
     assert xadj.shape == (par["ny"], par["nx"])

--- a/pytests/test_nonstatconvolve.py
+++ b/pytests/test_nonstatconvolve.py
@@ -175,23 +175,32 @@ def test_unknown_engine_2d(par):
 
 
 @pytest.mark.parametrize("par", [(par1_1d), (par2_1d)])
-def test_NonStationaryConvolve1D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_NonStationaryConvolve1D(par, dtype):
     """Dot-test and inversion for NonStationaryConvolve1D operator"""
     # 1D
     if par["axis"] == 0:
         Cop = NonStationaryConvolve1D(
             dims=par["nx"],
-            hs=h1ns,
+            hs=h1ns.astype(dtype),
             ih=(int(par["nx"] // 4), int(2 * par["nx"] // 4), int(3 * par["nx"] // 4)),
-            dtype="float64",
+            dtype=dtype,
         )
-        assert dottest(Cop, par["nx"], par["nx"], backend=backend)
+        assert dottest(
+            Cop,
+            par["nx"],
+            par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
-        x = np.zeros(par["nx"])
+        x = np.zeros(par["nx"], dtype=dtype)
         x[par["nx"] // 2] = 1.0
+        y = Cop * x
+        xadj = Cop.H * y
         xlsqr = lsqr(
             Cop,
-            Cop * x,
+            y,
             x0=np.zeros_like(x),
             damp=1e-20,
             niter=200,
@@ -199,28 +208,39 @@ def test_NonStationaryConvolve1D(par):
             btol=1e-8,
             show=0,
         )[0]
+
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(x, xlsqr, decimal=1)
 
     # 1D on 2D
     nfilt = par["nx"] if par["axis"] == 0 else par["nz"]
     Cop = NonStationaryConvolve1D(
         dims=(par["nx"], par["nz"]),
-        hs=h1ns,
+        hs=h1ns.astype(dtype),
         ih=(int(nfilt // 4), int(2 * nfilt // 4), int(3 * nfilt // 4)),
         axis=par["axis"],
-        dtype="float64",
+        dtype=dtype,
     )
-    assert dottest(Cop, par["nx"] * par["nz"], par["nx"] * par["nz"], backend=backend)
+    assert dottest(
+        Cop,
+        par["nx"] * par["nz"],
+        par["nx"] * par["nz"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    x = np.zeros((par["nx"], par["nz"]))
+    x = np.zeros((par["nx"], par["nz"]), dtype=dtype)
     x[
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
         int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
     ] = 1.0
     x = x.ravel()
+    y = Cop * x
+    xadj = Cop.H * y
     xlsqr = lsqr(
         Cop,
-        Cop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=400,
@@ -228,6 +248,9 @@ def test_NonStationaryConvolve1D(par):
         btol=1e-8,
         show=0,
     )[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert_array_almost_equal(x, xlsqr, decimal=1)
 
 
@@ -254,34 +277,46 @@ def test_StationaryConvolve1D(par):
 
 
 @pytest.mark.parametrize("par", [(par_2d)])
-def test_NonStationaryConvolve2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_NonStationaryConvolve2D(par, dtype):
     """Dot-test and inversion for NonStationaryConvolve2D operator"""
     Cop = NonStationaryConvolve2D(
         dims=(par["nx"], par["nz"]),
-        hs=h2ns,
+        hs=h2ns.astype(dtype),
         ihx=(int(par["nx"] // 4), int(2 * par["nx"] // 4), int(3 * par["nx"] // 4)),
         ihz=(int(par["nz"] // 4), int(3 * par["nz"] // 4)),
         engine="numpy" if backend == "numpy" else "cuda",
-        dtype="float64",
+        dtype=dtype,
     )
-    assert dottest(Cop, par["nx"] * par["nz"], par["nx"] * par["nz"], backend=backend)
+    assert dottest(
+        Cop,
+        par["nx"] * par["nz"],
+        par["nx"] * par["nz"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    x = np.zeros((par["nx"], par["nz"]))
+    x = np.zeros((par["nx"], par["nz"]), dtype=dtype)
     x[
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
         int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
     ] = 1.0
     x = x.ravel()
+    y = Cop * x
+    xadj = Cop.H * y
     xlsqr = lsqr(
         Cop,
-        Cop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
-        niter=300,
+        niter=400,
         atol=1e-8,
         btol=1e-8,
         show=0,
     )[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert_array_almost_equal(x, xlsqr, decimal=1)
 
 
@@ -314,21 +349,30 @@ def test_StationaryConvolve2D(par):
         (par1_1d),
     ],
 )
-def test_NonStationaryFilters1D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_NonStationaryFilters1D(par, dtype):
     """Dot-test and inversion for NonStationaryFilters2D operator"""
-    x = np.zeros(par["nx"])
+    x = np.zeros(par["nx"], dtype=dtype)
     x[par["nx"] // 4], x[par["nx"] // 2], x[3 * par["nx"] // 4] = 1.0, 1.0, 1.0
     Cop = NonStationaryFilters1D(
         inp=x,
         hsize=nfilts[0],
         ih=(int(par["nx"] // 4), int(2 * par["nx"] // 4), int(3 * par["nx"] // 4)),
-        dtype="float64",
+        dtype=dtype,
     )
-    assert dottest(Cop, par["nx"], 3 * nfilts[0], backend=backend)
+    assert dottest(
+        Cop,
+        par["nx"],
+        3 * nfilts[0],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+    y = Cop * h1ns
+    h1adj = Cop.H * y
+    h1lsqr = lsqr(Cop, y, x0=np.zeros_like(h1ns), damp=1e-20, niter=200, show=0)[0]
 
-    h1lsqr = lsqr(
-        Cop, Cop * h1ns, x0=np.zeros_like(h1ns), damp=1e-20, niter=200, show=0
-    )[0]
+    assert y.dtype == dtype
+    assert h1adj.dtype == dtype
     assert_array_almost_equal(h1ns, h1lsqr, decimal=1)
 
 
@@ -336,9 +380,10 @@ def test_NonStationaryFilters1D(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par_2d)])
-def test_NonStationaryFilters2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_NonStationaryFilters2D(par, dtype):
     """Dot-test and inversion for NonStationaryFilters2D operator"""
-    x = np.zeros((par["nx"], par["nz"]))
+    x = np.zeros((par["nx"], par["nz"]), dtype=dtype)
     x[int(par["nx"] // 4)] = 1.0
     x[int(par["nx"] // 2)] = 1.0
     x[int(3 * par["nx"] // 4)] = 1.0
@@ -348,49 +393,62 @@ def test_NonStationaryFilters2D(par):
         hshape=nfilts,
         ihx=(int(par["nx"] // 4), int(2 * par["nx"] // 4), int(3 * par["nx"] // 4)),
         ihz=(int(par["nz"] // 4), int(3 * par["nz"] // 4)),
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
-        Cop, par["nx"] * par["nz"], 6 * nfilts[0] * nfilts[1], backend=backend
+        Cop,
+        par["nx"] * par["nz"],
+        6 * nfilts[0] * nfilts[1],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
 
+    y = Cop * h2ns.astype(dtype).ravel()
+    h2adj = Cop.H * y
     h2lsqr = lsqr(
         Cop,
-        Cop * h2ns.ravel(),
+        y,
         x0=np.zeros_like(h2ns).ravel(),
         damp=1e-20,
         niter=400,
         show=0,
     )[0]
+
+    assert y.dtype == dtype
+    assert h2adj.dtype == dtype
     assert_array_almost_equal(h2ns.ravel(), h2lsqr, decimal=1)
 
 
 @pytest.mark.parametrize("par", [(par_2d)])
-def test_NonStationaryConvolve3D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_NonStationaryConvolve3D(par, dtype):
     """Dot-test and inversion for NonStationaryConvolve3D operator"""
     Cop = NonStationaryConvolve3D(
         dims=(par["nx"], par["nx"], par["nz"]),
-        hs=h3ns,
+        hs=h3ns.astype(dtype),
         ihx=(int(par["nx"] // 4), int(3 * par["nx"] // 4)),
         ihy=(int(par["nx"] // 4), int(3 * par["nx"] // 4)),
         ihz=(int(par["nz"] // 4), int(3 * par["nz"] // 4)),
         engine="numpy" if backend == "numpy" else "cuda",
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         Cop,
         par["nx"] * par["nx"] * par["nz"],
         par["nx"] * par["nx"] * par["nz"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    x = np.zeros((par["nx"], par["nx"], par["nz"]))
+    x = np.zeros((par["nx"], par["nx"], par["nz"]), dtype=dtype)
     x[
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
         int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
         int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
     ] = 1.0
     x = x.ravel()
+    y = Cop * x
+    xadj = Cop.H * y
     xlsqr = lsqr(
         Cop,
         Cop * x,
@@ -401,6 +459,9 @@ def test_NonStationaryConvolve3D(par):
         btol=1e-8,
         show=0,
     )[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     # given the size of the problem, we can only run few iterations and test accuracy up to 30%
     assert np.linalg.norm(x - xlsqr) / np.linalg.norm(x) < 0.3
 

--- a/pytests/test_oneway.py
+++ b/pytests/test_oneway.py
@@ -38,7 +38,6 @@ par1 = {
     "nx": 10,
     "nt": 20,
     "kind": "p",
-    "dtype": "float32",
     "fftengine": "numpy",
     "kwargs_fft": {},
 }  # even, p, numpy
@@ -47,7 +46,6 @@ par2 = {
     "nx": 11,
     "nt": 21,
     "kind": "p",
-    "dtype": "float32",
     "fftengine": "numpy",
     "kwargs_fft": {},
 }  # odd, p, numpy
@@ -56,7 +54,6 @@ par1s = {
     "nx": 10,
     "nt": 20,
     "kind": "p",
-    "dtype": "float32",
     "fftengine": "scipy",
     "kwargs_fft": dict(workers=4),
 }  # even, p, scipy
@@ -65,7 +62,6 @@ par1w = {
     "nx": 10,
     "nt": 20,
     "kind": "p",
-    "dtype": "float32",
     "fftengine": "fft",
     "kwargs_fft": {},
 }  # even, p, fftw
@@ -74,14 +70,12 @@ par1v = {
     "nx": 10,
     "nt": 20,
     "kind": "vz",
-    "dtype": "float32",
 }  # even, vz, numpy
 par2v = {
     "ny": 9,
     "nx": 11,
     "nt": 21,
     "kind": "vz",
-    "dtype": "float32",
 }  # odd, vz, numpy
 
 # deghosting params
@@ -116,7 +110,8 @@ def create_data2D(datakind):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par1w)])
-def test_PhaseShift_2dsignal(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PhaseShift_2dsignal(par, dtype):
     """Dot-test for PhaseShift of 2d signal"""
     vel = 1500.0
     zprop = 200
@@ -131,16 +126,27 @@ def test_PhaseShift_2dsignal(par):
         freq,
         kx,
         fftengine=par["fftengine"] if backend == "numpy" else "numpy",
-        dtype=par["dtype"],
+        dtype=dtype,
         **kwargs_fft,
     )
     assert dottest(
-        Pop, par["nt"] * par["nx"], par["nt"] * par["nx"], rtol=1e-3, backend=backend
+        Pop,
+        par["nt"] * par["nx"],
+        par["nt"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
+
+    x = np.ones((par["nt"], par["nx"]), dtype=dtype)
+    y = Pop * x.ravel()
+    xadj = Pop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_PhaseShift_3dsignal(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PhaseShift_3dsignal(par, dtype):
     """Dot-test for PhaseShift of 3d signal"""
     vel = 1500.0
     zprop = 200
@@ -148,14 +154,20 @@ def test_PhaseShift_3dsignal(par):
     kx = np.fft.fftshift(np.fft.fftfreq(par["nx"], 1.0))
     ky = np.fft.fftshift(np.fft.fftfreq(par["ny"], 1.0))
 
-    Pop = PhaseShift(vel, zprop, par["nt"], freq, kx, ky, dtype=par["dtype"])
+    Pop = PhaseShift(vel, zprop, par["nt"], freq, kx, ky, dtype=dtype)
     assert dottest(
         Pop,
         par["nt"] * par["nx"] * par["ny"],
         par["nt"] * par["nx"] * par["ny"],
-        rtol=1e-3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    x = np.ones((par["nt"], par["nx"], par["ny"]), dtype=dtype)
+    y = Pop * x.ravel()
+    xadj = Pop.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par1v), (par2v)])
@@ -176,7 +188,7 @@ def test_Deghosting_2dsignal(par):
         npad=0,
         ntaper=0,
         solver=lsqr,
-        dtype=par["dtype"],
+        dtype=np.float32,
         **dict(damp=1e-10, niter=60),
     )
 

--- a/pytests/test_pad.py
+++ b/pytests/test_pad.py
@@ -15,8 +15,8 @@ import pytest
 from pylops.basicoperators import Pad
 from pylops.utils import dottest
 
-par1 = {"ny": 11, "nx": 11, "pad": ((0, 2), (4, 5)), "dtype": "float64"}  # square
-par2 = {"ny": 21, "nx": 11, "pad": ((3, 1), (0, 3)), "dtype": "float64"}  # rectangular
+par1 = {"ny": 11, "nx": 11, "pad": ((0, 2), (4, 5))}  # square
+par2 = {"ny": 21, "nx": 11, "pad": ((3, 1), (0, 3))}  # rectangular
 
 np.random.seed(10)
 
@@ -36,26 +36,46 @@ def test_Pad_2d_negative(par):
 
 
 @pytest.mark.parametrize("par", [(par1)])
-def test_Pad1d(par):
-    """Dot-test and adjoint for Pad operator on 1d signal"""
-    Pop = Pad(dims=par["ny"], pad=par["pad"][0], dtype=par["dtype"])
-    assert dottest(Pop, Pop.shape[0], Pop.shape[1], backend=backend)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Pad1d(par, dtype):
+    """Dot-test and forward/adjoint for Pad operator on 1d signal"""
+    Pop = Pad(dims=par["ny"], pad=par["pad"][0], dtype=dtype)
+    assert dottest(
+        Pop,
+        Pop.shape[0],
+        Pop.shape[1],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    x = np.arange(par["ny"], dtype=par["dtype"]) + 1.0
+    x = np.arange(par["ny"], dtype=dtype) + 1.0
     y = Pop * x
-    xinv = Pop.H * y
-    assert_array_equal(x, xinv)
+    xadj = Pop.H * y
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_equal(x, xadj)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_Pad2d(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Pad2d(par, dtype):
     """Dot-test and adjoint for Pad operator on 2d signal"""
-    Pop = Pad(dims=(par["ny"], par["nx"]), pad=par["pad"], dtype=par["dtype"])
-    assert dottest(Pop, Pop.shape[0], Pop.shape[1], backend=backend)
+    Pop = Pad(dims=(par["ny"], par["nx"]), pad=par["pad"], dtype=dtype)
+    assert dottest(
+        Pop,
+        Pop.shape[0],
+        Pop.shape[1],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    x = (np.arange(par["ny"] * par["nx"], dtype=par["dtype"]) + 1.0).reshape(
+    x = (np.arange(par["ny"] * par["nx"], dtype=dtype) + 1.0).reshape(
         par["ny"], par["nx"]
     )
     y = Pop * x.ravel()
     xadj = Pop.H * y
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
     assert_array_equal(x.ravel(), xadj)

--- a/pytests/test_patching.py
+++ b/pytests/test_patching.py
@@ -173,7 +173,7 @@ def test_Patch2D(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par4)])
@@ -217,7 +217,7 @@ def test_Patch2D_scalings(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par4)])
@@ -261,7 +261,7 @@ def test_Patch2D_singlepatch1(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -304,7 +304,7 @@ def test_Patch2D_singlepatch2(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -359,7 +359,7 @@ def test_Patch3D(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -411,7 +411,7 @@ def test_Patch3D_singlepatch1(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -463,7 +463,7 @@ def test_Patch3D_singlepatch2(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -518,7 +518,7 @@ def test_Patch3D_singlepatch12(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -569,4 +569,4 @@ def test_Patch3D_singlepatch3(par, dtype):
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)

--- a/pytests/test_patching.py
+++ b/pytests/test_patching.py
@@ -135,9 +135,13 @@ par6 = {
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch2D(par):
-    """Dot-test and inverse for Patch2D operator"""
-    Op = MatrixMult(np.ones((par["nwiny"] * par["nwint"], par["ny"] * par["nt"])))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch2D(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Patch2D operator"""
+    Op = MatrixMult(
+        np.ones((par["nwiny"] * par["nwint"], par["ny"] * par["nt"]), dtype=dtype),
+        dtype=dtype,
+    )
 
     nwins, dims, _, _ = patch2d_design(
         (par["npy"], par["npt"]),
@@ -159,20 +163,28 @@ def test_Patch2D(par):
         Pop,
         par["npy"] * par["npt"],
         par["ny"] * par["nt"] * nwins[0] * nwins[1],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["ny"] * nwins[0] * par["nt"] * nwins[1])
+    x = np.ones(par["ny"] * nwins[0] * par["nt"] * nwins[1], dtype=dtype)
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par4)])
-def test_Patch2D_scalings(par):
-    """Dot-test and inverse for Patch2D operator with scalings"""
-    Op = MatrixMult(np.ones((par["nwiny"] * par["nwint"], par["ny"] * par["nt"])))
-    scalings = np.arange(par["nwiny"] * par["nwint"]) + 1.0
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch2D_scalings(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Patch2D operator with scalings"""
+    Op = MatrixMult(
+        np.ones((par["nwiny"] * par["nwint"], par["ny"] * par["nt"]), dtype=dtype),
+        dtype=dtype,
+    )
+    scalings = np.arange(par["nwiny"] * par["nwint"], dtype=dtype) + 1.0
 
     nwins, dims, _, _ = patch2d_design(
         (par["npy"], par["npt"]),
@@ -195,19 +207,27 @@ def test_Patch2D_scalings(par):
         Pop,
         par["npy"] * par["npt"],
         par["ny"] * par["nt"] * nwins[0] * nwins[1],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["ny"] * nwins[0] * par["nt"] * nwins[1])
+    x = np.ones(par["ny"] * nwins[0] * par["nt"] * nwins[1], dtype=dtype)
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par4)])
-def test_Patch2D_singlepatch1(par):
-    """Dot-test and inverse for Patch2D operator with single patch in fist dimension"""
-    Op = MatrixMult(np.ones((par["npy"] * par["nwint"], par["npy"] * par["nt"])))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch2D_singlepatch1(par, dtype):
+    """Dot-test and inverse for Patch2D operator with single patch in first dimension"""
+    Op = MatrixMult(
+        np.ones((par["npy"] * par["nwint"], par["npy"] * par["nt"]), dtype=dtype),
+        dtype=dtype,
+    )
 
     nwins, dims, _, _ = patch2d_design(
         (par["npy"], par["npt"]),
@@ -231,19 +251,27 @@ def test_Patch2D_singlepatch1(par):
         Pop,
         par["npy"] * par["npt"],
         par["npy"] * par["nt"] * nwins[0] * nwins[1],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["npy"] * nwins[0] * par["nt"] * nwins[1])
+    x = np.ones(par["npy"] * nwins[0] * par["nt"] * nwins[1], dtype=dtype)
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch2D_singlepatch2(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch2D_singlepatch2(par, dtype):
     """Dot-test and inverse for Patch2D operator with single patch in second dimension"""
-    Op = MatrixMult(np.ones((par["nwiny"] * par["npt"], par["ny"] * par["npt"])))
+    Op = MatrixMult(
+        np.ones((par["nwiny"] * par["npt"], par["ny"] * par["npt"]), dtype=dtype),
+        dtype=dtype,
+    )
 
     nwins, dims, _, _ = patch2d_design(
         (par["npy"], par["npt"]),
@@ -266,25 +294,32 @@ def test_Patch2D_singlepatch2(par):
         Pop,
         par["npy"] * par["npt"],
         par["ny"] * par["npt"] * nwins[0] * nwins[1],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["ny"] * nwins[0] * par["npt"] * nwins[1])
+    x = np.ones(par["ny"] * nwins[0] * par["npt"] * nwins[1], dtype=dtype)
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch3D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch3D(par, dtype):
     """Dot-test and inverse for Patch3D operator"""
     Op = MatrixMult(
         np.ones(
             (
                 par["nwiny"] * par["nwinx"] * par["nwint"],
                 par["ny"] * par["nx"] * par["nt"],
-            )
-        )
+            ),
+            dtype=dtype,
+        ),
+        dtype=dtype,
     )
 
     nwins, dims, _, _ = patch3d_design(
@@ -312,25 +347,34 @@ def test_Patch3D(par):
         Pop,
         par["npy"] * par["npx"] * par["npt"],
         par["ny"] * par["nx"] * par["nt"] * nwins[0] * nwins[1] * nwins[2],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones((par["ny"] * nwins[0], par["nx"] * nwins[1], par["nt"] * nwins[2]))
+    x = np.ones(
+        (par["ny"] * nwins[0], par["nx"] * nwins[1], par["nt"] * nwins[2]), dtype=dtype
+    )
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch3D_singlepatch1(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch3D_singlepatch1(par, dtype):
     """Dot-test and inverse for Patch3D operator with single patch in fist dimension"""
     Op = MatrixMult(
         np.ones(
             (
                 par["npy"] * par["nwinx"] * par["nwint"],
                 par["npy"] * par["nx"] * par["nt"],
-            )
-        )
+            ),
+            dtype=dtype,
+        ),
+        dtype=dtype,
     )
 
     nwins, dims, _, _ = patch3d_design(
@@ -355,25 +399,34 @@ def test_Patch3D_singlepatch1(par):
         Pop,
         par["npy"] * par["npx"] * par["npt"],
         par["npy"] * par["nx"] * par["nt"] * nwins[0] * nwins[1] * nwins[2],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones((par["npy"] * nwins[0], par["nx"] * nwins[1], par["nt"] * nwins[2]))
+    x = np.ones(
+        (par["npy"] * nwins[0], par["nx"] * nwins[1], par["nt"] * nwins[2]), dtype=dtype
+    )
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch3D_singlepatch2(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch3D_singlepatch2(par, dtype):
     """Dot-test and inverse for Patch3D operator with single patch in second dimension"""
     Op = MatrixMult(
         np.ones(
             (
                 par["nwiny"] * par["npx"] * par["nwint"],
                 par["ny"] * par["npx"] * par["nt"],
-            )
-        )
+            ),
+            dtype=dtype,
+        ),
+        dtype=dtype,
     )
 
     nwins, dims, _, _ = patch3d_design(
@@ -398,17 +451,24 @@ def test_Patch3D_singlepatch2(par):
         Pop,
         par["npy"] * par["npx"] * par["npt"],
         par["ny"] * par["npx"] * par["nt"] * nwins[0] * nwins[1] * nwins[2],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones((par["ny"] * nwins[0], par["npx"] * nwins[1], par["nt"] * nwins[2]))
+    x = np.ones(
+        (par["ny"] * nwins[0], par["npx"] * nwins[1], par["nt"] * nwins[2]), dtype=dtype
+    )
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch3D_singlepatch12(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch3D_singlepatch12(par, dtype):
     """Dot-test and inverse for Patch3D operator with single patch in
     fist and second dimensions"""
     Op = MatrixMult(
@@ -416,8 +476,10 @@ def test_Patch3D_singlepatch12(par):
             (
                 par["npy"] * par["npx"] * par["nwint"],
                 par["npy"] * par["npx"] * par["nt"],
-            )
-        )
+            ),
+            dtype=dtype,
+        ),
+        dtype=dtype,
     )
 
     nwins, dims, _, _ = patch3d_design(
@@ -443,25 +505,35 @@ def test_Patch3D_singlepatch12(par):
         Pop,
         par["npy"] * par["npx"] * par["npt"],
         par["npy"] * par["npx"] * par["nt"] * nwins[0] * nwins[1] * nwins[2],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones((par["npy"] * nwins[0], par["npx"] * nwins[1], par["nt"] * nwins[2]))
+    x = np.ones(
+        (par["npy"] * nwins[0], par["npx"] * nwins[1], par["nt"] * nwins[2]),
+        dtype=dtype,
+    )
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Patch3D_singlepatch3(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Patch3D_singlepatch3(par, dtype):
     """Dot-test and inverse for Patch3D operator with single patch in third dimension"""
     Op = MatrixMult(
         np.ones(
             (
                 par["nwiny"] * par["nwinx"] * par["npt"],
                 par["ny"] * par["nx"] * par["npt"],
-            )
-        )
+            ),
+            dtype=dtype,
+        ),
+        dtype=dtype,
     )
 
     nwins, dims, _, _ = patch3d_design(
@@ -485,10 +557,16 @@ def test_Patch3D_singlepatch3(par):
         Pop,
         par["npy"] * par["npx"] * par["npt"],
         par["ny"] * par["nx"] * par["npt"] * nwins[0] * nwins[1] * nwins[2],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones((par["ny"] * nwins[0], par["nx"] * nwins[1], par["npt"] * nwins[2]))
+    x = np.ones(
+        (par["ny"] * nwins[0], par["nx"] * nwins[1], par["npt"] * nwins[2]), dtype=dtype
+    )
     y = Pop * x.ravel()
-
+    xadj = Pop.H * y
     xinv = Pop / y
-    assert_array_almost_equal(x.ravel(), xinv)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x.ravel(), xinv, decimal=4 if dtype == np.float32 else 8)

--- a/pytests/test_patching.py
+++ b/pytests/test_patching.py
@@ -13,6 +13,7 @@ else:
 import pytest
 
 from pylops.basicoperators import MatrixMult
+from pylops.optimization.basic import cgls
 from pylops.signalprocessing import Patch2D, Patch3D
 from pylops.signalprocessing.patch2d import patch2d_design
 from pylops.signalprocessing.patch3d import patch3d_design
@@ -166,14 +167,14 @@ def test_Patch2D(par, dtype):
         rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["ny"] * nwins[0] * par["nt"] * nwins[1], dtype=dtype)
+    x = np.ones((nwins[0], nwins[1], par["ny"], par["nt"]), dtype=dtype)
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par4)])
@@ -210,14 +211,14 @@ def test_Patch2D_scalings(par, dtype):
         rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["ny"] * nwins[0] * par["nt"] * nwins[1], dtype=dtype)
+    x = np.ones((nwins[0], nwins[1], par["ny"], par["nt"]), dtype=dtype)
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par4)])
@@ -254,14 +255,14 @@ def test_Patch2D_singlepatch1(par, dtype):
         rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["npy"] * nwins[0] * par["nt"] * nwins[1], dtype=dtype)
+    x = np.ones((nwins[0], nwins[1], par["npy"], par["nt"]), dtype=dtype)
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -297,14 +298,14 @@ def test_Patch2D_singlepatch2(par, dtype):
         rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones(par["ny"] * nwins[0] * par["npt"] * nwins[1], dtype=dtype)
+    x = np.ones((nwins[0], nwins[1], par["ny"], par["nt"]), dtype=dtype)
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -351,15 +352,15 @@ def test_Patch3D(par, dtype):
         backend=backend,
     )
     x = np.ones(
-        (par["ny"] * nwins[0], par["nx"] * nwins[1], par["nt"] * nwins[2]), dtype=dtype
+        (nwins[0], nwins[1], nwins[2], par["ny"], par["nx"], par["nt"]),
     )
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -403,15 +404,15 @@ def test_Patch3D_singlepatch1(par, dtype):
         backend=backend,
     )
     x = np.ones(
-        (par["npy"] * nwins[0], par["nx"] * nwins[1], par["nt"] * nwins[2]), dtype=dtype
+        (nwins[0], nwins[1], nwins[2], par["npy"], par["nx"], par["nt"]),
     )
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -455,15 +456,15 @@ def test_Patch3D_singlepatch2(par, dtype):
         backend=backend,
     )
     x = np.ones(
-        (par["ny"] * nwins[0], par["npx"] * nwins[1], par["nt"] * nwins[2]), dtype=dtype
+        (nwins[0], nwins[1], nwins[2], par["ny"], par["npx"], par["nt"]),
     )
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -509,16 +510,16 @@ def test_Patch3D_singlepatch12(par, dtype):
         backend=backend,
     )
     x = np.ones(
-        (par["npy"] * nwins[0], par["npx"] * nwins[1], par["nt"] * nwins[2]),
+        (nwins[0], nwins[1], nwins[2], par["npy"], par["npx"], par["nt"]),
         dtype=dtype,
     )
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
@@ -561,12 +562,12 @@ def test_Patch3D_singlepatch3(par, dtype):
         backend=backend,
     )
     x = np.ones(
-        (par["ny"] * nwins[0], par["nx"] * nwins[1], par["npt"] * nwins[2]), dtype=dtype
+        (nwins[0], nwins[1], nwins[2], par["ny"], par["nx"], par["npt"]),
     )
     y = Pop * x.ravel()
     xadj = Pop.H * y
-    xinv = Pop / y
+    xinv = cgls(Pop, y, niter=50)[0]
 
     assert y.dtype == dtype
     assert xadj.dtype == dtype
-    assert_array_almost_equal(x.ravel(), xinv, decimal=3 if dtype == np.float32 else 8)
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)

--- a/pytests/test_poststack.py
+++ b/pytests/test_poststack.py
@@ -112,14 +112,14 @@ def test_PoststackLinearModelling1d(par, dtype):
         PPop_dense,
         nt0,
         nt0,
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
     # Linear operator
     PPop = PoststackLinearModelling(wav.astype(dtype), nt0=nt0, explicit=False)
     assert dottest(
-        PPop, nt0, nt0, rtol=1e-4 if dtype == np.float32 else 1e-6, backend=backend
+        PPop, nt0, nt0, rtol=1e-3 if dtype == np.float32 else 1e-6, backend=backend
     )
 
     # Compare data (dense vs lop) and check dtype
@@ -243,7 +243,7 @@ def test_PoststackLinearModelling2d(par, dtype):
         PPop_dense,
         nz * nx,
         nz * nx,
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -255,7 +255,7 @@ def test_PoststackLinearModelling2d(par, dtype):
         PPop,
         nz * nx,
         nz * nx,
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 

--- a/pytests/test_poststack.py
+++ b/pytests/test_poststack.py
@@ -161,7 +161,7 @@ def test_PoststackLinearModelling1d(par, dtype):
             simultaneous=par["simultaneous"],
             **dict_inv,
         )[0]
-        err = 5e-3 if dtype == np.float32 else 2e-3
+        err = 1e-2 if dtype == np.float32 else 8e-3
         assert np.linalg.norm(m - minv) / np.linalg.norm(m) < err
 
 
@@ -224,7 +224,7 @@ def test_PoststackLinearModelling1d_nonstationary(par, dtype):
             simultaneous=par["simultaneous"],
             **dict_inv,
         )[0]
-        err = 5e-3 if dtype == np.float32 else 2e-3
+        err = 1e-2 if dtype == np.float32 else 8e-3
         assert np.linalg.norm(m - minv) / np.linalg.norm(m) < err
 
 

--- a/pytests/test_poststack.py
+++ b/pytests/test_poststack.py
@@ -138,8 +138,12 @@ def test_PoststackLinearModelling1d(par, dtype):
     for explicit, data in zip([True, False], [d_dense, d], strict=True):
         if par["epsR"] is None:
             dict_inv = (
-                dict() if not explicit else dict(cond=1e-6)
-            )  # to avoid instability
+                dict()
+                if not explicit
+                else dict(rcond=1e-6)
+                if int(os.environ.get("TEST_CUPY_PYLOPS", 0))
+                else dict(cond=1e-6)
+            )  # to avoid instability (cond for scipy abd rcond for cupy)
         else:
             dict_inv = (
                 dict(damp=0 if par["epsI"] is None else par["epsI"], iter_lim=80)
@@ -198,8 +202,12 @@ def test_PoststackLinearModelling1d_nonstationary(par, dtype):
     for explicit, data in zip([True, False], [d_dense, d], strict=True):
         if par["epsR"] is None:
             dict_inv = (
-                dict() if not explicit else dict(cond=1e-6)
-            )  # to avoid instability
+                dict()
+                if not explicit
+                else dict(rcond=1e-6)
+                if int(os.environ.get("TEST_CUPY_PYLOPS", 0))
+                else dict(cond=1e-6)
+            )  # to avoid instability (cond for scipy abd rcond for cupy)
         else:
             dict_inv = (
                 dict(damp=0 if par["epsI"] is None else par["epsI"], iter_lim=80)
@@ -266,8 +274,12 @@ def test_PoststackLinearModelling2d(par, dtype):
     for explicit, data in zip([True, False], [d_dense, d], strict=True):
         if explicit and not par["simultaneous"] and par["epsR"] is None:
             dict_inv = (
-                dict() if not explicit else dict(cond=1e-6)
-            )  # to avoid instability
+                dict()
+                if not explicit
+                else dict(rcond=1e-6)
+                if int(os.environ.get("TEST_CUPY_PYLOPS", 0))
+                else dict(cond=1e-6)
+            )  # to avoid instability (cond for scipy abd rcond for cupy)
         elif explicit and not par["simultaneous"] and par["epsR"] is not None:
             dict_inv = (
                 dict(damp=0 if par["epsI"] is None else par["epsI"], iter_lim=10)

--- a/pytests/test_poststack.py
+++ b/pytests/test_poststack.py
@@ -132,6 +132,7 @@ def test_PoststackLinearModelling1d(par, dtype):
     assert madj.dtype == dtype
     assert madj_dense.dtype == dtype
     assert_array_almost_equal(d, d_dense, decimal=4)
+    assert_array_almost_equal(madj, madj_dense, decimal=4)
 
     # Inversion (note that since the operator is ill-conditioned, we cannot
     # expect a perfect reconstruction, hence the large relative error threshold)

--- a/pytests/test_poststack.py
+++ b/pytests/test_poststack.py
@@ -101,27 +101,45 @@ par7 = {
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_PoststackLinearModelling1d(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PoststackLinearModelling1d(par, dtype):
     """Dot-test, comparison of dense vs lop implementation and
     inversion for PoststackLinearModelling in 1d with stationary wavelet
     """
     # Dense
-    PPop_dense = PoststackLinearModelling(wav, nt0=nt0, explicit=True)
-    assert dottest(PPop_dense, nt0, nt0, rtol=1e-4, backend=backend)
+    PPop_dense = PoststackLinearModelling(wav.astype(dtype), nt0=nt0, explicit=True)
+    assert dottest(
+        PPop_dense,
+        nt0,
+        nt0,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Linear operator
-    PPop = PoststackLinearModelling(wav, nt0=nt0, explicit=False)
-    assert dottest(PPop, nt0, nt0, rtol=1e-4, backend=backend)
+    PPop = PoststackLinearModelling(wav.astype(dtype), nt0=nt0, explicit=False)
+    assert dottest(
+        PPop, nt0, nt0, rtol=1e-4 if dtype == np.float32 else 1e-6, backend=backend
+    )
 
-    # Compare data
-    d = PPop * m.ravel()
-    d_dense = PPop_dense * m.T.ravel()
+    # Compare data (dense vs lop) and check dtype
+    d = PPop * m.astype(dtype)
+    d_dense = PPop_dense * m.astype(dtype)
+    madj = PPop.H * d
+    madj_dense = PPop_dense.H * d_dense
+    assert d.dtype == dtype
+    assert d_dense.dtype == dtype
+    assert madj.dtype == dtype
+    assert madj_dense.dtype == dtype
     assert_array_almost_equal(d, d_dense, decimal=4)
 
-    # Inversion
-    for explicit in [True, False]:
+    # Inversion (note that since the operator is ill-conditioned, we cannot
+    # expect a perfect reconstruction, hence the large relative error threshold)
+    for explicit, data in zip([True, False], [d_dense, d], strict=True):
         if par["epsR"] is None:
-            dict_inv = {}
+            dict_inv = (
+                dict() if not explicit else dict(cond=1e-6)
+            )  # to avoid instability
         else:
             dict_inv = (
                 dict(damp=0 if par["epsI"] is None else par["epsI"], iter_lim=80)
@@ -130,40 +148,58 @@ def test_PoststackLinearModelling1d(par):
             )
 
         minv = PoststackInversion(
-            d,
-            wav,
-            m0=mback,
+            data,
+            wav.astype(dtype),
+            m0=mback.astype(dtype),
             explicit=explicit,
             epsR=par["epsR"],
             epsI=par["epsI"],
             simultaneous=par["simultaneous"],
-            **dict_inv
+            **dict_inv,
         )[0]
-        assert np.linalg.norm(m - minv) / np.linalg.norm(minv) < 1e-2
+        err = 5e-3 if dtype == np.float32 else 2e-3
+        assert np.linalg.norm(m - minv) / np.linalg.norm(m) < err
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_PoststackLinearModelling1d_nonstationary(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PoststackLinearModelling1d_nonstationary(par, dtype):
     """Dot-test, comparison of dense vs lop implementation and
     inversion for PoststackLinearModelling in 1d with nonstationary wavelet
     """
     # Dense
-    PPop_dense = PoststackLinearModelling(wavs, nt0=nt0, explicit=True)
-    assert dottest(PPop_dense, nt0, nt0, rtol=1e-4, backend=backend)
+    PPop_dense = PoststackLinearModelling(wavs.astype(dtype), nt0=nt0, explicit=True)
+    assert dottest(
+        PPop_dense,
+        nt0,
+        nt0,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Linear operator
-    PPop = PoststackLinearModelling(wavs, nt0=nt0, explicit=False)
-    assert dottest(PPop, nt0, nt0, rtol=1e-4, backend=backend)
+    PPop = PoststackLinearModelling(wavs.astype(dtype), nt0=nt0, explicit=False)
+    assert dottest(
+        PPop, nt0, nt0, rtol=1e-3 if dtype == np.float32 else 1e-6, backend=backend
+    )
 
-    # Compare data
-    d = PPop * m.ravel()
-    d_dense = PPop_dense * m.T.ravel()
+    # Compare data (dense vs lop) and check dtype
+    d = PPop * m.astype(dtype)
+    d_dense = PPop_dense * m.astype(dtype)
+    madj = PPop.H * d
+    madj_dense = PPop_dense.H * d_dense
+    assert d.dtype == dtype
+    assert d_dense.dtype == dtype
+    assert madj.dtype == dtype
+    assert madj_dense.dtype == dtype
     assert_array_almost_equal(d, d_dense, decimal=4)
 
     # Inversion
-    for explicit in [True, False]:
+    for explicit, data in zip([True, False], [d_dense, d], strict=True):
         if par["epsR"] is None:
-            dict_inv = {}
+            dict_inv = (
+                dict() if not explicit else dict(cond=1e-6)
+            )  # to avoid instability
         else:
             dict_inv = (
                 dict(damp=0 if par["epsI"] is None else par["epsI"], iter_lim=80)
@@ -171,41 +207,67 @@ def test_PoststackLinearModelling1d_nonstationary(par):
                 else dict(damp=0 if par["epsI"] is None else par["epsI"], niter=80)
             )
         minv = PoststackInversion(
-            d,
-            wavs,
-            m0=mback,
+            data,
+            wavs.astype(dtype),
+            m0=mback.astype(dtype),
             explicit=explicit,
             epsR=par["epsR"],
             epsI=par["epsI"],
             simultaneous=par["simultaneous"],
-            **dict_inv
+            **dict_inv,
         )[0]
-        assert np.linalg.norm(m - minv) / np.linalg.norm(minv) < 1e-2
+        err = 5e-3 if dtype == np.float32 else 2e-3
+        assert np.linalg.norm(m - minv) / np.linalg.norm(m) < err
 
 
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7)]
 )
-def test_PoststackLinearModelling2d(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PoststackLinearModelling2d(par, dtype):
     """Dot-test and inversion for PoststackLinearModelling in 2d"""
 
     # Dense
-    PPop_dense = PoststackLinearModelling(wav, nt0=nz, spatdims=nx, explicit=True)
-    assert dottest(PPop_dense, nz * nx, nz * nx, rtol=1e-4, backend=backend)
+    PPop_dense = PoststackLinearModelling(
+        wav.astype(dtype), nt0=nz, spatdims=nx, explicit=True
+    )
+    assert dottest(
+        PPop_dense,
+        nz * nx,
+        nz * nx,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Linear operator
-    PPop = PoststackLinearModelling(wav, nt0=nz, spatdims=nx, explicit=False)
-    assert dottest(PPop, nz * nx, nz * nx, rtol=1e-4, backend=backend)
+    PPop = PoststackLinearModelling(
+        wav.astype(dtype), nt0=nz, spatdims=nx, explicit=False
+    )
+    assert dottest(
+        PPop,
+        nz * nx,
+        nz * nx,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Compare data
-    d = (PPop * m2d.ravel()).reshape(nz, nx)
-    d_dense = (PPop_dense * m2d.ravel()).reshape(nz, nx)
+    d = PPop * m2d.astype(dtype)
+    d_dense = PPop_dense * m2d.astype(dtype)
+    madj = PPop.H * d
+    madj_dense = PPop_dense.H * d_dense
+    assert d.dtype == dtype
+    assert d_dense.dtype == dtype
+    assert madj.dtype == dtype
+    assert madj_dense.dtype == dtype
     assert_array_almost_equal(d, d_dense, decimal=4)
 
     # Inversion
-    for explicit in [True, False]:
+    for explicit, data in zip([True, False], [d_dense, d], strict=True):
         if explicit and not par["simultaneous"] and par["epsR"] is None:
-            dict_inv = {}
+            dict_inv = (
+                dict() if not explicit else dict(cond=1e-6)
+            )  # to avoid instability
         elif explicit and not par["simultaneous"] and par["epsR"] is not None:
             dict_inv = (
                 dict(damp=0 if par["epsI"] is None else par["epsI"], iter_lim=10)
@@ -219,14 +281,15 @@ def test_PoststackLinearModelling2d(par):
                 else dict(damp=0 if par["epsI"] is None else par["epsI"], niter=10)
             )
         minv2d = PoststackInversion(
-            d,
-            wav,
-            m0=mback2d,
+            data,
+            wav.astype(dtype),
+            m0=mback2d.astype(dtype),
             explicit=explicit,
             epsI=par["epsI"],
             epsR=par["epsR"],
             epsRL1=par["epsRL1"],
             simultaneous=par["simultaneous"],
-            **dict_inv
+            **dict_inv,
         )[0]
-        assert np.linalg.norm(m2d - minv2d) / np.linalg.norm(m2d) < 1e-1
+        err = 5e-1 if dtype == np.float32 else 1e-1
+        assert np.linalg.norm(m2d - minv2d) / np.linalg.norm(m2d) < err

--- a/pytests/test_prestack.py
+++ b/pytests/test_prestack.py
@@ -237,15 +237,18 @@ par3b = {
         (par3b),
     ],
 )
-def test_PrestackLinearModelling(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PrestackLinearModelling(par, dtype):
     """Dot-test, comparison of dense vs lop implementation and
     inversion for PrestackLinearModelling
     """
     # Dense
     PPop_dense = PrestackLinearModelling(
-        wav,
-        theta,
-        vsvp=par["vsvp"],
+        wav.astype(dtype),
+        theta.astype(dtype),
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else par["vsvp"].astype(dtype),
         nt0=nt0,
         linearization=par["linearization"],
         explicit=True,
@@ -255,29 +258,45 @@ def test_PrestackLinearModelling(par):
         PPop_dense,
         nt0 * ntheta,
         nt0 * _linearizations[par["linearization"]],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
     # Linear operator
     PPop = PrestackLinearModelling(
-        wav,
-        theta,
-        vsvp=par["vsvp"],
+        wav.astype(dtype),
+        theta.astype(dtype),
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else par["vsvp"].astype(dtype),
         nt0=nt0,
         linearization=par["linearization"],
         explicit=False,
         kind=par["kind"],
     )
     assert dottest(
-        PPop, nt0 * ntheta, nt0 * _linearizations[par["linearization"]], backend=backend
+        PPop,
+        nt0 * ntheta,
+        nt0 * _linearizations[par["linearization"]],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
 
     # Compare data
-    d = PPop * m.ravel()
+    d = PPop * m.astype(dtype).ravel()
     d = d.reshape(nt0, ntheta)
-    d_dense = PPop_dense * m.T.ravel()
+    d_dense = PPop_dense * m.astype(dtype).T.ravel()
     d_dense = d_dense.reshape(ntheta, nt0).T
+    madj = PPop.H * d.ravel()
+    madj = madj.reshape(nt0, _linearizations[par["linearization"]])
+    madj_dense = PPop_dense.H * d_dense.T.ravel()
+    madj_dense = madj_dense.reshape(_linearizations[par["linearization"]], nt0).T
+    assert d.dtype == dtype
+    assert d_dense.dtype == dtype
+    assert madj.dtype == dtype
+    assert madj_dense.dtype == dtype
     assert_array_almost_equal(d, d_dense, decimal=4)
+    assert_array_almost_equal(madj, madj_dense, decimal=4)
 
     # Inversion
     for explicit in [True, False]:
@@ -294,9 +313,9 @@ def test_PrestackLinearModelling(par):
             )
         minv = PrestackInversion(
             d,
-            theta,
-            wav,
-            m0=mback,
+            theta.astype(dtype),
+            wav.astype(dtype),
+            m0=mback.astype(dtype),
             explicit=explicit,
             epsI=par["epsI"],
             epsR=par["epsR"],
@@ -305,36 +324,56 @@ def test_PrestackLinearModelling(par):
             kind=par["kind"],
             **dict_inv,
         )
-        assert np.linalg.norm(m - minv) / np.linalg.norm(minv) < 4e-2
+        err = 1e-1 if dtype == np.float32 else 5e-2
+        assert np.linalg.norm(m - minv) / np.linalg.norm(minv) < err
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_PrestackWaveletModelling(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PrestackWaveletModelling(par, dtype):
     """Dot-test and inversion for PrestackWaveletModelling"""
     # Operators
     Wavestop = PrestackWaveletModelling(
-        m,
-        theta,
+        m.astype(dtype),
+        theta.astype(dtype),
         nwav=ntwav,
         wavc=wavc,
-        vsvp=par["vsvp"],
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else par["vsvp"].astype(dtype),
         linearization=par["linearization"],
     )
-    assert dottest(Wavestop, nt0 * ntheta, ntwav, backend=backend)
+    assert dottest(
+        Wavestop,
+        nt0 * ntheta,
+        ntwav,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     Wavestop_phase = PrestackWaveletModelling(
-        m,
-        theta,
+        m.astype(dtype),
+        theta.astype(dtype),
         nwav=ntwav,
         wavc=wavc,
-        vsvp=par["vsvp"],
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else par["vsvp"].astype(dtype),
         linearization=par["linearization"],
     )
-    assert dottest(Wavestop_phase, nt0 * ntheta, ntwav, backend=backend)
+    assert dottest(
+        Wavestop_phase,
+        nt0 * ntheta,
+        ntwav,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Create data
     d = (Wavestop * wav).reshape(ntheta, nt0).T
     d_phase = (Wavestop_phase * wav_phase).reshape(ntheta, nt0).T
+    assert d.dtype == dtype
+    assert d_phase.dtype == dtype
 
     # Estimate wavelet
     wav_est = lsqr(
@@ -367,38 +406,59 @@ def test_PrestackWaveletModelling(par):
 @pytest.mark.parametrize(
     "par", [(par1), (par3), (par2s), (par4s), (par1r), (par3r), (par1b), (par3b)]
 )
-def test_PrestackLinearModelling2d(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PrestackLinearModelling2d(par, dtype):
     """Dot-test and inversion for PoststackLinearModelling in 2d"""
     nm = _linearizations[par["linearization"]]
     # Dense
     PPop_dense = PrestackLinearModelling(
-        wav,
-        theta,
-        vsvp=par["vsvp"],
+        wav.astype(dtype),
+        theta.astype(dtype),
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else par["vsvp"].astype(dtype),
         nt0=nz,
         spatdims=(nx,),
         linearization=par["linearization"],
         explicit=True,
     )
-    assert dottest(PPop_dense, nz * ntheta * nx, nz * nm * nx, backend=backend)
+    assert dottest(
+        PPop_dense,
+        nz * ntheta * nx,
+        nz * nm * nx,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Linear operator
     PPop = PrestackLinearModelling(
-        wav,
-        theta,
-        vsvp=par["vsvp"],
+        wav.astype(dtype),
+        theta.astype(dtype),
+        vsvp=par["vsvp"]
+        if isinstance(par["vsvp"], float)
+        else par["vsvp"].astype(dtype),
         nt0=nz,
         spatdims=(nx,),
         linearization=par["linearization"],
         explicit=False,
     )
-    assert dottest(PPop_dense, nz * ntheta * nx, nz * nm * nx, backend=backend)
+    assert dottest(
+        PPop_dense,
+        nz * ntheta * nx,
+        nz * nm * nx,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
     # Compare data
-    d = (PPop * m2d.ravel()).reshape(nz, ntheta, nx)
+    d = (PPop * m2d.astype(dtype).ravel()).reshape(nz, ntheta, nx)
     d_dense = (
-        (PPop_dense * m2d.swapaxes(0, 1).ravel()).reshape(ntheta, nz, nx).swapaxes(0, 1)
+        (PPop_dense * m2d.astype(dtype).swapaxes(0, 1).ravel())
+        .reshape(ntheta, nz, nx)
+        .swapaxes(0, 1)
     )
+    assert d.dtype == dtype
+    assert d_dense.dtype == dtype
     assert_array_almost_equal(d, d_dense, decimal=4)
 
     # Inversion
@@ -416,9 +476,9 @@ def test_PrestackLinearModelling2d(par):
             )
         minv2d = PrestackInversion(
             d,
-            theta,
-            wav,
-            m0=mback2d,
+            theta.astype(dtype),
+            wav.astype(dtype),
+            m0=mback2d.astype(dtype),
             explicit=explicit,
             epsI=par["epsI"],
             epsR=par["epsR"],
@@ -426,4 +486,5 @@ def test_PrestackLinearModelling2d(par):
             simultaneous=par["simultaneous"],
             **dict_inv,
         )
-        assert np.linalg.norm(m2d - minv2d) / np.linalg.norm(minv2d) < 2e-1
+        err = 1e-1 if dtype == np.float32 else 5e-2
+        assert np.linalg.norm(m2d - minv2d) / np.linalg.norm(minv2d) < err

--- a/pytests/test_pwd.py
+++ b/pytests/test_pwd.py
@@ -9,12 +9,10 @@ from pylops.utils import dottest
 par1 = {
     "nx": 16,
     "nt": 30,
-    "dtype": "float64",
 }  # even
 par2 = {
     "nx": 17,
     "nt": 31,
-    "dtype": "float64",
 }  # odd
 
 np.random.seed(10)
@@ -24,29 +22,53 @@ np.random.seed(10)
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_PWSprayer2D(par):
-    """Dot-test for PWSprayer2D"""
-    sigma = np.zeros((par["nx"], par["nt"]), dtype=par["dtype"])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PWSprayer2D(par, dtype):
+    """Dot-test and forward/adjoint  for PWSprayer2D"""
+    sigma = np.zeros((par["nx"], par["nt"]), dtype=dtype)
 
     Sop = PWSprayer2D(
         dims=(par["nx"], par["nt"]),
         sigma=sigma,
-        dtype=par["dtype"],
+        dtype=dtype,
     )
-    dottest(Sop, Sop.shape[0], par["nx"] * par["nt"])
+    dottest(
+        Sop,
+        Sop.shape[0],
+        par["nx"] * par["nt"],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+    )
+
+    x = np.ones(par["nx"] * par["nt"], dtype=dtype)
+    y = Sop * x
+    xadj = Sop.H * x
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_PWSmoother2D(par):
-    """Dot-test for PWSmoother2D"""
-    sigma = np.zeros((par["nx"], par["nt"]), dtype=par["dtype"])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_PWSmoother2D(par, dtype):
+    """Dot-test and forward/adjoint for PWSmoother2D"""
+    sigma = np.zeros((par["nx"], par["nt"]), dtype=dtype)
 
     Sop = PWSmoother2D(
         dims=(par["nx"], par["nt"]),
         sigma=sigma,
-        dtype=par["dtype"],
+        dtype=dtype,
     )
-    dottest(Sop, Sop.shape[0], par["nx"] * par["nt"])
+    dottest(
+        Sop,
+        Sop.shape[0],
+        par["nx"] * par["nt"],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+    )
+
+    x = np.ones(par["nx"] * par["nt"], dtype=dtype)
+    y = Sop * x
+    xadj = Sop.H * x
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype

--- a/pytests/test_pytensoroperator.py
+++ b/pytests/test_pytensoroperator.py
@@ -18,8 +18,8 @@ if pytensor_message is None:
         pytensor.config.gcc__cxxflags = "-Wno-c++11-narrowing"
 
 
-par1 = {"ny": 11, "nx": 11, "dtype": np.float32}  # square
-par2 = {"ny": 21, "nx": 11, "dtype": np.float32}  # overdetermined
+par1 = {"ny": 11, "nx": 11}  # square
+par2 = {"ny": 21, "nx": 11}  # overdetermined
 
 np.random.seed(0)
 rng = np.random.default_rng()
@@ -28,7 +28,7 @@ rng = np.random.default_rng()
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1)])
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_PyTensorOperator(par):
     """Verify output and gradient of PyTensor function obtained from a LinearOperator."""
     Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
@@ -48,7 +48,7 @@ def test_PyTensorOperator(par):
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
-@pytest.mark.parametrize("par", [(par1)])
+@pytest.mark.parametrize("par", [(par1), (par2)])
 def test_PyTensorOperator_nd(par):
     """Verify output and gradient of PyTensor function obtained from a LinearOperator
     using an ND-array."""

--- a/pytests/test_radon.py
+++ b/pytests/test_radon.py
@@ -235,13 +235,13 @@ def test_Radon3D(par, dtype):
         engine=par["engine"],
         dtype=dtype,
     )
-
     assert dottest(
         Rop,
         par["nhy"] * par["nhx"] * par["nt"],
         par["npy"] * par["npx"] * par["nt"],
         rtol=1e-3 if dtype == np.float32 else 1e-6,
     )
+
     y = Rop * x.ravel()
     y1 = R1op * x.ravel()
     assert y.dtype == dtype

--- a/pytests/test_radon.py
+++ b/pytests/test_radon.py
@@ -132,15 +132,16 @@ def test_unknown_engine():
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7), (par8)]
 )
-def test_Radon2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Radon2D(par, dtype):
     """Dot-test, forward and adjoint consistency check
     (for onthefly parameter), and sparse inverse for Radon2D operator
     """
     dt, dh = 0.005, 1
-    t = np.arange(par["nt"]) * dt
-    h = np.arange(par["nhx"]) * dh
-    px = np.linspace(0, par["pxmax"], par["npx"])
-    x = np.zeros((par["npx"], par["nt"]))
+    t = np.arange(par["nt"], dtype=dtype) * dt
+    h = np.arange(par["nhx"], dtype=dtype) * dh
+    px = np.linspace(0, par["pxmax"], par["npx"], dtype=dtype)
+    x = np.zeros((par["npx"], par["nt"]), dtype=dtype)
     x[2, par["nt"] // 2] = 1
 
     Rop = Radon2D(
@@ -152,7 +153,7 @@ def test_Radon2D(par):
         kind=par["kind"],
         onthefly=False,
         engine=par["engine"],
-        dtype="float64",
+        dtype=dtype,
     )
     R1op = Radon2D(
         t,
@@ -163,82 +164,96 @@ def test_Radon2D(par):
         kind=par["kind"],
         onthefly=True,
         engine=par["engine"],
-        dtype="float64",
+        dtype=dtype,
     )
-    assert dottest(Rop, par["nhx"] * par["nt"], par["npx"] * par["nt"], rtol=1e-3)
+    assert dottest(
+        Rop,
+        par["nhx"] * par["nt"],
+        par["npx"] * par["nt"],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+    )
 
     y = Rop * x.ravel()
     y1 = R1op * x.ravel()
+    assert y.dtype == dtype
+    assert y1.dtype == dtype
     assert_array_almost_equal(y, y1, decimal=4)
 
     xadj = Rop.H * y
     xadj1 = R1op.H * y
+    assert xadj.dtype == dtype
+    assert xadj1.dtype == dtype
     assert_array_almost_equal(xadj, xadj1, decimal=4)
 
     xinv, _, _ = fista(Rop, y, niter=30, eps=1e0)
     assert_array_almost_equal(x.ravel(), xinv, decimal=1)
 
 
-# @pytest.mark.skipif(
-#     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
-# )
-# @pytest.mark.parametrize(
-#     "par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7), (par8)]
-# )
-# def test_Radon3D(par):
-#     """Dot-test, forward and adjoint consistency check
-#     (for onthefly parameter), and sparse inverse for Radon3D operator
-#     """
-#     dt, dhy, dhx = 0.005, 1, 1
-#     t = np.arange(par["nt"]) * dt
-#     hy = np.arange(par["nhy"]) * dhy
-#     hx = np.arange(par["nhx"]) * dhx
-#     py = np.linspace(0, par["pymax"], par["npy"])
-#     px = np.linspace(0, par["pxmax"], par["npx"])
-#     x = np.zeros((par["npy"], par["npx"], par["nt"]))
-#     x[3, 2, par["nt"] // 2] = 1
+@pytest.mark.skipif(
+    int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
+)
+@pytest.mark.parametrize(
+    "par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7), (par8)]
+)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Radon3D(par, dtype):
+    """Dot-test, forward and adjoint consistency check
+    (for onthefly parameter), and sparse inverse for Radon3D operator
+    """
+    dt, dhy, dhx = 0.005, 1, 1
+    t = np.arange(par["nt"], dtype=dtype) * dt
+    hy = np.arange(par["nhy"], dtype=dtype) * dhy
+    hx = np.arange(par["nhx"], dtype=dtype) * dhx
+    py = np.linspace(0, par["pymax"], par["npy"], dtype=dtype)
+    px = np.linspace(0, par["pxmax"], par["npx"], dtype=dtype)
+    x = np.zeros((par["npy"], par["npx"], par["nt"]), dtype=dtype)
+    x[3, 2, par["nt"] // 2] = 1
 
-#     Rop = Radon3D(
-#         t,
-#         hy,
-#         hx,
-#         py,
-#         px,
-#         centeredh=par["centeredh"],
-#         interp=par["interp"],
-#         kind=par["kind"],
-#         onthefly=False,
-#         engine=par["engine"],
-#         dtype="float64",
-#     )
-#     R1op = Radon3D(
-#         t,
-#         hy,
-#         hx,
-#         py,
-#         px,
-#         centeredh=par["centeredh"],
-#         interp=par["interp"],
-#         kind=par["kind"],
-#         onthefly=True,
-#         engine=par["engine"],
-#         dtype="float64",
-#     )
+    Rop = Radon3D(
+        t,
+        hy,
+        hx,
+        py,
+        px,
+        centeredh=par["centeredh"],
+        interp=par["interp"],
+        kind=par["kind"],
+        onthefly=False,
+        engine=par["engine"],
+        dtype=dtype,
+    )
+    R1op = Radon3D(
+        t,
+        hy,
+        hx,
+        py,
+        px,
+        centeredh=par["centeredh"],
+        interp=par["interp"],
+        kind=par["kind"],
+        onthefly=True,
+        engine=par["engine"],
+        dtype=dtype,
+    )
 
-#     assert dottest(
-#         Rop,
-#         par["nhy"] * par["nhx"] * par["nt"],
-#         par["npy"] * par["npx"] * par["nt"],
-#         rtol=1e-3,
-#     )
-#     y = Rop * x.ravel()
-#     y1 = R1op * x.ravel()
-#     assert_array_almost_equal(y, y1, decimal=4)
+    assert dottest(
+        Rop,
+        par["nhy"] * par["nhx"] * par["nt"],
+        par["npy"] * par["npx"] * par["nt"],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+    )
+    y = Rop * x.ravel()
+    y1 = R1op * x.ravel()
+    assert y.dtype == dtype
+    assert y1.dtype == dtype
+    assert_array_almost_equal(y, y1, decimal=4)
 
-#     xadj = Rop.H * y
-#     xadj1 = R1op.H * y
-#     assert_array_almost_equal(xadj, xadj1, decimal=4)
+    xadj = Rop.H * y
+    xadj1 = R1op.H * y
+    assert xadj.dtype == dtype
+    assert xadj1.dtype == dtype
+    assert_array_almost_equal(xadj, xadj1, decimal=4)
 
-#     if Rop.engine == "numba":  # as numpy is too slow here...
-#         xinv, _, _ = fista(Rop, y, niter=200, eps=3e0)
-#         assert_array_almost_equal(x.ravel(), xinv, decimal=1)
+    if Rop.engine == "numba":  # as numpy is too slow here...
+        xinv, _, _ = fista(Rop, y, niter=200, eps=3e0)
+        assert_array_almost_equal(x.ravel(), xinv, decimal=1)

--- a/pytests/test_restriction.py
+++ b/pytests/test_restriction.py
@@ -22,8 +22,16 @@ par1 = {
     "imag": 0,
     "dtype": "float64",
     "inplace": "True",
-}  # real, inplace
-par2 = {
+}  # real (fp64), inplace
+par1s = {
+    "ny": 21,
+    "nx": 11,
+    "nt": 20,
+    "imag": 0,
+    "dtype": "float32",
+    "inplace": "True",
+}  # real (fp32), inplace
+par1j = {
     "ny": 21,
     "nx": 11,
     "nt": 20,
@@ -31,15 +39,23 @@ par2 = {
     "dtype": "complex128",
     "inplace": "True",
 }  # complex, inplace
-par3 = {
+par2 = {
     "ny": 21,
     "nx": 11,
     "nt": 20,
     "imag": 0,
     "dtype": "float64",
     "inplace": "False",
-}  # real, out of place
-par4 = {
+}  # real (fp64), out of place
+par2s = {
+    "ny": 21,
+    "nx": 11,
+    "nt": 20,
+    "imag": 0,
+    "dtype": "float32",
+    "inplace": "False",
+}  # real (fp32), out of place
+par2j = {
     "ny": 21,
     "nx": 11,
     "nt": 20,
@@ -52,47 +68,59 @@ par4 = {
 perc_subsampling = 0.4
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j), (par2), (par2s), (par2j)])
 def test_Restriction_1dsignal(par):
     """Dot-test, forward and adjoint for Restriction operator for 1d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
     Nsub = int(np.round(par["nx"] * perc_subsampling))
     iava = np.sort(np.random.permutation(np.arange(par["nx"]))[:Nsub])
 
-    Rop = Restriction(par["nx"], iava, inplace=par["dtype"], dtype=par["dtype"])
+    Rop = Restriction(par["nx"], iava, inplace=par["inplace"], dtype=par["dtype"])
     assert dottest(
-        Rop, Nsub, par["nx"], complexflag=0 if par["imag"] == 0 else 3, backend=backend
+        Rop,
+        Nsub,
+        par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
 
-    x = np.ones(par["nx"]) + par["imag"] * np.ones(par["nx"])
+    x = np.ones(par["nx"], dtype=dtype) + par["imag"] * np.ones(par["nx"], dtype=dtype)
     y = Rop * x
     x1 = Rop.H * y
     y1 = np.asarray(Rop.mask(x))
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(y, y1[iava])
     assert_array_almost_equal(x[iava], x1[iava])
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j), (par2), (par2s), (par2j)])
 def test_Restriction_2dsignal(par):
     """Dot-test, forward and adjoint for Restriction operator for 2d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
-    x = np.ones((par["nx"], par["nt"])) + par["imag"] * np.ones((par["nx"], par["nt"]))
+    x = np.ones((par["nx"], par["nt"]), dtype=dtype) + par["imag"] * np.ones(
+        (par["nx"], par["nt"]), dtype=dtype
+    )
 
     # 1st direction
     Nsub = int(np.round(par["nx"] * perc_subsampling))
     iava = np.sort(np.random.permutation(np.arange(par["nx"]))[:Nsub])
 
     Rop = Restriction(
-        (par["nx"], par["nt"]), iava, axis=0, inplace=par["dtype"], dtype=par["dtype"]
+        (par["nx"], par["nt"]), iava, axis=0, inplace=par["inplace"], dtype=par["dtype"]
     )
     assert dottest(
         Rop,
         Nsub * par["nt"],
         par["nx"] * par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -101,6 +129,8 @@ def test_Restriction_2dsignal(par):
     y1_fromflat = np.asarray(Rop.mask(x.ravel()))
     y1 = np.asarray(Rop.mask(x))
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(y, y1_fromflat.reshape(par["nx"], par["nt"])[iava])
     assert_array_almost_equal(y, y1[iava])
     assert_array_almost_equal(x[iava], x1[iava])
@@ -110,13 +140,14 @@ def test_Restriction_2dsignal(par):
     iava = np.sort(np.random.permutation(np.arange(par["nt"]))[:Nsub])
 
     Rop = Restriction(
-        (par["nx"], par["nt"]), iava, axis=1, inplace=par["dtype"], dtype=par["dtype"]
+        (par["nx"], par["nt"]), iava, axis=1, inplace=par["inplace"], dtype=par["dtype"]
     )
     assert dottest(
         Rop,
         par["nx"] * Nsub,
         par["nx"] * par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -125,18 +156,21 @@ def test_Restriction_2dsignal(par):
     y1_fromflat = np.asarray(Rop.mask(x.ravel()))
     y1 = np.asarray(Rop.mask(x))
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(y, y1_fromflat[:, iava])
     assert_array_almost_equal(y, y1[:, iava])
     assert_array_almost_equal(x[:, iava], x1[:, iava])
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j), (par2), (par2s), (par2j)])
 def test_Restriction_3dsignal(par):
     """Dot-test, forward and adjoint for Restriction operator for 3d signal"""
     np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
-    x = np.ones((par["ny"], par["nx"], par["nt"])) + par["imag"] * np.ones(
-        (par["ny"], par["nx"], par["nt"])
+    x = np.ones((par["ny"], par["nx"], par["nt"]), dtype=dtype) + par["imag"] * np.ones(
+        (par["ny"], par["nx"], par["nt"]), dtype=dtype
     )
 
     # 1st direction
@@ -147,7 +181,7 @@ def test_Restriction_3dsignal(par):
         (par["ny"], par["nx"], par["nt"]),
         iava,
         axis=0,
-        inplace=par["dtype"],
+        inplace=par["inplace"],
         dtype=par["dtype"],
     )
     assert dottest(
@@ -155,6 +189,7 @@ def test_Restriction_3dsignal(par):
         Nsub * par["nx"] * par["nt"],
         par["ny"] * par["nx"] * par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -163,6 +198,8 @@ def test_Restriction_3dsignal(par):
     y1_fromflat = np.asarray(Rop.mask(x.ravel()))
     y1 = np.asarray(Rop.mask(x))
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(
         y, y1_fromflat.reshape(par["ny"], par["nx"], par["nt"])[iava]
     )
@@ -177,7 +214,7 @@ def test_Restriction_3dsignal(par):
         (par["ny"], par["nx"], par["nt"]),
         iava,
         axis=1,
-        inplace=par["dtype"],
+        inplace=par["inplace"],
         dtype=par["dtype"],
     )
     assert dottest(
@@ -185,6 +222,7 @@ def test_Restriction_3dsignal(par):
         par["ny"] * Nsub * par["nt"],
         par["ny"] * par["nx"] * par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -193,6 +231,8 @@ def test_Restriction_3dsignal(par):
     y1_fromflat = np.asarray(Rop.mask(x.ravel()))
     y1 = np.asarray(Rop.mask(x))
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(y, y1_fromflat[:, iava])
     assert_array_almost_equal(y, y1[:, iava])
     assert_array_almost_equal(x[:, iava], x1[:, iava])
@@ -205,7 +245,7 @@ def test_Restriction_3dsignal(par):
         (par["ny"], par["nx"], par["nt"]),
         iava,
         axis=2,
-        inplace=par["dtype"],
+        inplace=par["inplace"],
         dtype=par["dtype"],
     )
     assert dottest(
@@ -213,6 +253,7 @@ def test_Restriction_3dsignal(par):
         par["ny"] * par["nx"] * Nsub,
         par["ny"] * par["nx"] * par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -221,6 +262,8 @@ def test_Restriction_3dsignal(par):
     y1_fromflat = np.asarray(Rop.mask(x.ravel()))
     y1 = np.asarray(Rop.mask(x))
 
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
     assert_array_almost_equal(y, y1_fromflat[:, :, iava])
     assert_array_almost_equal(y, y1[:, :, iava])
     assert_array_almost_equal(x[:, :, iava], x1[:, :, iava])

--- a/pytests/test_seislet.py
+++ b/pytests/test_seislet.py
@@ -15,7 +15,6 @@ par1 = {
     "dx": 10,
     "dt": 0.004,
     "level": None,
-    "dtype": "float32",
 }  # nx power of 2, max level
 par2 = {
     "nx": 16,
@@ -23,7 +22,6 @@ par2 = {
     "dx": 10,
     "dt": 0.004,
     "level": 2,
-    "dtype": "float32",
 }  # nx power of 2, smaller level
 par3 = {
     "nx": 13,
@@ -31,7 +29,6 @@ par3 = {
     "dx": 10,
     "dt": 0.004,
     "level": 2,
-    "dtype": "float32",
 }  # nx not power of 2, max level
 
 np.random.seed(10)
@@ -118,9 +115,10 @@ def test_predict(par):
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3)])
-def test_Seislet(par):
-    """Dot-test and forward-inverse for Seislet"""
-    slope = np.random.normal(0, 0.1, (par["nx"], par["nt"]))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Seislet(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Seislet"""
+    slope = np.random.normal(0, 0.1, (par["nx"], par["nt"])).astype(dtype)
 
     for kind in ("haar", "linear"):
         Sop = Seislet(
@@ -128,11 +126,19 @@ def test_Seislet(par):
             sampling=(par["dx"], par["dt"]),
             level=par["level"],
             kind=kind,
-            dtype=par["dtype"],
+            dtype=dtype,
         )
-        dottest(Sop, Sop.shape[0], par["nx"] * par["nt"])
+        dottest(
+            Sop,
+            Sop.shape[0],
+            par["nx"] * par["nt"],
+            rtol=1e-3 if dtype == np.float32 else 1e-6,
+        )
 
-        x = np.random.normal(0, 0.1, par["nx"] * par["nt"])
+        x = np.random.normal(0, 0.1, par["nx"] * par["nt"]).astype(dtype)
         y = Sop * x
+        xadj = Sop.H * y
         xinv = Sop.inverse(y)
-        assert_array_almost_equal(x, xinv)
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
+        assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 6)

--- a/pytests/test_shift.py
+++ b/pytests/test_shift.py
@@ -24,14 +24,28 @@ par1 = {
     "ny": 11,
     "imag": 0,
     "dtype": "float64",
-}  # square real
+}  # square real  (fp64)
 par2 = {
     "nt": 41,
     "nx": 21,
     "ny": 11,
     "imag": 0,
     "dtype": "float64",
-}  # overdetermined real
+}  # overdetermined real (fp64)
+par1s = {
+    "nt": 41,
+    "nx": 41,
+    "ny": 11,
+    "imag": 0,
+    "dtype": "float32",
+}  # square real (fp32)
+par2s = {
+    "nt": 41,
+    "nx": 21,
+    "ny": 11,
+    "imag": 0,
+    "dtype": "float32",
+}  # overdetermined real (fp32)
 par1j = {
     "nt": 41,
     "nx": 41,
@@ -59,14 +73,16 @@ def test_unknown_engine(par):
         )
 
 
-@pytest.mark.parametrize("par", [(par1), (par1j)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Shift1D(par):
-    """Dot-test and inversion for Shift operator on 1d data"""
+    """Dot-test and forward/adjoint/inversion for Shift operator on 1d data"""
     np.random.seed(0)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     shift = 5.5
     x = np.asarray(
-        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
-        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
+        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
+        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
     )
 
     Sop = Shift(
@@ -77,12 +93,15 @@ def test_Shift1D(par):
         par["nt"],
         par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
+    y = Sop * x
+    xadj = Sop.H * y
     xlsqr = lsqr(
         Sop,
-        Sop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=200,
@@ -90,22 +109,27 @@ def test_Shift1D(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
+    assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1,
     reason="SciPy engine not compatible with CuPy",
 )
-@pytest.mark.parametrize("par", [(par1), (par1j)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Shift1D_scipy(par):
-    """Dot-test and inversion for Shift operator on 1d data
+    """Dot-test and forward/adjoint/inversion for Shift operator on 1d data
     with scipy engine and workers"""
     np.random.seed(0)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     shift = 5.5
     x = np.asarray(
-        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
-        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
+        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
+        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
     )
 
     Sop = Shift(
@@ -121,12 +145,15 @@ def test_Shift1D_scipy(par):
         par["nt"],
         par["nt"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
+    y = Sop * x
+    xadj = Sop.H * y
     xlsqr = lsqr(
         Sop,
-        Sop * x,
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=200,
@@ -134,21 +161,26 @@ def test_Shift1D_scipy(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
+    assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_Shift2D(par):
-    """Dot-test and inversion for Shift operator on 2d data"""
+    """Dot-test and forward/adjoint/inversion for Shift operator on 2d data"""
     np.random.seed(0)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     shift = 5.5
 
     # 1st axis
     x = np.asarray(
-        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
-        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
+        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
+        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
     )
-    x = np.outer(x, np.ones(par["nx"]))
+    x = np.outer(x, np.ones(par["nx"], dtype=dtype))
     Sop = Shift(
         (par["nt"], par["nx"]),
         shift,
@@ -161,11 +193,15 @@ def test_Shift2D(par):
         par["nt"] * par["nx"],
         par["nt"] * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    y = Sop * x.ravel()
+    xadj = Sop.H * y
     xlsqr = lsqr(
         Sop,
-        Sop * x.ravel(),
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=200,
@@ -173,14 +209,17 @@ def test_Shift2D(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
+    assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
     # 2nd axis
     x = np.asarray(
-        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
-        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
+        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
+        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
     )
-    x = np.outer(x, np.ones(par["nx"])).T
+    x = np.outer(x, np.ones(par["nx"], dtype=dtype)).T
     Sop = Shift(
         (par["nx"], par["nt"]),
         shift,
@@ -193,11 +232,15 @@ def test_Shift2D(par):
         par["nt"] * par["nx"],
         par["nt"] * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    y = Sop * x.ravel()
+    xadj = Sop.H * y
     xlsqr = lsqr(
         Sop,
-        Sop * x.ravel(),
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=200,
@@ -205,21 +248,26 @@ def test_Shift2D(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
+    assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2), (par1j), (par2j)])
+@pytest.mark.parametrize("par", [(par1), (par2), (par1s), (par2s), (par1j), (par2j)])
 def test_Shift2Dvariable(par):
-    """Dot-test and inversion for Shift operator on 2d data with variable shift"""
+    """Dot-test and forward/adjoint/inversion for Shift operator on 2d data with variable shift"""
     np.random.seed(0)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     shift = npp.arange(par["nx"])
 
     # 1st axis
     x = np.asarray(
-        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
-        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
+        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
+        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
     )
-    x = np.outer(x, np.ones(par["nx"]))
+    x = np.outer(x, np.ones(par["nx"], dtype=dtype))
     Sop = Shift(
         (par["nt"], par["nx"]),
         shift,
@@ -232,11 +280,15 @@ def test_Shift2Dvariable(par):
         par["nt"] * par["nx"],
         par["nt"] * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    y = Sop * x.ravel()
+    xadj = Sop.H * y
     xlsqr = lsqr(
         Sop,
-        Sop * x.ravel(),
+        y,
         x0=np.zeros_like(x),
         damp=1e-20,
         niter=200,
@@ -244,14 +296,17 @@ def test_Shift2Dvariable(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
+    assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)
 
     # 2nd axis
     x = np.asarray(
-        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
-        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0]
+        gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
+        + par["imag"] * gaussian(np.arange(par["nt"] // 2 + 1), 2.0)[0].astype(dtype)
     )
-    x = np.outer(x, np.ones(par["nx"])).T
+    x = np.outer(x, np.ones(par["nx"], dtype=dtype)).T
     Sop = Shift(
         (par["nx"], par["nt"]),
         shift,
@@ -264,8 +319,12 @@ def test_Shift2Dvariable(par):
         par["nt"] * par["nx"],
         par["nt"] * par["nx"],
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
+
+    y = Sop * x.ravel()
+    xadj = Sop.H * y
     xlsqr = lsqr(
         Sop,
         Sop * x.ravel(),
@@ -276,4 +335,7 @@ def test_Shift2Dvariable(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
+    assert_array_almost_equal(x, xlsqr, decimal=2 if dtype == np.float32 else 4)

--- a/pytests/test_sliding.py
+++ b/pytests/test_sliding.py
@@ -13,6 +13,7 @@ else:
 import pytest
 
 from pylops.basicoperators import Identity, MatrixMult
+from pylops.optimization.basic import cgls
 from pylops.signalprocessing import Sliding1D, Sliding2D, Sliding3D
 from pylops.signalprocessing.sliding1d import sliding1d_design
 from pylops.signalprocessing.sliding2d import sliding2d_design
@@ -112,9 +113,10 @@ par6 = {
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Sliding1D(par):
-    """Dot-test and inverse for Sliding1D operator"""
-    Op = MatrixMult(np.ones((par["nwiny"], par["ny"])))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Sliding1D(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Sliding1D operator"""
+    Op = MatrixMult(np.ones((par["nwiny"], par["ny"]), dtype=dtype), dtype=dtype)
 
     nwins, dim = sliding1d_design(par["npy"], par["nwiny"], par["novery"], par["ny"])[
         :2
@@ -129,27 +131,38 @@ def test_Sliding1D(par):
         tapertype=par["tapertype"],
         savetaper=par["savetaper"],
     )
-    assert dottest(Slid, par["npy"], par["ny"] * nwins, backend=backend)
-    x = np.ones(par["ny"] * nwins)
-    y = Slid * x.ravel()
+    assert dottest(
+        Slid,
+        par["npy"],
+        par["ny"] * nwins,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    xinv = Slid / y
-    assert_array_almost_equal(x.ravel(), xinv)
+    x = np.ones((nwins, par["ny"]), dtype=dtype)
+    y = Slid * x.ravel()
+    xadj = Slid.H * y
+    xinv = cgls(Slid, y, niter=50)[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_Sliding1D_simOp(par):
-    """Dot-test and inverse for Sliding1D operator with
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Sliding1D_simOp(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Sliding1D operator with
     Op applied to all windows simultaneously
     """
     nwins, dim = sliding1d_design(
         par["npy"], par["nwiny"], par["novery"], par["nwiny"]
     )[:2]
 
-    Op = Identity((nwins, par["nwiny"]))
+    Op = Identity((nwins, par["nwiny"]), dtype=dtype)
 
     Slid = Sliding1D(
         Op,
@@ -160,18 +173,30 @@ def test_Sliding1D_simOp(par):
         tapertype=par["tapertype"],
         savetaper=par["savetaper"],
     )
-    assert dottest(Slid, par["npy"], par["nwiny"] * nwins)
-    x = np.ones(par["nwiny"] * nwins)
+    assert dottest(
+        Slid,
+        par["npy"],
+        par["nwiny"] * nwins,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+    )
+    x = np.ones((nwins, par["nwiny"]), dtype=dtype)
     y = Slid * x.ravel()
+    xadj = Slid.H * y
+    xinv = cgls(Slid, y, niter=50)[0]
 
-    xinv = Slid / y
-    assert_array_almost_equal(x.ravel(), xinv)
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Sliding2D(par):
-    """Dot-test and inverse for Sliding2D operator"""
-    Op = MatrixMult(np.ones((par["nwiny"] * par["nt"], par["ny"] * par["nt"])))
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Sliding2D(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Sliding2D operator"""
+    Op = MatrixMult(
+        np.ones((par["nwiny"] * par["nt"], par["ny"] * par["nt"]), dtype=dtype),
+        dtype=dtype,
+    )
 
     nwins, dims = sliding2d_design(
         (par["npy"], par["nt"]), par["nwiny"], par["novery"], (par["ny"], par["nt"])
@@ -186,28 +211,36 @@ def test_Sliding2D(par):
         savetaper=par["savetaper"],
     )
     assert dottest(
-        Slid, par["npy"] * par["nt"], par["ny"] * par["nt"] * nwins, backend=backend
+        Slid,
+        par["npy"] * par["nt"],
+        par["ny"] * par["nt"] * nwins,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
-    x = np.ones((par["ny"] * nwins, par["nt"]))
+    x = np.ones((nwins, par["ny"], par["nt"]), dtype=dtype)
     y = Slid * x.ravel()
+    xadj = Slid.H * y
+    xinv = cgls(Slid, y, niter=50)[0]
 
-    xinv = Slid / y
-    assert_array_almost_equal(x.ravel(), xinv)
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_Sliding2D_simOp(par):
-    """Dot-test and inverse for Sliding2D operator with
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Sliding2D_simOp(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Sliding2D operator with
     Op applied to all windows simultaneously
     """
     nwins, dims = sliding2d_design(
         (par["npy"], par["nt"]), par["nwiny"], par["novery"], (par["nwiny"], par["nt"])
     )[:2]
 
-    Op = Identity((nwins, par["nwiny"], par["nt"]))
+    Op = Identity((nwins, par["nwiny"], par["nt"]), dtype=dtype)
 
     Slid = Sliding2D(
         Op,
@@ -218,20 +251,37 @@ def test_Sliding2D_simOp(par):
         tapertype=par["tapertype"],
         savetaper=par["savetaper"],
     )
-    x = np.ones((nwins, par["nwiny"], par["nt"]))
-    y = Slid * x.ravel()
+    assert dottest(
+        Slid,
+        par["npy"] * par["nt"],
+        par["nwiny"] * par["nt"] * nwins,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    xinv = Slid / y
-    assert_array_almost_equal(x.ravel(), xinv)
+    x = np.ones((nwins, par["nwiny"], par["nt"]), dtype=dtype)
+    y = Slid * x.ravel()
+    xadj = Slid.H * y
+    xinv = cgls(Slid, y, niter=50)[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Sliding3D(par):
-    """Dot-test and inverse for Sliding3D operator"""
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Sliding3D(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Sliding3D operator"""
     Op = MatrixMult(
         np.ones(
-            (par["nwiny"] * par["nwinx"] * par["nt"], par["ny"] * par["nx"] * par["nt"])
-        )
+            (
+                par["nwiny"] * par["nwinx"] * par["nt"],
+                par["ny"] * par["nx"] * par["nt"],
+            ),
+            dtype=dtype,
+        ),
+        dtype=dtype,
     )
 
     nwins, dims = sliding3d_design(
@@ -255,21 +305,27 @@ def test_Sliding3D(par):
         Slid,
         par["npy"] * par["npx"] * par["nt"],
         par["ny"] * par["nx"] * par["nt"] * nwins[0] * nwins[1],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
-    x = np.ones((par["ny"] * par["nx"] * nwins[0] * nwins[1], par["nt"]))
-    y = Slid * x.ravel()
 
-    xinv = Slid / y
-    assert_array_almost_equal(x.ravel(), xinv)
+    x = np.ones((nwins[0], nwins[1], par["ny"], par["nx"], par["nt"]), dtype=dtype)
+    y = Slid * x.ravel()
+    xadj = Slid.H * y
+    xinv = cgls(Slid, y, niter=50)[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)
 
 
 @pytest.mark.skipif(
     int(os.environ.get("TEST_CUPY_PYLOPS", 0)) == 1, reason="Not CuPy enabled"
 )
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_Sliding3D_simOp(par):
-    """Dot-test and inverse for Sliding3D operator with
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Sliding3D_simOp(par, dtype):
+    """Dot-test and forward/adjoint/inverse for Sliding3D operator with
     Op applied to all windows simultaneously
     """
     nwins, dims = sliding3d_design(
@@ -279,7 +335,7 @@ def test_Sliding3D_simOp(par):
         (par["nwiny"], par["nwinx"], par["nt"]),
     )[:2]
 
-    Op = Identity((*nwins, par["nwiny"], par["nwinx"], par["nt"]))
+    Op = Identity((*nwins, par["nwiny"], par["nwinx"], par["nt"]), dtype=dtype)
 
     Slid = Sliding3D(
         Op,
@@ -295,9 +351,16 @@ def test_Sliding3D_simOp(par):
         Slid,
         par["npy"] * par["npx"] * par["nt"],
         par["nwiny"] * par["nwinx"] * par["nt"] * nwins[0] * nwins[1],
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
     )
-    x = np.ones((par["nwiny"] * par["nwinx"] * nwins[0] * nwins[1], par["nt"]))
-    y = Slid * x.ravel()
 
-    xinv = Slid / y
-    assert_array_almost_equal(x.ravel(), xinv)
+    x = np.ones(
+        (nwins[0], nwins[1], par["nwiny"], par["nwinx"], par["nt"]), dtype=dtype
+    )
+    y = Slid * x.ravel()
+    xadj = Slid.H * y
+    xinv = cgls(Slid, y, niter=50)[0]
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xinv, decimal=3 if dtype == np.float32 else 8)

--- a/pytests/test_smoothing.py
+++ b/pytests/test_smoothing.py
@@ -27,14 +27,23 @@ np.random.seed(0)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4)])
-def test_Smoothing1D(par):
-    """Dot-test and inversion for Smoothing1D"""
-    # 1d kernel on 1d signal
-    D1op = Smoothing1D(nsmooth=5, dims=par["nx"], dtype="float64")
-    assert dottest(D1op, par["nx"], par["nx"], backend=backend)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Smoothing1D(par, dtype):
+    """Dot-test and forward/adjoint/inversion for Smoothing1D"""
 
-    x = np.random.normal(0, 1, par["nx"])
+    # 1d kernel on 1d signal
+    D1op = Smoothing1D(nsmooth=5, dims=par["nx"], dtype=dtype)
+    assert dottest(
+        D1op,
+        par["nx"],
+        par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    x = np.random.normal(0, 1, par["nx"]).astype(dtype)
     y = D1op * x
+    xadj = D1op.H * y
     xlsqr = lsqr(
         D1op,
         y,
@@ -45,16 +54,26 @@ def test_Smoothing1D(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=3)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xlsqr, decimal=1 if dtype == np.float32 else 3)
 
     # 1d kernel on 2d signal
     D1op = Smoothing1D(
-        nsmooth=5, dims=(par["ny"], par["nx"]), axis=par["axis"], dtype="float64"
+        nsmooth=5, dims=(par["ny"], par["nx"]), axis=par["axis"], dtype=dtype
     )
-    assert dottest(D1op, par["ny"] * par["nx"], par["ny"] * par["nx"], backend=backend)
+    assert dottest(
+        D1op,
+        par["ny"] * par["nx"],
+        par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
 
-    x = np.random.normal(0, 1, (par["ny"], par["nx"])).ravel()
+    x = np.random.normal(0, 1, (par["ny"], par["nx"])).astype(dtype).ravel()
     y = D1op * x
+    xadj = D1op.H * y
     xlsqr = lsqr(
         D1op,
         y,
@@ -65,51 +84,68 @@ def test_Smoothing1D(par):
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=3)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xlsqr, decimal=1 if dtype == np.float32 else 3)
 
     # 1d kernel on 3d signal
     D1op = Smoothing1D(
         nsmooth=5,
         dims=(par["nz"], par["ny"], par["nx"]),
         axis=par["axis"],
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
         D1op,
         par["nz"] * par["ny"] * par["nx"],
         par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
     )
 
-    x = np.random.normal(0, 1, (par["nz"], par["ny"], par["nx"])).ravel()
+    x = np.random.normal(0, 1, (par["nz"], par["ny"], par["nx"])).astype(dtype).ravel()
     y = D1op * x
+    xadj = D1op.H * y
     xlsqr = lsqr(
         D1op,
         y,
         x0=np.zeros_like(x),
         damp=1e-10,
-        niter=100,
+        niter=200,
         atol=1e-8,
         btol=1e-8,
         show=0,
     )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=3)
+
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
+    assert_array_almost_equal(x, xlsqr, decimal=1 if dtype == np.float32 else 3)
 
 
 @pytest.mark.parametrize("par", [(par1), (par2), (par3), (par4), (par5), (par6)])
-def test_Smoothing2D(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_Smoothing2D(par, dtype):
     """Dot-test for Smoothing2D"""
     # 2d kernel on 2d signal
     if par["axis"] < 2:
-        D2op = Smoothing2D(nsmooth=(5, 5), dims=(par["ny"], par["nx"]), dtype="float64")
-        assert dottest(D2op, par["ny"] * par["nx"], par["ny"] * par["nx"], rtol=1e-3)
+        D2op = Smoothing2D(nsmooth=(5, 5), dims=(par["ny"], par["nx"]), dtype=dtype)
+        assert dottest(
+            D2op,
+            par["ny"] * par["nx"],
+            par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
         # forward
-        x = np.zeros((par["ny"], par["nx"]))
+        x = np.zeros((par["ny"], par["nx"]), dtype=dtype)
         x[par["ny"] // 2, par["nx"] // 2] = 1.0
         x = x.ravel()
         y = D2op * x
+        xadj = D2op.H * y
         y = y.reshape(par["ny"], par["nx"])
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
         assert_array_almost_equal(
             y[par["ny"] // 2 - 2 : par["ny"] // 2 + 3 :, par["nx"] // 2],
             np.ones(5) / 25,
@@ -137,19 +173,26 @@ def test_Smoothing2D(par):
         nsmooth=(5, 5),
         dims=(par["nz"], par["ny"], par["nx"]),
         axes=axes,
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
-        D2op, par["nz"] * par["ny"] * par["nx"], par["nz"] * par["ny"] * par["nx"]
+        D2op,
+        par["nz"] * par["ny"] * par["nx"],
+        par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
 
     # forward
-    x = np.zeros((par["nz"], par["ny"], par["nx"]))
+    x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
     x[par["nz"] // 2, par["ny"] // 2, par["nx"] // 2] = 1.0
     x = x.ravel()
     y = D2op * x
-    y = y.reshape(par["nz"], par["ny"], par["nx"])
+    xadj = D2op.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
+    y = y.reshape(par["nz"], par["ny"], par["nx"])
     if par["axis"] == 0:
         assert_array_almost_equal(
             y[
@@ -193,27 +236,35 @@ def test_Smoothing2D(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
-def test_SmoothingND(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_SmoothingND(par, dtype):
     """Dot-test for SmoothingND"""
     # 3d signal
     axes = list(range(3))
-    D2op = SmoothingND(
+    D3op = SmoothingND(
         nsmooth=(3, 3, 3),
         dims=(par["nz"], par["ny"], par["nx"]),
         axes=axes,
-        dtype="float64",
+        dtype=dtype,
     )
     assert dottest(
-        D2op, par["nz"] * par["ny"] * par["nx"], par["nz"] * par["ny"] * par["nx"]
+        D3op,
+        par["nz"] * par["ny"] * par["nx"],
+        par["nz"] * par["ny"] * par["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
     )
 
     # forward
-    x = np.zeros((par["nz"], par["ny"], par["nx"]))
+    x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
     x[par["nz"] // 2, par["ny"] // 2, par["nx"] // 2] = 1.0
     x = x.ravel()
-    y = D2op * x
-    y = y.reshape(par["nz"], par["ny"], par["nx"])
+    y = D3op * x
+    xadj = D3op.H * y
+    assert y.dtype == dtype
+    assert xadj.dtype == dtype
 
+    y = y.reshape(par["nz"], par["ny"], par["nx"])
     assert_array_almost_equal(
         y[
             par["nz"] // 2 - 1 : par["nz"] // 2 + 2,
@@ -233,7 +284,7 @@ def test_SmoothingND(par):
 
     # inverse
     xlsqr = lsqr(
-        D2op,
+        D3op,
         y.ravel(),
         x0=np.zeros_like(x),
         damp=1e-10,

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -17,28 +17,31 @@ import torch
 from pylops import MatrixMult, TorchOperator
 from pylops.utils.backend import to_numpy
 
-par1 = {"ny": 11, "nx": 11, "dtype": np.float32}  # square
-par2 = {"ny": 21, "nx": 11, "dtype": np.float32}  # overdetermined
+par1 = {"ny": 11, "nx": 11}  # square
+par2 = {"ny": 21, "nx": 11}  # overdetermined
 
 np.random.seed(0)
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Not OSX enabled")
 @pytest.mark.parametrize("par", [(par1)])
-def test_TorchOperator(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_TorchOperator(par, dtype):
     """Apply forward and gradient. As for linear operators the gradient
     must equal the adjoint of operator applied to the same vector, the two
     results are also checked to be the same.
     """
     device = "cpu" if backend == "numpy" else "cuda"
 
-    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
+    Dop = MatrixMult(
+        np.random.normal(0.0, 1.0, (par["ny"], par["nx"])).astype(dtype), dtype=dtype
+    )
     Top = TorchOperator(Dop, batch=False, device="cpu" if backend == "numpy" else "gpu")
 
-    x = np.random.normal(0.0, 1.0, par["nx"])
+    x = np.random.normal(0.0, 1.0, par["nx"]).astype(dtype)
     xt = torch.from_numpy(to_numpy(x)).to(device).view(-1)
     xt.requires_grad = True
-    v = np.random.normal(0.0, 1.0, par["ny"])
+    v = np.random.normal(0.0, 1.0, par["ny"]).astype(dtype)
     vt = torch.from_numpy(to_numpy(v)).to(device).view(-1)
 
     # pylops operator
@@ -48,46 +51,60 @@ def test_TorchOperator(par):
     # torch operator
     yt = Top.apply(xt)
     yt.backward(vt, retain_graph=True)
+    yt = yt.detach().cpu()
+    xadjt = xt.grad.cpu()
 
-    assert_array_equal(y, yt.detach().cpu().numpy())
-    assert_array_equal(xadj, xt.grad.cpu().numpy())
+    assert yt.dtype == torch.from_numpy(x).dtype
+    assert xadjt.dtype == torch.from_numpy(x).dtype
+    assert_array_equal(y, yt.numpy())
+    assert_array_equal(xadj, xadjt.numpy())
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Not OSX enabled")
 @pytest.mark.parametrize("par", [(par1)])
-def test_TorchOperator_batch(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_TorchOperator_batch(par, dtype):
     """Apply forward for input with multiple samples (= batch) and flattened arrays"""
     device = "cpu" if backend == "numpy" else "cuda"
 
-    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])))
+    Dop = MatrixMult(
+        np.random.normal(0.0, 1.0, (par["ny"], par["nx"])).astype(dtype), dtype=dtype
+    )
     Top = TorchOperator(Dop, batch=True, device="cpu" if backend == "numpy" else "gpu")
 
-    x = np.random.normal(0.0, 1.0, (4, par["nx"]))
+    x = np.random.normal(0.0, 1.0, (4, par["nx"])).astype(dtype)
     xt = torch.from_numpy(to_numpy(x)).to(device)
     xt.requires_grad = True
 
     y = Dop.matmat(x.T).T
     yt = Top.apply(xt)
 
+    assert yt.dtype == torch.from_numpy(x).dtype
     assert_array_equal(y, yt.detach().cpu().numpy())
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Not OSX enabled")
 @pytest.mark.parametrize("par", [(par1)])
-def test_TorchOperator_batch_nd(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_TorchOperator_batch_nd(par, dtype):
     """Apply forward for input with multiple samples (= batch) and nd-arrays"""
     device = "cpu" if backend == "numpy" else "cuda"
 
-    Dop = MatrixMult(np.random.normal(0.0, 1.0, (par["ny"], par["nx"])), otherdims=(2,))
+    Dop = MatrixMult(
+        np.random.normal(0.0, 1.0, (par["ny"], par["nx"])).astype(dtype),
+        otherdims=(2,),
+        dtype=dtype,
+    )
     Top = TorchOperator(
         Dop, batch=True, flatten=False, device="cpu" if backend == "numpy" else "cuda"
     )
 
-    x = np.random.normal(0.0, 1.0, (4, par["nx"], 2))
+    x = np.random.normal(0.0, 1.0, (4, par["nx"], 2)).astype(dtype)
     xt = torch.from_numpy(to_numpy(x)).to(device)
     xt.requires_grad = True
 
     y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
     yt = Top.apply(xt)
 
+    assert yt.dtype == torch.from_numpy(x).dtype
     assert_array_equal(y, yt.detach().cpu().numpy())

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -51,13 +51,13 @@ def test_TorchOperator(par, dtype):
     # torch operator
     yt = Top.apply(xt)
     yt.backward(vt, retain_graph=True)
-    yt = yt.detach().cpu()
-    xadjt = xt.grad.cpu()
+    yt = yt.detach().cpu().numpy()
+    xadjt = xt.grad.cpu().numpy()
 
-    assert yt.dtype == torch.from_numpy(x).dtype
-    assert xadjt.dtype == torch.from_numpy(x).dtype
-    assert_array_equal(y, yt.numpy())
-    assert_array_equal(xadj, xadjt.numpy())
+    assert yt.dtype == x.dtype
+    assert xadjt.dtype == x.dtype
+    assert_array_equal(y, yt)
+    assert_array_equal(xadj, xadjt)
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Not OSX enabled")
@@ -78,9 +78,9 @@ def test_TorchOperator_batch(par, dtype):
 
     y = Dop.matmat(x.T).T
     yt = Top.apply(xt)
-
-    assert yt.dtype == torch.from_numpy(x).dtype
-    assert_array_equal(y, yt.detach().cpu().numpy())
+    yt = yt.detach().cpu().numpy()
+    assert yt.dtype == x.dtype
+    assert_array_equal(y, yt)
 
 
 @pytest.mark.skipif(platform.system() == "Darwin", reason="Not OSX enabled")
@@ -105,6 +105,9 @@ def test_TorchOperator_batch_nd(par, dtype):
 
     y = (Dop @ x.transpose(1, 2, 0)).transpose(2, 0, 1)
     yt = Top.apply(xt)
+    yt = yt.detach().cpu().numpy()
 
-    assert yt.dtype == torch.from_numpy(x).dtype
-    assert_array_equal(y, yt.detach().cpu().numpy())
+    assert yt.dtype == dtype
+    assert_array_equal(
+        y,
+    )

--- a/pytests/test_torchoperator.py
+++ b/pytests/test_torchoperator.py
@@ -108,6 +108,4 @@ def test_TorchOperator_batch_nd(par, dtype):
     yt = yt.detach().cpu().numpy()
 
     assert yt.dtype == dtype
-    assert_array_equal(
-        y,
-    )
+    assert_array_equal(y, yt)

--- a/pytests/test_transpose.py
+++ b/pytests/test_transpose.py
@@ -16,19 +16,22 @@ import pytest
 from pylops.basicoperators import Transpose
 from pylops.utils import dottest
 
-par1 = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float64"}  # real
-par2 = {"ny": 21, "nx": 11, "nt": 20, "imag": 1j, "dtype": "complex128"}  # complex
+par1 = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float64"}  # real (fp64)
+par1s = {"ny": 21, "nx": 11, "nt": 20, "imag": 0, "dtype": "float32"}  # real (fp32)
+par1j = {"ny": 21, "nx": 11, "nt": 20, "imag": 1j, "dtype": "complex128"}  # complex
 
 np.random.seed(10)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Transpose_2dsignal(par):
     """Dot-test and adjoint for Transpose operator for 2d signals"""
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
     dims = (par["ny"], par["nx"])
-    x = np.arange(par["ny"] * par["nx"]).reshape(dims) + par["imag"] * np.arange(
-        par["ny"] * par["nx"]
-    ).reshape(dims)
+    x = np.arange(par["ny"] * par["nx"], dtype=dtype).reshape(dims) + par[
+        "imag"
+    ] * np.arange(par["ny"] * par["nx"], dtype=dtype).reshape(dims)
 
     Top = Transpose(dims=dims, axes=(1, 0), dtype=par["dtype"])
     assert dottest(
@@ -44,19 +47,23 @@ def test_Transpose_2dsignal(par):
     y = y.reshape(Top.dimsd)
     xadj = xadj.reshape(Top.dims)
 
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
     assert_array_equal(x, xadj)
     assert_array_equal(y, x.T)
 
 
-@pytest.mark.parametrize("par", [(par1), (par2)])
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j)])
 def test_Transpose_3dsignal(par):
     """Dot-test and adjoint for Transpose operator for 3d signals"""
-    dims = (par["ny"], par["nx"], par["nt"])
-    x = np.arange(par["ny"] * par["nx"] * par["nt"]).reshape(dims) + par[
-        "imag"
-    ] * np.arange(par["ny"] * par["nx"] * par["nt"]).reshape(dims)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
 
-    Top = Transpose(dims=dims, axes=(2, 1, 0))
+    dims = (par["ny"], par["nx"], par["nt"])
+    x = np.arange(par["ny"] * par["nx"] * par["nt"], dtype=dtype).reshape(dims) + par[
+        "imag"
+    ] * np.arange(par["ny"] * par["nx"] * par["nt"], dtype=dtype).reshape(dims)
+
+    Top = Transpose(dims=dims, axes=(2, 1, 0), dtype=par["dtype"])
     assert dottest(
         Top,
         npp.prod(dims),
@@ -71,4 +78,6 @@ def test_Transpose_3dsignal(par):
     y = y.reshape(Top.dimsd)
     xadj = xadj.reshape(Top.dims)
 
+    assert y.dtype == par["dtype"]
+    assert xadj.dtype == par["dtype"]
     assert_array_equal(x, xadj)

--- a/pytests/test_transpose.py
+++ b/pytests/test_transpose.py
@@ -39,6 +39,7 @@ def test_Transpose_2dsignal(par):
         npp.prod(dims),
         npp.prod(dims),
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
     y = Top * x.ravel()
@@ -69,6 +70,7 @@ def test_Transpose_3dsignal(par):
         npp.prod(dims),
         npp.prod(dims),
         complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 

--- a/pytests/test_twoway.py
+++ b/pytests/test_twoway.py
@@ -61,3 +61,9 @@ def test_acwave2d():
     assert dottest(
         Dop, par["ns"] * par["nr"] * Dop.geometry.nt, par["nz"] * par["nx"], atol=1e-1
     )
+
+    x = np.ones(par["nz"] * par["nx"], dtype="float32")
+    y = Dop * x
+    xadj = Dop.H * y
+    assert y.dtype == "float32"
+    assert xadj.dtype == "float32"

--- a/pytests/test_waveeqprocessing.py
+++ b/pytests/test_waveeqprocessing.py
@@ -140,9 +140,12 @@ def create_data(par, nv):
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7), (par8)]
 )
-def test_MDC_1virtualsource(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_MDC_1virtualsource(par, dtype):
     """Dot-test and inversion for MDC operator of 1 virtual source"""
+    cdtype = (np.empty(0, dtype=dtype) + 1j * np.empty(0, dtype=dtype)).dtype
     nt2, wav, mwav, Gwav, Gwav_fft = create_data(par, 1)
+    Gwav_fft = Gwav_fft.astype(cdtype)
 
     MDCop = MDC(
         np.asarray(Gwav_fft).transpose(2, 0, 1),
@@ -152,10 +155,18 @@ def test_MDC_1virtualsource(par):
         dr=parmod["dx"],
         twosided=par["twosided"],
     )
-    dottest(MDCop, nt2 * parmod["ny"], nt2 * parmod["nx"], backend=backend)
-    mwav = np.asarray(mwav).T
+    dottest(
+        MDCop,
+        nt2 * parmod["ny"],
+        nt2 * parmod["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    mwav = np.asarray(mwav.astype(dtype)).T
     d = MDCop * mwav.ravel()
     d = d.reshape(nt2, parmod["ny"])
+    assert d.dtype == dtype
 
     for it, amp in zip(it0_G, amp_G, strict=True):
         ittot = it0_m + it
@@ -201,9 +212,12 @@ def test_MDC_1virtualsource(par):
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par5), (par6), (par7), (par8)]
 )
-def test_MDC_Nvirtualsources(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_MDC_Nvirtualsources(par, dtype):
     """Dot-test and inversion for MDC operator of N virtual source"""
+    cdtype = (np.empty(0, dtype=dtype) + 1j * np.empty(0, dtype=dtype)).dtype
     nt2, _, mwav, Gwav, Gwav_fft = create_data(par, parmod["nx"])
+    Gwav_fft = Gwav_fft.astype(cdtype)
 
     MDCop = MDC(
         np.asarray(Gwav_fft).transpose(2, 0, 1),
@@ -217,12 +231,14 @@ def test_MDC_Nvirtualsources(par):
         MDCop,
         nt2 * parmod["ny"] * parmod["nx"],
         nt2 * parmod["nx"] * parmod["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
-    mwav = np.asarray(mwav).transpose(2, 0, 1)
+    mwav = np.asarray(mwav.astype(dtype)).transpose(2, 0, 1)
     d = MDCop * mwav.ravel()
     d = d.reshape(nt2, parmod["ny"], parmod["nx"])
+    assert d.dtype == dtype
 
     for it, _ in zip(it0_G, amp_G, strict=True):
         ittot = it0_m + it
@@ -272,9 +288,12 @@ def test_MDC_Nvirtualsources(par):
         (par1),
     ],
 )
-def test_MDC_1virtualsource_scipy(par):
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_MDC_1virtualsource_scipy(par, dtype):
     """Dot-test for MDC operator of 1 virtual source with scipy engine and workers"""
-    nt2, _, _, _, Gwav_fft = create_data(par, 1)
+    cdtype = (np.empty(0, dtype=dtype) + 1j * np.empty(0, dtype=dtype)).dtype
+    nt2, _, mwav, _, Gwav_fft = create_data(par, 1)
+    Gwav_fft = Gwav_fft.astype(cdtype)
 
     MDCop = MDC(
         np.asarray(Gwav_fft).transpose(2, 0, 1),
@@ -286,4 +305,15 @@ def test_MDC_1virtualsource_scipy(par):
         engine="scipy",
         **dict(workers=4),
     )
-    dottest(MDCop, nt2 * parmod["ny"], nt2 * parmod["nx"], backend=backend)
+    dottest(
+        MDCop,
+        nt2 * parmod["ny"],
+        nt2 * parmod["nx"],
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    mwav = np.asarray(mwav.astype(dtype)).T
+    d = MDCop * mwav.ravel()
+    d = d.reshape(nt2, parmod["ny"])
+    assert d.dtype == dtype

--- a/pytests/test_waveeqprocessing.py
+++ b/pytests/test_waveeqprocessing.py
@@ -159,7 +159,7 @@ def test_MDC_1virtualsource(par, dtype):
         MDCop,
         nt2 * parmod["ny"],
         nt2 * parmod["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -231,7 +231,7 @@ def test_MDC_Nvirtualsources(par, dtype):
         MDCop,
         nt2 * parmod["ny"] * parmod["nx"],
         nt2 * parmod["nx"] * parmod["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 
@@ -309,7 +309,7 @@ def test_MDC_1virtualsource_scipy(par, dtype):
         MDCop,
         nt2 * parmod["ny"],
         nt2 * parmod["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        rtol=1e-3 if dtype == np.float32 else 1e-6,
         backend=backend,
     )
 


### PR DESCRIPTION
This PR fixes dtype consistency for the following operators when forward/adjoint is applied:
- `AVOLinearModelling`: when `vsvp` is a scalar, the matrix G becomes fp64 by default, it is not now casted to the dtype of the operator.
- `Bilinear`: currently, because the indices are casted to np.int64, also the weights become np.float64 also when the input/operator is np.float32 - fixes https://github.com/PyLops/pylops/issues/744
- `Interp`: same fix as Bilinear for linear and sinc modes.
- `Laplacian`: appended operators are created in a slightly different way to ensure that no automatic upcasting is triggered in `l2op += weight * SecondDerivative(...)` step
- `Marchenko`: fixed dtype for some of the internal operators and vectors
- `NonStationaryFilters2D`: fix dtype at initialization of hstmp in rmatvec method.
- `Seislet`: fix dtype at initialization of arrays and pad operator.
- `Sliding1D/2D/3D`: fix dtype of taper (and application of internal `Op`, this to enable using pylops solvers)
- `Smoothing1D/2D/ND`: fix dtype of h

As part of this PR, assertions for dtype are added to the test of all operators.