### PR TITLE
Add damp support to CG solver (closes #406)

### DIFF
--- a/pylops/optimization/basic.py
+++ b/pylops/optimization/basic.py
@@ -47,10 +47,7 @@ def cg(
     niter : :obj:`int`, optional
         Number of iterations
     damp : :obj:`float`, optional
-        Damping coefficient. When non-zero, the damped system
-        :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}` is
-        solved instead of :math:`\mathbf{Op}\,\mathbf{x} = \mathbf{y}`. ``Op``
-        must be square and symmetric positive-definite.
+        Damping coefficient
     tol : :obj:`float`, optional
         Absolute tolerance on residual norm. Stops the solver when the
         residual norm is below this value.

--- a/pylops/optimization/basic.py
+++ b/pylops/optimization/basic.py
@@ -22,6 +22,7 @@ def cg(
     y: NDArray,
     x0: NDArray | None = None,
     niter: int = 10,
+    damp: float = 0.0,
     tol: float = 1e-4,
     rtol: float = 0.0,
     rtol1: float = 0.0,
@@ -45,6 +46,11 @@ def cg(
         Initial guess
     niter : :obj:`int`, optional
         Number of iterations
+    damp : :obj:`float`, optional
+        Damping coefficient. When non-zero, the damped system
+        :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}` is
+        solved instead of :math:`\mathbf{Op}\,\mathbf{x} = \mathbf{y}`. ``Op``
+        must be square and symmetric positive-definite.
     tol : :obj:`float`, optional
         Absolute tolerance on residual norm. Stops the solver when the
         residual norm is below this value.
@@ -101,6 +107,7 @@ def cg(
         x0=x0,
         tol=tol,
         niter=niter,
+        damp=damp,
         show=show,
         itershow=itershow,
         preallocate=preallocate,

--- a/pylops/optimization/cls_basic.py
+++ b/pylops/optimization/cls_basic.py
@@ -68,6 +68,13 @@ class CG(Solver):
     Solve the :math:`\mathbf{y} = \mathbf{Op}\,\mathbf{x}` problem using conjugate gradient
     iterations [1]_.
 
+    When a non-zero damping coefficient :math:`\epsilon` is provided to ``setup``/``solve``,
+    the damped system :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}` is
+    solved instead; this is achieved by adding :math:`\epsilon\mathbf{c}` to every operator
+    application :math:`\mathbf{Op}\,\mathbf{c}` in the iterations. ``Op`` is still required to
+    be square and symmetric positive-definite (with :math:`\epsilon \geq 0` the damped
+    operator remains so).
+
     .. [1] Hestenes, M R., Stiefel, E., “Methods of Conjugate Gradients for Solving
        Linear Systems”, Journal of Research of the National Bureau of Standards.
        vol. 49. 1952.
@@ -134,6 +141,7 @@ class CG(Solver):
         y: NDArray,
         x0: NDArray | None = None,
         niter: int | None = None,
+        damp: float = 0.0,
         tol: float = 1e-4,
         preallocate: bool = False,
         show: bool = False,
@@ -150,6 +158,10 @@ class CG(Solver):
         niter : :obj:`int`, optional
             Number of iterations (default to ``None`` in case a user wants to
             manually step over the solver)
+        damp : :obj:`float`, optional
+            Damping coefficient. When non-zero, the damped system
+            :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}`
+            is solved instead of :math:`\mathbf{Op}\,\mathbf{x} = \mathbf{y}`.
         tol : :obj:`float`, optional
             Absolute tolerance on residual norm. Stops the solver when the
             residual norm is below this value.
@@ -170,6 +182,7 @@ class CG(Solver):
         """
         self.y = y
         self.niter = niter
+        self.damp = damp
         self.tol = tol
 
         self.ncp = get_array_module(y)
@@ -187,6 +200,9 @@ class CG(Solver):
             else:
                 self.r = self.ncp.empty_like(self.y)
                 self.ncp.subtract(self.y, self.Op.matvec(x), out=self.r)
+            # account for the damping term in the initial residual
+            if self.damp != 0.0:
+                self.r -= self.damp * x
         self.c = self.r.copy()
         self.kold = self.ncp.abs(self.r.dot(self.r.conj()))
 
@@ -221,6 +237,10 @@ class CG(Solver):
 
         """
         Opc = self.Op.matvec(self.c)
+        # solve the damped system (Op + damp*I) x = y by adding the damping
+        # contribution to every application of the operator
+        if self.damp != 0.0:
+            Opc = Opc + self.damp * self.c
         cOpc = self.ncp.abs(self.c.dot(Opc.conj()))
         a = self.kold / cOpc
         if not self.preallocate:
@@ -317,6 +337,7 @@ class CG(Solver):
         y: NDArray,
         x0: NDArray | None = None,
         niter: int = 10,
+        damp: float = 0.0,
         tol: float = 1e-4,
         preallocate: bool = False,
         show: bool = False,
@@ -333,6 +354,10 @@ class CG(Solver):
             internally as zero vector
         niter : :obj:`int`, optional
             Number of iterations
+        damp : :obj:`float`, optional
+            Damping coefficient. When non-zero, the damped system
+            :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}`
+            is solved instead of :math:`\mathbf{Op}\,\mathbf{x} = \mathbf{y}`.
         tol : :obj:`float`, optional
             Absolute tolerance on residual norm. Stops the solver when the
             residual norm is below this value.
@@ -360,7 +385,13 @@ class CG(Solver):
 
         """
         x = self.setup(
-            y=y, x0=x0, niter=niter, tol=tol, preallocate=preallocate, show=show
+            y=y,
+            x0=x0,
+            niter=niter,
+            damp=damp,
+            tol=tol,
+            preallocate=preallocate,
+            show=show,
         )
         x = self.run(x, niter, show=show, itershow=itershow)
         self.finalize(show)

--- a/pylops/optimization/cls_basic.py
+++ b/pylops/optimization/cls_basic.py
@@ -65,15 +65,9 @@ class CG(Solver):
 
     Notes
     -----
-    Solve the :math:`\mathbf{y} = \mathbf{Op}\,\mathbf{x}` problem using conjugate gradient
-    iterations [1]_.
-
-    When a non-zero damping coefficient :math:`\epsilon` is provided to ``setup``/``solve``,
-    the damped system :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}` is
-    solved instead; this is achieved by adding :math:`\epsilon\mathbf{c}` to every operator
-    application :math:`\mathbf{Op}\,\mathbf{c}` in the iterations. ``Op`` is still required to
-    be square and symmetric positive-definite (with :math:`\epsilon \geq 0` the damped
-    operator remains so).
+    Solve the :math:`\mathbf{y} = (\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x}` problem
+    using conjugate gradient iterations [1]_, where :math:`\epsilon` is the damping
+    coefficient.
 
     .. [1] Hestenes, M R., Stiefel, E., “Methods of Conjugate Gradients for Solving
        Linear Systems”, Journal of Research of the National Bureau of Standards.
@@ -159,9 +153,7 @@ class CG(Solver):
             Number of iterations (default to ``None`` in case a user wants to
             manually step over the solver)
         damp : :obj:`float`, optional
-            Damping coefficient. When non-zero, the damped system
-            :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}`
-            is solved instead of :math:`\mathbf{Op}\,\mathbf{x} = \mathbf{y}`.
+            Damping coefficient
         tol : :obj:`float`, optional
             Absolute tolerance on residual norm. Stops the solver when the
             residual norm is below this value.
@@ -202,7 +194,10 @@ class CG(Solver):
                 self.ncp.subtract(self.y, self.Op.matvec(x), out=self.r)
             # account for the damping term in the initial residual
             if self.damp != 0.0:
-                self.r -= self.damp * x
+                if not self.preallocate:
+                    self.r = self.r - self.damp * x
+                else:
+                    self.ncp.subtract(self.r, self.damp * x, out=self.r)
         self.c = self.r.copy()
         self.kold = self.ncp.abs(self.r.dot(self.r.conj()))
 
@@ -237,8 +232,7 @@ class CG(Solver):
 
         """
         Opc = self.Op.matvec(self.c)
-        # solve the damped system (Op + damp*I) x = y by adding the damping
-        # contribution to every application of the operator
+        # add damping contribution
         if self.damp != 0.0:
             Opc = Opc + self.damp * self.c
         cOpc = self.ncp.abs(self.c.dot(Opc.conj()))
@@ -355,9 +349,7 @@ class CG(Solver):
         niter : :obj:`int`, optional
             Number of iterations
         damp : :obj:`float`, optional
-            Damping coefficient. When non-zero, the damped system
-            :math:`(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y}`
-            is solved instead of :math:`\mathbf{Op}\,\mathbf{x} = \mathbf{y}`.
+            Damping coefficient
         tol : :obj:`float`, optional
             Absolute tolerance on residual norm. Stops the solver when the
             residual norm is below this value.

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -104,7 +104,7 @@ def test_cg(par):
 
 @pytest.mark.parametrize("par", [(par1), (par2)])
 def test_cg_damp(par):
-    """CG with damping solves the damped system (Op + damp*I) x = y (issue #406).
+    """CG with damping solves the damped system (Op + damp*I) x = y.
 
     Verify equivalence between internal damping, adding ``damp*I`` to the
     operator (with ``damp=0`` in the solver), and the dense solution; and that
@@ -116,16 +116,17 @@ def test_cg_damp(par):
     A = np.random.normal(0, 1, (n, n)) + par["imag"] * np.random.normal(0, 1, (n, n))
     A = np.conj(A).T @ A + np.eye(n)  # symmetric positive-definite
     Aop = MatrixMult(A, dtype=par["dtype"])
-    y = np.random.normal(0, 1, n) + par["imag"] * np.random.normal(0, 1, n)
+    x = np.ones(n) + par["imag"] * np.ones(n)
+    y = Aop * x
     damp = 0.8
 
     x_dense = np.linalg.solve(A + damp * np.eye(n), y)
     # adding damp*I to the operator and using damp=0 must match internal damping
     Aop_damped = MatrixMult(A + damp * np.eye(n), dtype=par["dtype"])
 
-    for prealloc in [False, True]:
-        x_int = cg(Aop, y, niter=4 * n, tol=1e-10, damp=damp, preallocate=prealloc)[0]
-        x_ext = cg(Aop_damped, y, niter=4 * n, tol=1e-10, preallocate=prealloc)[0]
+    for preallocate in [False, True]:
+        x_int = cg(Aop, y, niter=4 * n, tol=1e-10, damp=damp, preallocate=preallocate)[0]
+        x_ext = cg(Aop_damped, y, niter=4 * n, tol=1e-10, preallocate=preallocate)[0]
         assert_array_almost_equal(x_int, x_dense, decimal=5)
         assert_array_almost_equal(x_int, x_ext, decimal=5)
 

--- a/pytests/test_solver.py
+++ b/pytests/test_solver.py
@@ -102,6 +102,38 @@ def test_cg(par):
         assert_array_almost_equal(x, xinv, decimal=4)
 
 
+@pytest.mark.parametrize("par", [(par1), (par2)])
+def test_cg_damp(par):
+    """CG with damping solves the damped system (Op + damp*I) x = y (issue #406).
+
+    Verify equivalence between internal damping, adding ``damp*I`` to the
+    operator (with ``damp=0`` in the solver), and the dense solution; and that
+    ``damp=0`` reproduces the undamped result.
+    """
+    np.random.seed(10)
+
+    n = par["nx"]
+    A = np.random.normal(0, 1, (n, n)) + par["imag"] * np.random.normal(0, 1, (n, n))
+    A = np.conj(A).T @ A + np.eye(n)  # symmetric positive-definite
+    Aop = MatrixMult(A, dtype=par["dtype"])
+    y = np.random.normal(0, 1, n) + par["imag"] * np.random.normal(0, 1, n)
+    damp = 0.8
+
+    x_dense = np.linalg.solve(A + damp * np.eye(n), y)
+    # adding damp*I to the operator and using damp=0 must match internal damping
+    Aop_damped = MatrixMult(A + damp * np.eye(n), dtype=par["dtype"])
+
+    for prealloc in [False, True]:
+        x_int = cg(Aop, y, niter=4 * n, tol=1e-10, damp=damp, preallocate=prealloc)[0]
+        x_ext = cg(Aop_damped, y, niter=4 * n, tol=1e-10, preallocate=prealloc)[0]
+        assert_array_almost_equal(x_int, x_dense, decimal=5)
+        assert_array_almost_equal(x_int, x_ext, decimal=5)
+
+    # damp=0 reproduces the undamped solution
+    x_undamped = cg(Aop, y, niter=4 * n, tol=1e-10, damp=0.0)[0]
+    assert_array_almost_equal(x_undamped, np.linalg.solve(A, y), decimal=5)
+
+
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1j), (par2j), (par3j), (par3j)]
 )


### PR DESCRIPTION
## Motivation

`CG` currently only solves $\mathbf{Op}\,\mathbf{x} = \mathbf{y}$. As discussed in #406, it should also be able to solve the *damped* system

$$(\mathbf{Op} + \epsilon\mathbf{I})\,\mathbf{x} = \mathbf{y},$$

consistent with `cgls`/`lsqr` (which both expose `damp`). The `damp` argument used to exist on `CG` as an unused stub and was removed in v2; this PR re-introduces it **with a working implementation**.

This matches the issue's *definition of done* ("Added implementation with `damp != 0`") and the semantics @mrava87 confirmed there: solve $(A + \text{damp}\,I)x = y$, equivalent to adding `damp*I` to the operator and using `damp=0`.

## Implementation

Damping is applied by adding $\epsilon\mathbf{c}$ to **every application of the operator** $\mathbf{Op}\,\mathbf{c}$ in the iterations (and $\epsilon\mathbf{x}_0$ to the initial residual when `x0` is given) — i.e. the operator is implicitly replaced by $\mathbf{Op} + \epsilon\mathbf{I}$:

```python
Opc = self.Op.matvec(self.c)
if self.damp != 0.0:
    Opc = Opc + self.damp * self.c
```

`damp` is threaded through `cg()`, `CG.solve` and `CG.setup` (default `0.0`). With `damp=0.0` the code path is identical to before, so existing behaviour is unchanged. `Op` must remain square and SPD, which $\mathbf{Op} + \epsilon\mathbf{I}$ is for $\epsilon \ge 0$.

## Verification

Added `test_cg_damp` which checks, for both `preallocate` modes, the equivalence @mrava87 suggested in the issue:

- internal damping `cg(Op, y, damp=d)` == adding `d*I` to the operator `cg(Op + d*I, y, damp=0)`
- both == dense `(Op + d*I)^{-1} y`
- `damp=0` still recovers the undamped `Op^{-1} y`

Full `pytests/test_solver.py` passes (100 tests), `ruff check` clean.