### PR TITLE
Agent: added pi coverage checker

### DIFF
--- a/.pi/prompts/optest.md
+++ b/.pi/prompts/optest.md
@@ -1,0 +1,44 @@
+---
+description: Raise an operator's test coverage above 90% by adding/modifying tests
+argument-hint: "<OperatorName> [threshold]"
+---
+Goal: bring test coverage for the PyLops operator `$1` to at least **${2:-90}%**.
+
+Follow this workflow precisely:
+
+1. **Locate the operator.** Find the source module that defines `class $1`
+   (e.g. `grep -rln "^class $1\b" pylops/`) and the test file(s) that already
+   exercise it (`grep -rln "$1" pytests/`).
+
+2. **Measure baseline coverage** for this operator only:
+   ```bash
+   .pi/tools/operator_coverage.sh $1
+   ```
+   Read the reported percentage and the list of *missing* line numbers.
+
+3. **Inspect the uncovered lines** in the source module. For each missing line,
+   identify what behaviour is untested: alternate dtypes, branches (e.g.
+   `kind`/`edge`/`order` options), error paths (`raise`/`NotImplementedError`),
+   adjoint vs forward, ND vs 1D, backend dispatch, etc.
+
+4. **Add or modify tests** in the existing `pytests/test_*.py` file for this
+   operator. Match the repo's conventions:
+   - Parametrize with `@pytest.mark.parametrize` over `par` dicts and `dtype`.
+   - Always include a `dottest(...)` adjoint check for new configurations.
+   - Use `assert_array_almost_equal` for forward/inverse comparisons.
+   - Keep the CuPy/`backend` guard pattern used at the top of the test file.
+   Do NOT weaken assertions or add trivial no-op tests just to hit lines.
+
+5. **Re-run** `.pi/tools/operator_coverage.sh $1` and iterate steps 3–4 until
+   `COVERAGE_PCT >= ${2:-90}`. If some lines are genuinely untestable on the
+   current backend (e.g. CUDA-only paths), say so explicitly and exclude them
+   from the target with justification rather than faking coverage.
+
+6. **Validate** the new tests actually pass and lint cleanly:
+   ```bash
+   make lint
+   ```
+   (run the relevant pytest file directly if a full `make tests` is too slow).
+
+7. **Report** a short summary: starting %, final %, which test functions were
+   added/changed, and any lines deliberately left uncovered with the reason.

--- a/.pi/tools/operator_coverage.sh
+++ b/.pi/tools/operator_coverage.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# operator_coverage.sh -- measure test coverage for a single PyLops operator.
+#
+# Usage:
+#   .pi/tools/operator_coverage.sh <OperatorName> [extra pytest args...]
+#
+# Example:
+#   .pi/tools/operator_coverage.sh FirstDerivative
+#   .pi/tools/operator_coverage.sh FFT -k fft
+#
+# It locates the source module that defines `class <OperatorName>`, runs the
+# test suite with coverage scoped to that single module, then prints the
+# coverage percentage and the list of uncovered (missing) line numbers.
+#
+# Runner selection (first available wins, override with RUNNER env var):
+#   1. $RUNNER (e.g. RUNNER="uv run")
+#   2. uv run            (if `uv` is on PATH)
+#   3. python3 -m        (if the `coverage` module is importable)
+#
+set -euo pipefail
+
+OP="${1:-}"
+if [[ -z "$OP" ]]; then
+    echo "usage: $0 <OperatorName> [extra pytest args...]" >&2
+    exit 2
+fi
+shift || true
+
+# Script lives in <repo>/.pi/tools/, so the repo root is two levels up.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- locate the source module defining the operator -------------------------
+SRC="$(grep -rln "^class ${OP}\b" pylops/ || true)"
+if [[ -z "$SRC" ]]; then
+    echo "error: could not find 'class ${OP}' under pylops/" >&2
+    exit 1
+fi
+if [[ "$(echo "$SRC" | wc -l)" -gt 1 ]]; then
+    echo "warning: multiple modules define '${OP}':" >&2
+    echo "$SRC" >&2
+    SRC="$(echo "$SRC" | head -1)"
+    echo "using: $SRC" >&2
+fi
+
+# --- locate the test file(s) that reference this operator -------------------
+# Used as the default pytest target so we don't run (and break on) the whole
+# suite, which may fail to collect due to optional deps (torch, cupy, ...).
+# Pick the test file with the most references to the operator (the dedicated
+# one), avoiding files that merely use it as a building block.
+TESTS="$(grep -rcl --include='*.py' "\b${OP}\b" pytests/ 2>/dev/null \
+          | xargs -r grep -rc "\b${OP}\b" 2>/dev/null \
+          | sort -t: -k2 -nr | head -1 | cut -d: -f1 || true)"
+if [[ $# -gt 0 ]]; then
+    PYTEST_ARGS=("$@")                 # caller-provided args win
+elif [[ -n "$TESTS" ]]; then
+    PYTEST_ARGS=("$TESTS")
+else
+    PYTEST_ARGS=()                     # fall back to full suite
+fi
+
+# --- pick a runner ----------------------------------------------------------
+if [[ -n "${RUNNER:-}" ]]; then
+    RUN=($RUNNER)
+elif command -v uv >/dev/null 2>&1; then
+    RUN=(uv run)
+elif python3 -c "import coverage" >/dev/null 2>&1; then
+    RUN=(python3 -m)
+    # python3 -m coverage ...  -> prepend nothing, handled below
+    RUN=()
+else
+    echo "error: no runner found. Install 'uv' or 'coverage' (pip install coverage pytest)." >&2
+    exit 1
+fi
+
+cov() { "${RUN[@]}" coverage "$@"; }
+
+echo "==> operator : ${OP}"
+echo "==> source   : ${SRC}"
+echo "==> runner   : ${RUN[*]:-python3 -m} coverage"
+echo "==> pytest   : ${PYTEST_ARGS[*]:-<full suite>}"
+echo
+
+# --- run coverage scoped to that single source file -------------------------
+cov run --source=pylops -m pytest "${PYTEST_ARGS[@]}" >/tmp/optest_pytest.log 2>&1 || {
+    echo "pytest run failed; tail of log:" >&2
+    tail -40 /tmp/optest_pytest.log >&2
+    exit 1
+}
+
+echo "===================== COVERAGE (missing lines) ====================="
+cov report -m --include="$SRC"
+echo "===================================================================="
+
+# --- extract percentage for scripting / threshold checks --------------------
+PCT="$(cov report --include="$SRC" | awk '/TOTAL|'"$(basename "$SRC")"'/{gsub("%","",$NF); print $NF}' | tail -1)"
+echo
+echo "COVERAGE_PCT=${PCT}"

--- a/pytests/test_derivative.py
+++ b/pytests/test_derivative.py
@@ -98,6 +98,16 @@ par4e = {
 np.random.seed(10)
 
 
+def test_FirstDerivative_invalid():
+    """FirstDerivative raises NotImplementedError for invalid kind/order"""
+    # invalid centered order
+    with pytest.raises(NotImplementedError, match="order must be"):
+        FirstDerivative(10, kind="centered", order=4)
+    # invalid kind
+    with pytest.raises(NotImplementedError, match="kind must be"):
+        FirstDerivative(10, kind="invalid")
+
+
 @pytest.mark.parametrize(
     "par", [(par1), (par2), (par3), (par4), (par1e), (par2e), (par3e), (par4e)]
 )


### PR DESCRIPTION
This PR adds some initial support for `pi` agent with a prompt template and tool to check for coverage of one operator and suggest tests to reach >90%