### PR TITLE
Fix: change call of on_end callback to pass output x of step

### DIFF
--- a/pylops/optimization/basesolver.py
+++ b/pylops/optimization/basesolver.py
@@ -129,7 +129,9 @@ class Solver(metaclass=ABCMeta):
                                 self, kwargs.get("x0", None)
                             )
                         else:
-                            getattr(cb, f"on_{func.__name__}_end")(self, args[0])
+                            getattr(cb, f"on_{func.__name__}_end")(
+                                self, ret[0] if isinstance(ret, tuple) else ret
+                            )
                 return ret
 
             return wrapper


### PR DESCRIPTION
This PR fixes how the callbacks `on_end` methods are called for the `step` method. Currently the first input of `step` is passed (i.e., the previous model) as `args[0]`.

However, what the callback should be able to work on is the output of step (i.e., the new model), as `ret` or `ret[0]` for multiple outputs.

Note that whilst this is a **breaking change**, it is considered as a bug fix as having the previous model to do checks in callbacks is not ideal.