### PR TITLE
Feat: speep-up Fourier Radon CUDA kernels

### DIFF
--- a/pylops/signalprocessing/_fourierradon2d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon2d_cuda.py
@@ -21,7 +21,7 @@ def _radon_inner_2d_kernel(x, y, f, px, h, flim0, flim1, npx, nh):
     if ih < nh and ifr >= flim0 and ifr <= flim1:
         loc_r, loc_i = 0, 0
         for ipx in range(npx):
-            # slow computation with exp(1j * x) for reference
+            # slow computation of exp(1j * x) for reference
             # y[ih, ifr] += x[ipx, ifr] * exp(TWO_PI_MINUS * f[ifr] * px[ipx] * h[ih])
 
             # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
@@ -46,7 +46,7 @@ def _aradon_inner_2d_kernel(x, y, f, px, h, flim0, flim1, npx, nh):
     if ipx < npx and ifr >= flim0 and ifr <= flim1:
         loc_r, loc_i = 0, 0
         for ih in range(nh):
-            # slow computation with exp(1j * x) for reference
+            # slow computation of exp(1j * x) for reference
             # x[ipx, ifr] += y[ih, ifr] * exp(TWO_PI_I_PLUS * f[ifr] * px[ipx] * h[ih])
 
             # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048

--- a/pylops/signalprocessing/_fourierradon2d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon2d_cuda.py
@@ -19,12 +19,18 @@ def _radon_inner_2d_kernel(x, y, f, px, h, flim0, flim1, npx, nh):
     """
     ih, ifr = cuda.grid(2)
     if ih < nh and ifr >= flim0 and ifr <= flim1:
+        loc_r, loc_i = 0, 0
         for ipx in range(npx):
-            # slow computation of exp(1j * x)
+            # slow computation with exp(1j * x) for reference
             # y[ih, ifr] += x[ipx, ifr] * exp(TWO_PI_MINUS * f[ifr] * px[ipx] * h[ih])
+
             # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
+            # with local registers (no direct accumulation into global memory)
+            x_r, x_i = x[ipx, ifr].real, x[ipx, ifr].imag
             s, c = cuda.libdevice.sincosf(TWO_PI_MINUS * f[ifr] * px[ipx] * h[ih])
-            y[ih, ifr] += x[ipx, ifr] * (c + IMG * s)
+            loc_r += x_r * c - x_i * s
+            loc_i += x_r * s + x_i * c
+        y[ih, ifr] = loc_r + IMG * loc_i
 
 
 @cuda.jit
@@ -38,12 +44,18 @@ def _aradon_inner_2d_kernel(x, y, f, px, h, flim0, flim1, npx, nh):
     """
     ipx, ifr = cuda.grid(2)
     if ipx < npx and ifr >= flim0 and ifr <= flim1:
+        loc_r, loc_i = 0, 0
         for ih in range(nh):
-            # slow computation of exp(1j * x)
+            # slow computation with exp(1j * x) for reference
             # x[ipx, ifr] += y[ih, ifr] * exp(TWO_PI_I_PLUS * f[ifr] * px[ipx] * h[ih])
+
             # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
+            # with local registers (no direct accumulation into global memory)
+            y_r, y_i = y[ih, ifr].real, y[ih, ifr].imag
             s, c = cuda.libdevice.sincosf(TWO_PI_PLUS * f[ifr] * px[ipx] * h[ih])
-            x[ipx, ifr] += y[ih, ifr] * (c + IMG * s)
+            loc_r += y_r * c - y_i * s
+            loc_i += y_r * s + y_i * c
+        x[ipx, ifr] = loc_r + IMG * loc_i
 
 
 def _radon_inner_2d_cuda(

--- a/pylops/signalprocessing/_fourierradon3d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon3d_cuda.py
@@ -64,7 +64,7 @@ def _aradon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy
                 )
                 loc_r += x_r * c - x_i * s
                 loc_i += x_r * s + x_i * c
-        x[ipy, ipx, ifr] = loc_r + IMG * loc_i
+        y[ipy, ipx, ifr] = loc_r + IMG * loc_i
 
 
 def _radon_inner_3d_cuda(

--- a/pylops/signalprocessing/_fourierradon3d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon3d_cuda.py
@@ -28,7 +28,7 @@ def _radon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy,
                 # )
                 # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
                 # with local registers (no direct accumulation into global memory)
-                x_r, x_i = x[ihy, ihx, ifr].real, x[ihy, ihx, ifr].imag
+                x_r, x_i = x[ipy, ipx, ifr].real, x[ipy, ipx, ifr].imag
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )

--- a/pylops/signalprocessing/_fourierradon3d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon3d_cuda.py
@@ -28,12 +28,12 @@ def _radon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy,
                 # )
                 # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
                 # with local registers (no direct accumulation into global memory)
-                y_r, y_i = y[ihy, ihx, ifr].real, y[ihy, ihx, ifr].imag
+                x_r, x_i = x[ihy, ihx, ifr].real, x[ihy, ihx, ifr].imag
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
-                loc_r += y_r * c - y_i * s
-                loc_i += y_r * s + y_i * c
+                loc_r += x_r * c - x_i * s
+                loc_i += x_r * s + x_i * c
         y[ihy, ihx, ifr] = loc_r + IMG * loc_i
 
 
@@ -58,13 +58,13 @@ def _aradon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy
 
                 # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
                 # with local registers (no direct accumulation into global memory)
-                x_r, x_i = y[ihy, ihx, ifr].real, y[ihy, ihx, ifr].imag
+                y_r, y_i = y[ihy, ihx, ifr].real, y[ihy, ihx, ifr].imag
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_PLUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
-                loc_r += x_r * c - x_i * s
-                loc_i += x_r * s + x_i * c
-        y[ipy, ipx, ifr] = loc_r + IMG * loc_i
+                loc_r += y_r * c - y_i * s
+                loc_i += y_r * s + y_i * c
+        x[ipy, ipx, ifr] = loc_r + IMG * loc_i
 
 
 def _radon_inner_3d_cuda(

--- a/pylops/signalprocessing/_fourierradon3d_cuda.py
+++ b/pylops/signalprocessing/_fourierradon3d_cuda.py
@@ -19,17 +19,22 @@ def _radon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy,
     """
     ihy, ihx, ifr = cuda.grid(3)
     if ihy < nhy and ihx < nhx and ifr >= flim0 and ifr <= flim1:
+        loc_r, loc_i = 0, 0
         for ipy in range(npy):
             for ipx in range(npx):
-                # slow computation of exp(1j * x)
+                # slow computation of exp(1j * x) for reference
                 # y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * exp(
                 #     TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 # )
                 # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
+                # with local registers (no direct accumulation into global memory)
+                y_r, y_i = y[ihy, ihx, ifr].real, y[ihy, ihx, ifr].imag
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_MINUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
-                y[ihy, ihx, ifr] += x[ipy, ipx, ifr] * (c + IMG * s)
+                loc_r += y_r * c - y_i * s
+                loc_i += y_r * s + y_i * c
+        y[ihy, ihx, ifr] = loc_r + IMG * loc_i
 
 
 @cuda.jit
@@ -43,16 +48,23 @@ def _aradon_inner_3d_kernel(x, y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy
     """
     ipy, ipx, ifr = cuda.grid(3)
     if ipy < npy and ipx < npx and ifr >= flim0 and ifr <= flim1:
+        loc_r, loc_i = 0, 0
         for ihy in range(nhy):
             for ihx in range(nhx):
-                # slow computation of exp(1j * x)
+                # slow computation of exp(1j * x) for reference
                 # x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * exp(
                 #     TWO_PI_I_PLUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 # )
+
+                # fast computation of exp(1j * x) - see https://stackoverflow.com/questions/9860711/cucomplex-h-and-exp/9863048#9863048
+                # with local registers (no direct accumulation into global memory)
+                x_r, x_i = y[ihy, ihx, ifr].real, y[ihy, ihx, ifr].imag
                 s, c = cuda.libdevice.sincosf(
                     TWO_PI_PLUS * f[ifr] * (py[ipy] * hy[ihy] + px[ipx] * hx[ihx])
                 )
-                x[ipy, ipx, ifr] += y[ihy, ihx, ifr] * (c + IMG * s)
+                loc_r += x_r * c - x_i * s
+                loc_i += x_r * s + x_i * c
+        x[ipy, ipx, ifr] = loc_r + IMG * loc_i
 
 
 def _radon_inner_3d_cuda(

--- a/pytests/test_memoizeoperator.py
+++ b/pytests/test_memoizeoperator.py
@@ -72,11 +72,11 @@ def test_memoize_evals_2(par):
     # Approach 1
     Aop1 = Aop.toreal(forw=False, adj=True)
     xinv1 = Aop1.div(y).real
-    assert_array_almost_equal(x, xinv1)
+    assert_array_almost_equal(xinv1, x, decimal=2 if rdtype == np.float32 else 4)
 
     # Approach 2
     Amop = MemoizeOperator(Aop, max_neval=10)
     Aop2 = VStack([Amop.toreal(), Amop.toimag()])
     y2 = np.concatenate([np.real(y), np.imag(y)])
     xinv2 = Aop2.div(y2)
-    assert_array_almost_equal(x, xinv2)
+    assert_array_almost_equal(xinv2, x, decimal=2 if rdtype == np.float32 else 4)


### PR DESCRIPTION
This PR provides a speed-up to the  Fourier Radon CUDA kernels by accumulating into temporaries instead of directly into the output global array.

Speed-ups of the order 3x/1.5x of and are observed for the 2d/3d cases.