### PR TITLE
Bug: Restriction with repeated indices

### DIFF
--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -63,11 +63,8 @@ class Restriction(LinearOperator):
         Shape of the array after the forward, but before flattening.
 
         For example, ``y_reshaped = (Op * x.ravel()).reshape(Op.dimsd)``.
-    iavamask : :obj:`numpy.ndarray`
-        Mask of indices used in adjoint mode when ``iava`` is a
-        CuPy array.
-    iavareshape : :obj:`numpy.ndarray`
-        Shape used to reshape ``iava`` to be compatible with ``dims``.
+    repeated : :obj:`bool`
+        Indicates whether there are repeated indices in ``iava``.
     shape : :obj:`tuple`
         Operator shape.
 
@@ -140,6 +137,9 @@ class Restriction(LinearOperator):
         self.axis = axis
         self.iava = ncp.asarray(iava)
 
+        # check whether any index in iava is repeated
+        self.repeated = np.unique(self.iava).size != self.iava.size
+
     def _matvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
         if not self.inplace:
@@ -176,7 +176,7 @@ class Restriction(LinearOperator):
             y = y_real + 1j * y_imag
         else:
             y = ncp.zeros(self.dims, dtype=self.dtype)
-            y = inplace_add(x, y, indices, accumulate=True)
+            y = inplace_add(x, y, indices, accumulate=self.repeated)
         y = y.ravel()
         return y
 

--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -11,25 +11,10 @@ from pylops.utils._internal import _value_or_sized_to_tuple
 from pylops.utils.backend import (
     get_array_module,
     get_normalize_axis_index,
-    inplace_set,
-    to_numpy,
 )
 from pylops.utils.typing import DTypeLike, InputDimsLike, IntNDArray, NDArray
 
 logger = logging.getLogger(__name__)
-
-
-def _compute_iavamask(dims, axis, iava, ncp):
-    """Compute restriction mask when using cupy arrays"""
-    otherdims = np.array(dims)
-    otherdims = np.delete(otherdims, axis)
-    iavamask = np.zeros(int(dims[axis]), dtype=int)
-    iavamask[iava] = 1
-    iavamask = np.moveaxis(
-        np.broadcast_to(iavamask, list(otherdims) + [dims[axis]]), -1, axis
-    )
-    iavamask = np.where(iavamask.ravel() == 1)[0]
-    return ncp.asarray(iavamask)
 
 
 class Restriction(LinearOperator):
@@ -149,17 +134,8 @@ class Restriction(LinearOperator):
             name=name,
         )
 
-        iavareshape = np.ones(len(self.dims), dtype=int)
-        iavareshape[axis] = len(iava)
-
-        # currently cupy does not support put_along_axis, so we need to
-        # explicitly create a list of indices in the n-dimensional
-        # model space which will be used in _rmatvec to place the input
-        if ncp != np:
-            self.iavamask = _compute_iavamask(self.dims, axis, to_numpy(iava), ncp)
         self.inplace = inplace
         self.axis = axis
-        self.iavareshape = iavareshape
         self.iava = ncp.asarray(iava)
 
     def _matvec(self, x: NDArray) -> NDArray:
@@ -176,24 +152,22 @@ class Restriction(LinearOperator):
         if not self.inplace:
             x = x.copy()
         x = ncp.reshape(x, self.dimsd)
-        if ncp == np:
-            y = ncp.zeros(self.dims, dtype=self.dtype)
-            ncp.put_along_axis(
-                y, ncp.reshape(self.iava, self.iavareshape), x, axis=self.axis
-            )
-        else:
-            if not hasattr(self, "iavamask"):
-                self.iavamask = _compute_iavamask(
-                    self.dims, self.axis, to_numpy(self.iava), ncp
-                )
-            y = ncp.zeros(int(self.shape[-1]), dtype=self.dtype)
-            y = inplace_set(x.ravel(), y, self.iavamask)
+        y = ncp.zeros(self.dims, dtype=self.dtype)
+        ncp.add.at(
+            y,
+            tuple(
+                self.iava if ax == self.axis else slice(None) for ax in range(y.ndim)
+            ),
+            x,
+        )
         y = y.ravel()
         return y
 
     def mask(self, x: NDArray) -> NDArray:
         """Apply mask to input signal returning a signal of same size with
         values at ``iava`` locations and ``0`` at other locations
+
+        If any location is repeated in ``iava``, an error is raised.
 
         Parameters
         ----------
@@ -205,12 +179,20 @@ class Restriction(LinearOperator):
         y : :obj:`numpy.ma.core.MaskedArray`
             Masked array.
 
+        Raises
+        ------
+        ValueError
+            If any index is repeated in iava
         """
         ncp = get_array_module(x)
         if ncp != np:
             iava = ncp.asnumpy(self.iava)
         else:
             iava = self.iava.copy()
+
+        if np.unique(iava).size != iava.size:
+            msg = "At least one index in iava is repeated, mask is not enabled..."
+            raise ValueError(msg)
 
         y = np_ma.array(np.zeros(self.dims), mask=np.ones(self.dims), dtype=self.dtype)
         x = np.reshape(x, self.dims)

--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -10,7 +10,9 @@ from pylops import LinearOperator
 from pylops.utils._internal import _value_or_sized_to_tuple
 from pylops.utils.backend import (
     get_array_module,
+    get_module_name,
     get_normalize_axis_index,
+    inplace_add,
 )
 from pylops.utils.typing import DTypeLike, InputDimsLike, IntNDArray, NDArray
 
@@ -155,15 +157,8 @@ class Restriction(LinearOperator):
         indices = tuple(
             self.iava if ax == self.axis else slice(None) for ax in range(x.ndim)
         )
-        if ncp == np or not self.dtype.kind == "c":
-            y = ncp.zeros(self.dims, dtype=self.dtype)
-            ncp.add.at(
-                y,
-                indices,
-                x,
-            )
-        else:
-            # work on real/image separately for cupy arrays as cp.add.at does
+        if get_module_name(ncp) == "cupy" and self.dtype.kind == "c":
+            # work on real/imag separately for cupy arrays as cp.add.at does
             # not support complex dtype
             rdtype = ncp.real(ncp.ones(1, self.dtype)).dtype
             y_real = ncp.zeros(self.dims, dtype=rdtype)
@@ -179,6 +174,9 @@ class Restriction(LinearOperator):
                 x.imag,
             )
             y = y_real + 1j * y_imag
+        else:
+            y = ncp.zeros(self.dims, dtype=self.dtype)
+            y = inplace_add(x, y, indices, accumulate=True)
         y = y.ravel()
         return y
 
@@ -202,6 +200,7 @@ class Restriction(LinearOperator):
         ------
         ValueError
             If any index is repeated in iava
+
         """
         ncp = get_array_module(x)
         if ncp != np:

--- a/pylops/basicoperators/restriction.py
+++ b/pylops/basicoperators/restriction.py
@@ -152,14 +152,33 @@ class Restriction(LinearOperator):
         if not self.inplace:
             x = x.copy()
         x = ncp.reshape(x, self.dimsd)
-        y = ncp.zeros(self.dims, dtype=self.dtype)
-        ncp.add.at(
-            y,
-            tuple(
-                self.iava if ax == self.axis else slice(None) for ax in range(y.ndim)
-            ),
-            x,
+        indices = tuple(
+            self.iava if ax == self.axis else slice(None) for ax in range(x.ndim)
         )
+        if ncp == np or not self.dtype.kind == "c":
+            y = ncp.zeros(self.dims, dtype=self.dtype)
+            ncp.add.at(
+                y,
+                indices,
+                x,
+            )
+        else:
+            # work on real/image separately for cupy arrays as cp.add.at does
+            # not support complex dtype
+            rdtype = ncp.real(ncp.ones(1, self.dtype)).dtype
+            y_real = ncp.zeros(self.dims, dtype=rdtype)
+            y_imag = ncp.zeros(self.dims, dtype=rdtype)
+            ncp.add.at(
+                y_real,
+                indices,
+                x.real,
+            )
+            ncp.add.at(
+                y_imag,
+                indices,
+                x.imag,
+            )
+            y = y_real + 1j * y_imag
         y = y.ravel()
         return y
 

--- a/pylops/signalprocessing/interp.py
+++ b/pylops/signalprocessing/interp.py
@@ -37,9 +37,6 @@ def _linearinterp(
     """Linear interpolation."""
     ncp = get_array_module(iava)
 
-    if np.issubdtype(iava.dtype, np.integer):
-        iava = iava.astype(np.float64)
-
     sample_size = dims[axis]
     dimsd = list(dims)
     dimsd[axis] = len(iava)
@@ -47,6 +44,8 @@ def _linearinterp(
 
     # ensure that samples are not beyond the last sample, in that case set to
     # penultimate sample and raise a warning
+    if ncp.issubdtype(iava.dtype, ncp.integer):
+        iava = iava.astype(ncp.float64)
     iava = _clip_iava_above_last_sample_index(  # type: ignore
         iava=iava,  # type: ignore
         sample_size=sample_size,
@@ -171,7 +170,7 @@ def Interp(
         The ``"cubic_spline"``-interpolation was added.
 
     tol : :obj:`float`, optional
-        .. versionadded:: 2.9.0
+        .. versionadded:: 2.8.0
 
         Tolerance for sinc interpolation values to be retained (values
         below ``tol`` are set to zero and a sparse matrix is created). If ``None``,

--- a/pylops/utils/backend.py
+++ b/pylops/utils/backend.py
@@ -651,7 +651,9 @@ def inplace_set(x: ArrayLike, y: ArrayLike, idx: list) -> NDArray:
         return y
 
 
-def inplace_add(x: ArrayLike, y: ArrayLike, idx: list) -> NDArray:
+def inplace_add(
+    x: ArrayLike, y: ArrayLike, idx: list, accumulate: bool = False
+) -> NDArray:
     """Perform inplace add based on input
 
     Parameters
@@ -662,6 +664,10 @@ def inplace_add(x: ArrayLike, y: ArrayLike, idx: list) -> NDArray:
         Output array
     idx : :obj:`list`
         Indices to sum at
+    accumulate : :obj:`bool`, optional
+        Whether to accumulate the values (``True``) or not (``False``).
+        Defaults to ``False``, which is faster. However, select ``True``
+        when ``idx`` has repeated values.
 
     Returns
     -------
@@ -673,7 +679,15 @@ def inplace_add(x: ArrayLike, y: ArrayLike, idx: list) -> NDArray:
         y = y.at[idx].add(x)
         return y
     else:
-        y[idx] += x
+        if accumulate:
+            ncp = get_array_module(x)
+            ncp.add.at(
+                y,
+                idx,
+                x,
+            )
+        else:
+            y[idx] += x
         return y
 
 

--- a/pylops/utils/signalprocessing.py
+++ b/pylops/utils/signalprocessing.py
@@ -47,7 +47,7 @@ def convmtx(h: NDArray, n: int, offset: int = 0, sparse: bool = False) -> NDArra
     offset : :obj:`int`, optional
         Index of the center of the filter
     sparse : :obj:`bool`, optional
-        .. versionadded:: 2.9.0
+        .. versionadded:: 2.8.0
 
         Return dense (``False``) or sparse (``True``) matrix
 
@@ -119,7 +119,7 @@ def nonstationary_convmtx(
         provided values (use it to avoid wrap-around or pass filters with
         enough padding)
     sparse : :obj:`bool`, optional
-        .. versionadded:: 2.9.0
+        .. versionadded:: 2.8.0
 
         Return dense (``False``) or sparse (``True``) matrix
 

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 import numpy as np
 
-from pylops import Laplacian, Restriction, SecondDerivative
+from pylops import Laplacian, Real, Restriction, SecondDerivative
 from pylops.optimization.leastsquares import regularized_inversion
 from pylops.optimization.sparsity import fista
 from pylops.signalprocessing import (
@@ -247,6 +247,11 @@ def SeismicInterpolation(
             Rop1 = Restriction(dims1, iava1, axis=1, dtype=ropdtype)
             Rop = Rop1 * Rop
 
+    # convert output to real when using fk transform
+    if kind == "fk":
+        Realop = Real(dimsd, dtype=ropdtype)
+        Rop = Realop * Rop
+
     # create other operators for inversion
     if kind == "spatial":
         prec = False
@@ -267,7 +272,7 @@ def SeismicInterpolation(
                     raise ValueError(msg)
                 else:
                     sampling = (dspat, dspat1, dt)
-            Pop = FFTND(dims=dims, nffts=nffts, sampling=sampling)
+            Pop = FFTND(dims=dims, nffts=nffts, sampling=sampling, dtype=cdtype)
             Pop = Pop.H
         else:
             if sampling is None:
@@ -278,7 +283,7 @@ def SeismicInterpolation(
                     raise ValueError(msg)
                 else:
                     sampling = (dspat, dt)
-            Pop = FFT2D(dims=dims, nffts=nffts, sampling=sampling)
+            Pop = FFT2D(dims=dims, nffts=nffts, sampling=sampling, dtype=cdtype)
             Pop = Pop.H
         SIop = Rop * Pop
         # Force data to be of same dtype of operator
@@ -292,10 +297,13 @@ def SeismicInterpolation(
                 spataxis,
                 spat1axis,
                 (np.max(paxis) * dspat / dt, np.max(p1axis) * dspat1 / dt),
+                dtype=dtype,
             ).H
             dimsp = (spataxis.size, spat1axis.size, taxis.size)
         else:
-            Pop = ChirpRadon2D(taxis, spataxis, np.max(paxis) * dspat / dt).H
+            Pop = ChirpRadon2D(
+                taxis, spataxis, np.max(paxis) * dspat / dt, dtype=dtype
+            ).H
             dimsp = (spataxis.size, taxis.size)
         SIop = Rop * Pop
     elif "radon" in kind:
@@ -312,6 +320,7 @@ def SeismicInterpolation(
                 centeredh=centeredh,
                 kind=kindradon,
                 engine=engine,
+                dtype=dtype,
             )
             dimsp = (paxis.size, p1axis.size, taxis.size)
 
@@ -323,6 +332,7 @@ def SeismicInterpolation(
                 centeredh=centeredh,
                 kind=kindradon,
                 engine=engine,
+                dtype=dtype,
             )
             dimsp = (paxis.size, taxis.size)
         SIop = Rop * Pop
@@ -349,6 +359,7 @@ def SeismicInterpolation(
                     centeredh=True,
                     kind="linear",
                     engine=engine,
+                    dtype=dtype,
                 )
             else:
                 npaxis, np1axis = nwin[0], nwin[1]
@@ -357,6 +368,7 @@ def SeismicInterpolation(
                     spataxis_local,
                     spat1axis_local,
                     (np.max(paxis) * dspat / dt, np.max(p1axis) * dspat1 / dt),
+                    dtype=dtype,
                 ).H
             dimsp = (nwins[0] * npaxis, nwins[1] * np1axis, dimsslid[2])
             Pop = Sliding3D(
@@ -377,6 +389,7 @@ def SeismicInterpolation(
                     centeredh=True,
                     kind="linear",
                     engine=engine,
+                    dtype=dtype,
                 )
             else:
                 npaxis = nwin

--- a/pylops/waveeqprocessing/seismicinterpolation.py
+++ b/pylops/waveeqprocessing/seismicinterpolation.py
@@ -209,7 +209,11 @@ def SeismicInterpolation(
           in 3-dimensional case
 
     """
+    # identify dtypes
     dtype = data.dtype
+    cdtype = (np.ones(1, dtype=dtype) + 1j * np.ones(1, dtype=dtype)).dtype
+    ropdtype = cdtype if kind == "fk" else dtype
+
     ndims = data.ndim
     if ndims == 1 or ndims > 3:
         msg = f"data must have 2 or 3 dimensions, got {ndims}"
@@ -231,16 +235,16 @@ def SeismicInterpolation(
 
     # create restriction/interpolation operator
     if iava.dtype == float:
-        Rop = Interp(dims, iava, axis=0, kind="linear", dtype=dtype)
+        Rop = Interp(dims, iava, axis=0, kind="linear", dtype=ropdtype)
         if ndims == 3 and iava1 is not None:
             dims1 = (len(iava), nrec[1], dimsd[2])
-            Rop1 = Interp(dims1, iava1, axis=1, kind="linear", dtype=dtype)
+            Rop1 = Interp(dims1, iava1, axis=1, kind="linear", dtype=ropdtype)
             Rop = Rop1 * Rop
     else:
-        Rop = Restriction(dims, iava, axis=0, dtype=dtype)
+        Rop = Restriction(dims, iava, axis=0, dtype=ropdtype)
         if ndims == 3 and iava1 is not None:
             dims1 = (len(iava), nrec[1], dimsd[2])
-            Rop1 = Restriction(dims1, iava1, axis=1, dtype=dtype)
+            Rop1 = Restriction(dims1, iava1, axis=1, dtype=ropdtype)
             Rop = Rop1 * Rop
 
     # create other operators for inversion

--- a/pytests/test_interpolation.py
+++ b/pytests/test_interpolation.py
@@ -176,7 +176,7 @@ def test_Interp_1dsignal(par: InterpolationTestParameters, dtype: np.dtype):
     ).astype(dtype)
 
     Nsub = int(np.round(par.x_num * SUBSAMPLING_PERCENTAGE))
-    iava = np.sort(np.random.permutation(np.arange(par.x_num - 1))[:Nsub])
+    iava = np.sort(np.random.permutation(np.arange(par.x_num))[:Nsub])
 
     # fixed indices
     Iop, _ = Interp(par.x_num, iava, kind=par.kind, dtype=dtype1)
@@ -247,7 +247,7 @@ def test_Interp_2dsignal(par: InterpolationTestParameters, dtype: np.dtype):
 
     # 1st direction
     Nsub = int(np.round(par.x_num * SUBSAMPLING_PERCENTAGE))
-    iava = np.sort(np.random.permutation(np.arange(par.x_num - 1))[:Nsub])
+    iava = np.sort(np.random.permutation(np.arange(par.x_num))[:Nsub])
 
     # fixed indices
     Iop, _ = Interp(
@@ -297,7 +297,7 @@ def test_Interp_2dsignal(par: InterpolationTestParameters, dtype: np.dtype):
 
     # 2nd direction
     Nsub = int(np.round(par.t_num * SUBSAMPLING_PERCENTAGE))
-    iava = np.sort(np.random.permutation(np.arange(par.t_num - 1))[:Nsub])
+    iava = np.sort(np.random.permutation(np.arange(par.t_num))[:Nsub])
 
     # fixed indices
     Iop, _ = Interp(
@@ -372,7 +372,7 @@ def test_Interp_3dsignal(par: InterpolationTestParameters, dtype: np.dtype):
 
     # 1st direction
     Nsub = int(np.round(par.y_num * SUBSAMPLING_PERCENTAGE))
-    iava = np.sort(np.random.permutation(np.arange(par.y_num - 1))[:Nsub])
+    iava = np.sort(np.random.permutation(np.arange(par.y_num))[:Nsub])
 
     # fixed indices
     Iop, _ = Interp(
@@ -430,7 +430,7 @@ def test_Interp_3dsignal(par: InterpolationTestParameters, dtype: np.dtype):
 
     # 2nd direction
     Nsub = int(np.round(par.x_num * SUBSAMPLING_PERCENTAGE))
-    iava = np.sort(np.random.permutation(np.arange(par.x_num - 1))[:Nsub])
+    iava = np.sort(np.random.permutation(np.arange(par.x_num))[:Nsub])
 
     # fixed indices
     Iop, _ = Interp(
@@ -475,7 +475,7 @@ def test_Interp_3dsignal(par: InterpolationTestParameters, dtype: np.dtype):
 
     # 3rd direction
     Nsub = int(np.round(par.t_num * SUBSAMPLING_PERCENTAGE))
-    iava = np.sort(np.random.permutation(np.arange(par.t_num - 1))[:Nsub])
+    iava = np.sort(np.random.permutation(np.arange(par.t_num))[:Nsub])
 
     # fixed indices
     Iop, _ = Interp(

--- a/pytests/test_restriction.py
+++ b/pytests/test_restriction.py
@@ -99,6 +99,46 @@ def test_Restriction_1dsignal(par):
 
 
 @pytest.mark.parametrize("par", [(par1), (par1s), (par1j), (par2), (par2s), (par2j)])
+def test_Restriction_1dsignal_repeated(par):
+    """Dot-test, forward and adjoint for Restriction operator for 1d signal
+    with repeated incides (adjoint must sum over them)"""
+    np.random.seed(10)
+    dtype = np.empty(0, dtype=par["dtype"]).real.dtype
+
+    Nsub = int(np.round(par["nx"] * perc_subsampling))
+    iava = np.sort(np.random.permutation(np.arange(par["nx"]))[:Nsub])
+
+    # Force 2 repetitions
+    iava[1] = iava[0]
+    iava[-1] = iava[-2]
+
+    Rop = Restriction(par["nx"], iava, inplace=par["inplace"], dtype=par["dtype"])
+    assert dottest(
+        Rop,
+        Nsub,
+        par["nx"],
+        complexflag=0 if par["imag"] == 0 else 3,
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    x = np.arange(par["nx"], dtype=dtype) + par["imag"] * np.arange(
+        par["nx"], dtype=dtype
+    )
+    y = Rop * x
+    x1 = Rop.H * y
+
+    x1ana_iava = np.zeros_like(x)
+    x1ana_iava[iava[1:-1]] = x[iava[1:-1]]
+    x1ana_iava[iava[0]] += x[iava[0]]
+    x1ana_iava[iava[-1]] += x[iava[-1]]
+
+    assert y.dtype == par["dtype"]
+    assert x1.dtype == par["dtype"]
+    assert_array_almost_equal(x1, x1ana_iava)
+
+
+@pytest.mark.parametrize("par", [(par1), (par1s), (par1j), (par2), (par2s), (par2j)])
 def test_Restriction_2dsignal(par):
     """Dot-test, forward and adjoint for Restriction operator for 2d signal"""
     np.random.seed(10)


### PR DESCRIPTION
Handles https://github.com/PyLops/pylops/issues/769 by allowing repeated indices in `iava` for both NumPy and CuPy. 

As a by-product, the divergent code required by the `np.put_along_axis` is now removed as `np.add.at` is also available in CuPy