### PR TITLE
Feat: disabled automatic cache of numba-jit functions

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -20,3 +20,9 @@ Yes. Nevertheless you need to tell PyLops that you don't want to use its ``cupy`
 backend by setting the environment variable ``CUPY_PYLOPS=0``.
 Failing to do so will lead to an error when you import ``pylops`` because some of the ``cupyx``
 routines that we use are not available in earlier version of ``cupy``.
+
+
+**3. What can I do if my system Python does not allow** `caching Numba compiled functions <https://numba.pydata.org/numba-doc/dev/developer/caching.html>`_ **?**
+
+From PyLops 2.8.0, this is turned off by default. However, it can be enabled by setting ``NUMBA_CACHE_PYLOPS=1``, 
+and Numba JIT-ed functions will be automatically cached into ``NUMBA_CACHE_DIR``.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -24,5 +24,7 @@ routines that we use are not available in earlier version of ``cupy``.
 
 **3. What can I do if my system Python does not allow** `caching Numba compiled functions <https://numba.pydata.org/numba-doc/dev/developer/caching.html>`_ **?**
 
-From PyLops 2.8.0, this is turned off by default. However, it can be enabled by setting ``NUMBA_CACHE_PYLOPS=1``, 
+Prir to PyLops v2.8.0, you must set ``NUMBA_CACHE_DIR`` to a non read-only directory.
+
+From PyLops v2.8.0, this is turned off by default. However, it can be enabled by setting ``NUMBA_CACHE_PYLOPS=1``, 
 and Numba JIT-ed functions will be automatically cached into ``NUMBA_CACHE_DIR``.

--- a/pylops/basicoperators/_spread_numba.py
+++ b/pylops/basicoperators/_spread_numba.py
@@ -3,12 +3,13 @@ import os
 
 from numba import jit, prange
 
-# detect whether to use parallel or not
+# Detect whether to use parallel and cache or not
 numba_threads = int(os.getenv("NUMBA_NUM_THREADS", "1"))
 parallel = True if numba_threads != 1 else False
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _matvec_numba_table(x, y, dims, interp, table, dtable):
     """numba implementation of forward mode with table.
     See official documentation for description of variables
@@ -32,7 +33,7 @@ def _matvec_numba_table(x, y, dims, interp, table, dtable):
     return y.ravel()
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _rmatvec_numba_table(x, y, dims, dimsd, interp, table, dtable):
     """numba implementation of adjoint mode with table.
     See official documentation for description of variables
@@ -58,7 +59,7 @@ def _rmatvec_numba_table(x, y, dims, dimsd, interp, table, dtable):
     return y.ravel()
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _matvec_numba_onthefly(x, y, dims, interp, fh):
     """numba implementation of forward mode with on-the-fly computations.
     See official documentation for description of variables
@@ -82,7 +83,7 @@ def _matvec_numba_onthefly(x, y, dims, interp, fh):
     return y.ravel()
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _rmatvec_numba_onthefly(x, y, dims, dimsd, interp, fh):
     """numba implementation of adjoint mode with on-the-fly computations.
     See official documentation for description of variables

--- a/pylops/signalprocessing/_fourierradon2d_numba.py
+++ b/pylops/signalprocessing/_fourierradon2d_numba.py
@@ -4,12 +4,13 @@ from math import pi
 
 from numba import jit, prange
 
-# detect whether to use parallel or not
+# Detect whether to use parallel and cache or not
 numba_threads = int(os.getenv("NUMBA_NUM_THREADS", "1"))
 parallel = True if numba_threads != 1 else False
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
 
 
-@jit(nopython=True, parallel=parallel, nogil=True, cache=True, fastmath=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache, fastmath=True)
 def _radon_inner_2d(X, Y, f, px, h, flim0, flim1, npx, nh):
     for ih in prange(nh):
         for ifr in range(flim0, flim1):
@@ -17,7 +18,7 @@ def _radon_inner_2d(X, Y, f, px, h, flim0, flim1, npx, nh):
                 Y[ih, ifr] += X[ipx, ifr] * exp(-1j * 2 * pi * f[ifr] * px[ipx] * h[ih])
 
 
-@jit(nopython=True, parallel=parallel, nogil=True, cache=True, fastmath=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache, fastmath=True)
 def _aradon_inner_2d(X, Y, f, px, h, flim0, flim1, npx, nh):
     for ipx in prange(npx):
         for ifr in range(flim0, flim1):

--- a/pylops/signalprocessing/_fourierradon3d_numba.py
+++ b/pylops/signalprocessing/_fourierradon3d_numba.py
@@ -4,12 +4,13 @@ from math import pi
 
 from numba import jit, prange
 
-# detect whether to use parallel or not
+# Detect whether to use parallel and cache or not
 numba_threads = int(os.getenv("NUMBA_NUM_THREADS", "1"))
 parallel = True if numba_threads != 1 else False
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
 
 
-@jit(nopython=True, parallel=parallel, nogil=True, cache=True, fastmath=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache, fastmath=True)
 def _radon_inner_3d(X, Y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy, nhx):
     for ihy in prange(nhy):
         for ihx in prange(nhx):
@@ -25,7 +26,7 @@ def _radon_inner_3d(X, Y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy, nhx):
                         )
 
 
-@jit(nopython=True, parallel=parallel, nogil=True, cache=True, fastmath=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache, fastmath=True)
 def _aradon_inner_3d(X, Y, f, py, px, hy, hx, flim0, flim1, npy, npx, nhy, nhx):
     for ipy in prange(npy):
         for ipx in range(npx):

--- a/pylops/signalprocessing/_radon2d_numba.py
+++ b/pylops/signalprocessing/_radon2d_numba.py
@@ -3,27 +3,28 @@ import os
 import numpy as np
 from numba import jit
 
-# detect whether to use parallel or not
+# Detect whether to use parallel and cache or not
 numba_threads = int(os.getenv("NUMBA_NUM_THREADS", "1"))
 parallel = True if numba_threads != 1 else False
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=cache)
 def _linear_numba(x, t, px):
     return t + px * x
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=cache)
 def _parabolic_numba(x, t, px):
     return t + px * x**2
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=cache)
 def _hyperbolic_numba(x, t, px):
     return np.sqrt(t**2 + (x / px) ** 2)
 
 
-@jit(nopython=True, nogil=True)
+@jit(nopython=True, nogil=True, cache=cache)
 def _indices_2d_numba(f, x, px, t, nt, interp=True):
     """Compute time and space indices of parametric line in ``f`` function
     using numba. Refer to ``_indices_2d`` for full documentation.
@@ -44,7 +45,7 @@ def _indices_2d_numba(f, x, px, t, nt, interp=True):
     return xscan, tscan, dtscan
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _indices_2d_onthefly_numba(f, x, px, ip, t, nt, interp=True):
     """Wrapper around _indices_2d to allow on-the-fly computation of
     parametric curves using numba
@@ -61,7 +62,7 @@ def _indices_2d_onthefly_numba(f, x, px, ip, t, nt, interp=True):
     return xscan, tscan, dtscan
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _create_table_numba(f, x, pxaxis, nt, npx, nx, interp):
     """Create look up table using numba"""
     table = np.full((npx, nt, nx), np.nan, dtype=np.float32)

--- a/pylops/signalprocessing/_radon3d_numba.py
+++ b/pylops/signalprocessing/_radon3d_numba.py
@@ -3,27 +3,28 @@ import os
 import numpy as np
 from numba import jit
 
-# detect whether to use parallel or not
+# Detect whether to use parallel and cache or not
 numba_threads = int(os.getenv("NUMBA_NUM_THREADS", "1"))
 parallel = True if numba_threads != 1 else False
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=cache)
 def _linear_numba(y, x, t, py, px):
     return t + px * x + py * y
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=cache)
 def _parabolic_numba(y, x, t, py, px):
     return t + px * x**2 + py * y**2
 
 
-@jit(nopython=True)
+@jit(nopython=True, cache=cache)
 def _hyperbolic_numba(y, x, t, py, px):
     return np.sqrt(t**2 + (x / px) ** 2 + (y / py) ** 2)
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _indices_3d_numba(f, y, x, py, px, t, nt, interp=True):
     """Compute time and space indices of parametric line in ``f`` function
     using numba. Refer to ``_indices_3d`` for full documentation.
@@ -43,7 +44,7 @@ def _indices_3d_numba(f, y, x, py, px, t, nt, interp=True):
     return sscan, tscan, dtscan
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _indices_3d_onthefly_numba(f, y, x, py, px, ip, t, nt, interp=True):
     """Wrapper around _indices_3d to allow on-the-fly computation of
     parametric curves using numba
@@ -62,7 +63,7 @@ def _indices_3d_onthefly_numba(f, y, x, py, px, ip, t, nt, interp=True):
     return sscan, tscan, dtscan
 
 
-@jit(nopython=True, parallel=parallel, nogil=True)
+@jit(nopython=True, parallel=parallel, nogil=True, cache=cache)
 def _create_table_numba(f, y, x, pyaxis, pxaxis, nt, npy, npx, ny, nx, interp):
     """Create look up table using numba"""
     table = np.full((npx * npy, nt, ny * nx), np.nan, dtype=np.float32)

--- a/pylops/signalprocessing/_spraying2d_numba.py
+++ b/pylops/signalprocessing/_spraying2d_numba.py
@@ -1,3 +1,4 @@
+import os
 from math import floor
 
 from pylops.utils.typing import NDArray
@@ -18,7 +19,11 @@ except ImportError:  # pragma: no cover - executed only in no-numba builds
         return range(*args, **kwargs)
 
 
-@njit(cache=True, fastmath=True, parallel=False)
+# Detect whether to cache or not
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
+
+
+@njit(cache=cache, fastmath=True, parallel=False)
 def _spray_forward_numba(
     m: NDArray, sigma: NDArray, radius: int, alpha: float, out: NDArray
 ) -> None:
@@ -69,7 +74,7 @@ def _spray_forward_numba(
                 out[zi1, x] += t * amp
 
 
-@njit(cache=True, fastmath=True, parallel=True)
+@njit(cache=cache, fastmath=True, parallel=True)
 def _spray_adjoint_numba(
     d: NDArray, sigma: NDArray, radius: int, alpha: float, out: NDArray
 ) -> None:

--- a/pylops/utils/_pwd2d_numba.py
+++ b/pylops/utils/_pwd2d_numba.py
@@ -1,3 +1,5 @@
+import os
+
 from pylops.utils.typing import NDArray
 
 # Remap numba njit to no-ops and prange to range
@@ -16,7 +18,11 @@ except ImportError:  # pragma: no cover - executed only without numba
         return range(*args, **kwargs)
 
 
-@njit(fastmath=True, cache=True)
+# Detect whether to cache or not
+cache = bool(int(os.getenv("NUMBA_CACHE_PYLOPS", 0)))
+
+
+@njit(fastmath=True, cache=cache)
 def _B3(sigma: float) -> tuple[float, float, float]:
     """Quadratic B-spline coefficients (3 taps)."""
     b0 = (1.0 - sigma) * (2.0 - sigma) / 12.0
@@ -25,7 +31,7 @@ def _B3(sigma: float) -> tuple[float, float, float]:
     return b0, b1, b2
 
 
-@njit(fastmath=True, cache=True)
+@njit(fastmath=True, cache=cache)
 def _B3d(sigma: float) -> tuple[float, float, float]:
     """Derivatives of quadratic B-spline coefficients."""
     b0 = -(2.0 - sigma) / 12.0 - (1.0 - sigma) / 12.0
@@ -34,7 +40,7 @@ def _B3d(sigma: float) -> tuple[float, float, float]:
     return b0, b1, b2
 
 
-@njit(fastmath=True, cache=True)
+@njit(fastmath=True, cache=cache)
 def _B5(sigma: float) -> tuple[float, float, float, float, float]:
     """Quartic B-spline coefficients (5 taps)."""
     s = sigma
@@ -46,7 +52,7 @@ def _B5(sigma: float) -> tuple[float, float, float, float, float]:
     return b0, b1, b2, b3, b4
 
 
-@njit(fastmath=True, cache=True)
+@njit(fastmath=True, cache=cache)
 def _B5d(sigma: float) -> tuple[float, float, float, float, float]:
     """Derivatives of quartic B-spline coefficients."""
     s = sigma
@@ -88,7 +94,7 @@ def _B5d(sigma: float) -> tuple[float, float, float, float, float]:
     return b0, b1, b2, b3, b4
 
 
-@njit(parallel=True, fastmath=True, cache=True)
+@njit(parallel=True, fastmath=True, cache=cache)
 def _conv_allpass_numba(
     din: NDArray,
     dip: NDArray,


### PR DESCRIPTION
This PR modifies the behavior of numba-JITed functions making `cache=False` by default and introducing an environment variable `NUMBA_CACHE_PYLOPS`, which can be set to 1 to enable caching.

This change is motivated by the fact that in some systems one may install Python and Python related libraries in a read-only space, therefore the default `NUMBA_CACHE_DIR` would not work. Moreover, since `@jit` itself has `cache=False`, this change brings the default approach of PyLops closer to the default approach of Numba itself.