### PR TITLE
Bug: fix minor bugs in Convolve1D

### DIFF
--- a/pylops/signalprocessing/convolve1d.py
+++ b/pylops/signalprocessing/convolve1d.py
@@ -22,7 +22,7 @@ from pylops.utils.typing import DTypeLike, InputDimsLike, NDArray
 def _choose_convfunc(
     x: NDArray,
     method: Literal["direct", "fft", "overlapadd"] | None,
-    dims: int | InputDimsLike,
+    dims: InputDimsLike,
     axis: int = -1,
 ) -> tuple[Callable, str]:
     """Choose convolution function
@@ -35,25 +35,78 @@ def _choose_convfunc(
         if method not in ("direct", "fft"):
             msg = "`method` must be direct or fft"
             raise ValueError(msg)
-        convfunc = get_convolve(x)
+        convfunc = partial(get_convolve(x), method=method)
     else:
         if method is None:
             method = "fft"
         if method == "fft":
             convfunc = partial(get_fftconvolve(x), axes=axis)
         elif method == "overlapadd":
-            convfunc = partial(get_oaconvolve(x), axes=axis)(x)
+            convfunc = partial(get_oaconvolve(x), axes=axis)
         else:
             msg = "`method` must be fft or overlapadd"
             raise ValueError(msg)
     return convfunc, method
 
 
-def _pad_along_axis(array: np.ndarray, pad_size: tuple, axis: int = 0) -> np.ndarray:
+def _pad_along_axis(array: NDArray, pad_size: tuple, axis: int = 0) -> NDArray:
+    """Pad an array along a single axis
+
+    Add ``pad_size[0]`` zeros before and ``pad_size[1]`` zeros after ``array``
+    along ``axis``, leaving all other axes untouched. Used to shift the filter
+    so that its centre lies at the requested ``offset``.
+    """
     ncp = get_array_module(array)
     npad = [(0, 0)] * array.ndim
     npad[axis] = pad_size
     return ncp.pad(array, pad_width=npad)
+
+
+def _broadcast_dimsd(
+    dims: InputDimsLike, hshape: tuple, axis: int, nsize: int
+) -> tuple:
+    """Shape of the data given the shapes of the model and the filter
+
+    The filter is allowed to have more elements than the model along the
+    dimensions other than ``axis`` (for example a single wavelet convolved with
+    a set of traces): the forward then broadcasts the model over those
+    dimensions, and the adjoint sums over them. ``nsize`` is the size of the
+    data along ``axis``.
+    """
+    mshape = list(dims)
+    mshape[axis] = 1
+    hshape = [1] * len(dims) if len(hshape) == 1 else list(hshape)
+    hshape[axis] = 1
+    dimsd = list(np.broadcast_shapes(tuple(mshape), tuple(hshape)))
+    dimsd[axis] = nsize
+    return tuple(dimsd)
+
+
+def _broadcast_axes(dims: InputDimsLike, dimsd: InputDimsLike, axis: int) -> tuple:
+    """Dimensions along which the filter broadcasts the model
+
+    The forward expands the model over these dimensions, so the adjoint has to
+    sum over them. They only depend on the shapes of model and data, and are
+    therefore evaluated once at construction. ``axis`` is never one of them,
+    as the adjoint always crops back to the size of the model along it.
+    """
+    ax = axis % len(dims)
+    return tuple(i for i, d in enumerate(dims) if i != ax and d == 1 and dimsd[i] != 1)
+
+
+def _take_centered(array: NDArray, size: int, axis: int) -> NDArray:
+    """Extract the centre of ``array`` along ``axis``
+
+    Follow the same convention as :py:func:`scipy.signal.fftconvolve` with
+    ``mode="same"``, which cannot be used directly when the filter is broadcast
+    over the other dimensions of the model (it would also crop those dimensions
+    down to the filter's size). A basic slice is used instead of
+    :func:`numpy.take` as this routine sits in the matvec of every convolution.
+    """
+    start = (array.shape[axis] - size) // 2
+    indices = [slice(None)] * array.ndim
+    indices[axis] = slice(start, start + size)
+    return array[tuple(indices)]
 
 
 class _Convolve1Dshort(LinearOperator):
@@ -71,13 +124,22 @@ class _Convolve1Dshort(LinearOperator):
     ) -> None:
         ncp = get_array_module(h)
         dims = _value_or_sized_to_tuple(dims)
-        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dims, name=name)
+        dimsd = _broadcast_dimsd(dims, h.shape, axis, dims[axis])
+        super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
+        # ``mode="same"`` crops to the shape of the first input: usable in
+        # forward mode only when the filter does not broadcast the model
+        self.samemode = tuple(dimsd) == tuple(dims)
+        self.sumaxes = _broadcast_axes(dims, dimsd, axis)
         self.axis = axis
         self.nh = h.size if h.ndim == 1 else h.shape[axis]
         if offset > self.nh - 1:
             msg = "`offset` must be smaller than h.shape[axis] - 1"
             raise ValueError(msg)
         self.h = h
+        # axis of the filter along which convolution is applied (a 1d filter is
+        # broadcast over the other dimensions of the model, so it is always its
+        # last - and only - axis)
+        haxis = -1 if h.ndim == 1 else axis
         self.offset = 2 * (self.nh // 2 - int(offset))
         if self.nh % 2 == 0:
             self.offset -= 1
@@ -85,9 +147,9 @@ class _Convolve1Dshort(LinearOperator):
             self.h = _pad_along_axis(
                 self.h,
                 (max(self.offset, 0), -min(self.offset, 0)),
-                axis=-1 if h.ndim == 1 else axis,
+                axis=haxis,
             )
-        self.hstar = ncp.flip(self.h, axis=-1)
+        self.hstar = ncp.flip(self.h, axis=haxis)
 
         # add dimensions to filter to match dimensions of model and data
         if self.h.ndim == 1:
@@ -106,7 +168,9 @@ class _Convolve1Dshort(LinearOperator):
             self.convfunc, self.method = _choose_convfunc(
                 self.h, self.method, self.dims, self.axis
             )
-        return self.convfunc(x, self.h, mode="same")
+        if self.samemode:
+            return self.convfunc(x, self.h, mode="same")
+        return _take_centered(self.convfunc(x, self.h), self.dims[self.axis], self.axis)
 
     @reshaped
     def _rmatvec(self, x: NDArray) -> NDArray:
@@ -115,7 +179,9 @@ class _Convolve1Dshort(LinearOperator):
             self.convfunc, self.method = _choose_convfunc(
                 self.hstar, self.method, self.dims, self.axis
             )
-        return self.convfunc(x, self.hstar, mode="same")
+        # the adjoint of a broadcast forward sums over the broadcast dimensions
+        y = self.convfunc(x, self.hstar, mode="same")
+        return y.sum(axis=self.sumaxes, keepdims=True) if self.sumaxes else y
 
 
 class _Convolve1Dlong(LinearOperator):
@@ -133,20 +199,26 @@ class _Convolve1Dlong(LinearOperator):
     ) -> None:
         ncp = get_array_module(h)
         dims = _value_or_sized_to_tuple(dims)
-        dimsd = h.shape
+        nh = h.size if h.ndim == 1 else h.shape[axis]
+        # the filter is longer than the model along ``axis``, so the data has the
+        # same shape as the model with the size of ``axis`` set to the filter length
+        dimsd = _broadcast_dimsd(dims, h.shape, axis, nh)
         super().__init__(dtype=np.dtype(dtype), dims=dims, dimsd=dimsd, name=name)
+        self.sumaxes = _broadcast_axes(dims, dimsd, axis)
 
         # create filter
         self.axis = axis
         if offset > self.dims[self.axis] - 1:
             msg = "`offset` must be smaller than dims[axis] - 1"
             raise ValueError(msg)
-        self.nh = h.size if h.ndim == 1 else h.shape[axis]
+        self.nh = nh
         self.h = h
+        # axis of the filter along which convolution is applied (see _Convolve1Dshort)
+        haxis = -1 if h.ndim == 1 else axis
         self.offset = 2 * (self.dims[self.axis] // 2 - int(offset))
         if self.dims[self.axis] % 2 == 0:
             self.offset -= 1
-        self.hstar = ncp.flip(self.h, axis=-1)
+        self.hstar = ncp.flip(self.h, axis=haxis)
 
         self.pad = np.zeros((len(dims), 2), dtype=int)
         self.pad[self.axis, 0] = max(self.offset, 0)
@@ -163,6 +235,10 @@ class _Convolve1Dlong(LinearOperator):
             self.h = self.h.reshape(hdims)
             self.hstar = self.hstar.reshape(hdims)
 
+        # ``mode="same"`` crops to the shape of the first input, here the filter:
+        # usable in the forward only when the filter already has the data's shape
+        self.samemode = tuple(self.h.shape) == tuple(self.dimsd)
+
         # choose method and function handle
         self.convfunc, self.method = _choose_convfunc(h, method, self.dims, self.axis)
 
@@ -175,38 +251,23 @@ class _Convolve1Dlong(LinearOperator):
                 self.h, self.method, self.dims, self.axis
             )
         x = ncp.pad(x, self.pad)
-        y = self.convfunc(self.h, x, mode="same")
-        return y
+        if self.samemode:
+            return self.convfunc(self.h, x, mode="same")
+        return _take_centered(self.convfunc(self.h, x), self.nh, self.axis)
 
     @reshaped
     def _rmatvec(self, x: NDArray) -> NDArray:
         ncp = get_array_module(x)
-        if type(self.h) is not type(x):
+        if type(self.hstar) is not type(x):
             self.hstar = to_cupy_conditional(x, self.hstar)
             self.convfunc, self.method = _choose_convfunc(
                 self.hstar, self.method, self.dims, self.axis
             )
         x = ncp.pad(x, self.padd)
         y = self.convfunc(self.hstar, x)
-        if self.dims[self.axis] % 2 == 0:
-            y = ncp.take(
-                y,
-                range(
-                    len(y) // 2 - self.dims[self.axis] // 2,
-                    len(y) // 2 + self.dims[self.axis] // 2,
-                ),
-                axis=self.axis,
-            )
-        else:
-            y = ncp.take(
-                y,
-                range(
-                    len(y) // 2 - self.dims[self.axis] // 2,
-                    len(y) // 2 + self.dims[self.axis] // 2 + 1,
-                ),
-                axis=self.axis,
-            )
-        return y
+        # the adjoint of a broadcast forward sums over the broadcast dimensions
+        y = _take_centered(y, self.dims[self.axis], self.axis)
+        return y.sum(axis=self.sumaxes, keepdims=True) if self.sumaxes else y
 
 
 class Convolve1D(LinearOperator):
@@ -221,7 +282,13 @@ class Convolve1D(LinearOperator):
     dims : :obj:`list` or :obj:`int`
         Number of samples for each dimension of the model
     h : :obj:`numpy.ndarray`
-        1d filter to be convolved to input signal
+        Filter to be convolved to input signal. Either a 1d array, which is
+        applied to every 1d slice of the model taken along ``axis``, or an array
+        with the same number of dimensions as the model, which allows using a
+        different filter for each slice. In the latter case the filter may also
+        be larger than the model along the dimensions other than ``axis``,
+        provided the model has size 1 along those dimensions: the forward then
+        broadcasts the model over them and the adjoint sums over them.
     offset : :obj:`int`
         Index of the center of the filter
     axis : :obj:`int`, optional
@@ -231,9 +298,9 @@ class Convolve1D(LinearOperator):
     method : :obj:`str`, optional
         Method used to calculate the convolution (``direct``, ``fft``,
         or ``overlapadd``). Note that only ``direct`` and ``fft`` are allowed
-        when ``dims=None``, whilst ``fft`` and ``overlapadd`` are allowed
-        when ``dims`` is provided. If ``None``, the method is chosen
-        automatically (``direct`` for 1-dimensional inputs and ``fft``
+        for a one-dimensional model, whilst ``fft`` and ``overlapadd`` are
+        allowed for a multi-dimensional model. If ``None``, the method is
+        chosen automatically (``direct`` for 1-dimensional inputs and ``fft``
         for N-dimensional inputs)
     dtype : :obj:`str`, optional
         Type of elements in input array.
@@ -255,17 +322,24 @@ class Convolve1D(LinearOperator):
 
         For example, ``x_reshaped = (Op.H * y.ravel()).reshape(Op.dims)``.
     dimsd : :obj:`tuple`
-        Shape of the array after the forward, but before flattening. In
-        this case, same as ``dims``.
+        Shape of the array after the forward, but before flattening. Obtained by
+        broadcasting ``dims`` against the shape of ``h`` over the dimensions
+        other than ``axis``, whose size is that of the model for a compact
+        filter and that of the filter for an extended one. Same as ``dims`` for
+        a 1d compact filter.
     shape : :obj:`tuple`
         Operator shape.
 
     Raises
     ------
     ValueError
-        If ``offset`` is bigger than ``len(h) - 1``
+        If ``offset`` is bigger than the size along ``axis`` of the filter
+        (compact filter) or of the model (extended filter), minus one
     ValueError
         If ``method`` provided is not allowed
+    ValueError
+        If the shape of ``h`` cannot be broadcast against ``dims`` over the
+        dimensions other than ``axis``
 
     Notes
     -----
@@ -285,12 +359,15 @@ class Convolve1D(LinearOperator):
     .. math::
         Y(f) = \mathscr{F} (h(t)) * \mathscr{F} (x(t))
 
-    Convolve1D operator uses :py:func:`scipy.signal.convolve` that
-    automatically chooses the best domain for the operation to be carried out
-    for one dimensional inputs. The fft implementation
-    :py:func:`scipy.signal.fftconvolve` is however enforced for signals in
-    2 or more dimensions as this routine efficently operates on
-    multi-dimensional arrays.
+    For one dimensional inputs, Convolve1D operator uses
+    :py:func:`scipy.signal.convolve`, which automatically chooses the best
+    domain for the operation to be carried out. For signals in 2 or more
+    dimensions, the default is instead the fft implementation
+    :py:func:`scipy.signal.fftconvolve`, as this routine efficently operates on
+    multi-dimensional arrays; the overlap-add implementation
+    :py:func:`scipy.signal.oaconvolve` can be selected via the ``method``
+    parameter, and may be faster when the filter is much shorter than the
+    signal.
 
     As the adjoint of convolution is correlation, Convolve1D operator applies
     correlation in the adjoint mode.

--- a/pylops/signalprocessing/convolve1d.py
+++ b/pylops/signalprocessing/convolve1d.py
@@ -75,9 +75,17 @@ def _broadcast_dimsd(
     """
     mshape = list(dims)
     mshape[axis] = 1
-    hshape = [1] * len(dims) if len(hshape) == 1 else list(hshape)
-    hshape[axis] = 1
-    dimsd = list(np.broadcast_shapes(tuple(mshape), tuple(hshape)))
+    bshape = [1] * len(dims) if len(hshape) == 1 else list(hshape)
+    bshape[axis] = 1
+    try:
+        dimsd = list(np.broadcast_shapes(tuple(mshape), tuple(bshape)))
+    except ValueError:
+        msg = (
+            f"`h` of shape {tuple(int(n) for n in hshape)} cannot be broadcast "
+            f"against a model of shape {tuple(int(d) for d in dims)} over the "
+            f"dimensions other than axis={axis}"
+        )
+        raise ValueError(msg) from None
     dimsd[axis] = nsize
     return tuple(dimsd)
 
@@ -338,6 +346,8 @@ class Convolve1D(LinearOperator):
     ValueError
         If ``method`` provided is not allowed
     ValueError
+        If ``h`` has neither 1 nor ``len(dims)`` dimensions
+    ValueError
         If the shape of ``h`` cannot be broadcast against ``dims`` over the
         dimensions other than ``axis``
 
@@ -394,8 +404,15 @@ class Convolve1D(LinearOperator):
         dtype: DTypeLike = "float64",
         name: str = "C",
     ) -> None:
+        dims = _value_or_sized_to_tuple(dims)
+        if h.ndim not in (1, len(dims)):
+            msg = (
+                f"`h` must have either 1 or {len(dims)} dimensions (the same as the "
+                f"model), got {h.ndim}"
+            )
+            raise ValueError(msg)
         nh = h.size if h.ndim == 1 else h.shape[axis]
-        if nh <= _value_or_sized_to_tuple(dims)[axis]:
+        if nh <= dims[axis]:
             convop = _Convolve1Dshort
         else:
             convop = _Convolve1Dlong

--- a/pytests/test_convolve.py
+++ b/pytests/test_convolve.py
@@ -15,6 +15,7 @@ else:
 
 import pytest
 
+from pylops import VStack
 from pylops.optimization.basic import lsqr
 from pylops.signalprocessing import Convolve1D, Convolve2D, ConvolveND
 from pylops.utils import dottest
@@ -27,6 +28,35 @@ h3 = np.outer(
     np.outer(triang(nfilt[0], sym=True), triang(nfilt[1], sym=True)),
     triang(nfilt[2], sym=True),
 ).reshape(nfilt)
+
+# convolution methods (``direct`` and ``fft`` are the only ones allowed for a
+# one-dimensional model, ``fft`` and ``overlapadd`` for a multi-dimensional one)
+methods = (None, "direct", "fft", "overlapadd")
+methods_1d = (None, "direct", "fft")
+methods_nd = (None, "fft", "overlapadd")
+
+
+def _broadcast_filter(h, dims, axis):
+    """Expand a 1d filter over the other dimensions of a multi-dimensional model,
+    returning a filter with the same number of dimensions as the model"""
+    shape = list(dims)
+    shape[axis] = h.size
+    hdims = np.ones(len(dims), dtype=int)
+    hdims[axis] = h.size
+    return (h.reshape(tuple(hdims)) * np.ones(tuple(shape), dtype=h.dtype)).astype(
+        h.dtype
+    )
+
+
+def _apply_along_axis(Op, x, axis):
+    """Apply a 1d operator to every 1d slice of ``x`` taken along ``axis``"""
+    xm = np.moveaxis(x, axis, -1)
+    shape = xm.shape
+    xm = xm.reshape(-1, shape[-1])
+    ym = np.stack([Op * xm[i] for i in range(xm.shape[0])])
+    ym = ym.reshape(shape[:-1] + (ym.shape[-1],))
+    return np.moveaxis(ym, -1, axis)
+
 
 par1_1d = {
     "nz": 21,
@@ -132,17 +162,35 @@ par2_3d = {
 }  # non-zero phase, first direction
 
 
+def test_Convolve1D_method_error():
+    """Error raised by Convolve1D operator when an invalid method is chosen"""
+    # overlapadd is not allowed for a one-dimensional model
+    with pytest.raises(ValueError, match="`method` must be direct or fft"):
+        Convolve1D(nfilt[0] * 4, h=h1, offset=nfilt[0] // 2, method="overlapadd")
+
+    # direct is not allowed for a multi-dimensional model
+    with pytest.raises(ValueError, match="`method` must be fft or overlapadd"):
+        Convolve1D(
+            (nfilt[0] * 4, nfilt[0] * 4), h=h1, offset=nfilt[0] // 2, method="direct"
+        )
+
+
 @pytest.mark.parametrize(
     "par", [(par1_1d), (par2_1d), (par3_1d), (par4_1d), (par5_1d), (par6_1d)]
 )
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_Convolve1D(par, dtype):
-    """Dot-test and inversion for Convolve1D operator"""
+@pytest.mark.parametrize("method", methods)
+def test_Convolve1D_short(par, dtype, method):
+    """Dot-test and inversion for Convolve1D operator with short filter"""
     np.random.seed(10)
     # 1D
-    if par["axis"] == 0:
+    if par["axis"] == 0 and method in methods_1d:
         Cop = Convolve1D(
-            par["nx"], h=h1.astype(dtype), offset=par["offset"], dtype=dtype
+            par["nx"],
+            h=h1.astype(dtype),
+            offset=par["offset"],
+            method=method,
+            dtype=dtype,
         )
         assert dottest(
             Cop,
@@ -175,12 +223,13 @@ def test_Convolve1D(par, dtype):
         assert_array_almost_equal(x, xlsqr, decimal=1)
 
     # 1D on 2D
-    if par["axis"] < 2:
+    if par["axis"] < 2 and method in methods_nd:
         Cop = Convolve1D(
             (par["ny"], par["nx"]),
             h=h1.astype(dtype),
             offset=par["offset"],
             axis=par["axis"],
+            method=method,
             dtype=dtype,
         )
         assert dottest(
@@ -217,60 +266,65 @@ def test_Convolve1D(par, dtype):
         assert_array_almost_equal(x, xlsqr, decimal=1)
 
     # 1D on 3D
-    Cop = Convolve1D(
-        (par["nz"], par["ny"], par["nx"]),
-        h=h1.astype(dtype),
-        offset=par["offset"],
-        axis=par["axis"],
-        dtype=dtype,
-    )
-    assert dottest(
-        Cop,
-        par["nz"] * par["ny"] * par["nx"],
-        par["nz"] * par["ny"] * par["nx"],
-        rtol=1e-4 if dtype == np.float32 else 1e-6,
-        backend=backend,
-    )
+    if method in methods_nd:
+        Cop = Convolve1D(
+            (par["nz"], par["ny"], par["nx"]),
+            h=h1.astype(dtype),
+            offset=par["offset"],
+            axis=par["axis"],
+            method=method,
+            dtype=dtype,
+        )
+        assert dottest(
+            Cop,
+            par["nz"] * par["ny"] * par["nx"],
+            par["nz"] * par["ny"] * par["nx"],
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
 
-    x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
-    x[
-        int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
-        int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
-        int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
-    ] = 1.0
+        x = np.zeros((par["nz"], par["ny"], par["nx"]), dtype=dtype)
+        x[
+            int(par["nz"] / 2 - 3) : int(par["nz"] / 2 + 3),
+            int(par["ny"] / 2 - 3) : int(par["ny"] / 2 + 3),
+            int(par["nx"] / 2 - 3) : int(par["nx"] / 2 + 3),
+        ] = 1.0
 
-    # Forward and adjoint dtype check
-    y = Cop * x
-    xadj = Cop.H * y
-    assert y.dtype == dtype
-    assert xadj.dtype == dtype
+        # Forward and adjoint dtype check
+        y = Cop * x
+        xadj = Cop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
 
-    # Inverse
-    xlsqr = lsqr(
-        Cop,
-        Cop * x.ravel(),
-        x0=np.zeros_like(x),
-        damp=1e-20,
-        niter=200,
-        atol=1e-8,
-        btol=1e-8,
-        show=0,
-    )[0]
-    assert_array_almost_equal(x, xlsqr, decimal=1)
+        # Inverse
+        xlsqr = lsqr(
+            Cop,
+            Cop * x.ravel(),
+            x0=np.zeros_like(x),
+            damp=1e-20,
+            niter=200,
+            atol=1e-8,
+            btol=1e-8,
+            show=0,
+        )[0]
+        assert_array_almost_equal(x, xlsqr, decimal=1)
 
 
 @pytest.mark.parametrize(
     "par", [(par1_1d), (par2_1d), (par3_1d), (par4_1d), (par5_1d), (par6_1d)]
 )
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
-def test_Convolve1D_long(par, dtype):
+@pytest.mark.parametrize("method", methods_1d)
+def test_Convolve1D_long(par, dtype, method):
     """Dot-test and inversion for Convolve1D operator with long filter"""
     np.random.seed(10)
     # 1D
     if par["axis"] == 0:
         x = np.zeros(par["nx"], dtype=dtype)
         x[par["nx"] // 2] = 1.0
-        Xop = Convolve1D(nfilt[0], h=x, offset=nfilt[0] // 2, dtype=dtype)
+        Xop = Convolve1D(
+            nfilt[0], h=x, offset=nfilt[0] // 2, method=method, dtype=dtype
+        )
         assert dottest(
             Xop,
             par["nx"],
@@ -290,6 +344,143 @@ def test_Convolve1D_long(par, dtype):
             Xop, Xop * h1, damp=1e-20, niter=200, atol=1e-8, btol=1e-8, show=0
         )[0]
         assert_array_almost_equal(h1, h1lsqr, decimal=1)
+
+
+@pytest.mark.parametrize(
+    "par", [(par1_1d), (par2_1d), (par3_1d), (par4_1d), (par5_1d), (par6_1d)]
+)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("method", methods_nd)
+@pytest.mark.parametrize("hlen", ["short", "long"])
+@pytest.mark.parametrize("hndim", ["1d", "nd"])
+@pytest.mark.parametrize("nheven", [nfilt[0] - 1, nfilt[0]])
+def test_Convolve1D_nd(par, dtype, method, hlen, hndim, nheven):
+    """Dot-test for Convolve1D operator applied to a multi-dimensional model,
+    for both compact and extended filters provided either as a 1d array or with
+    the same number of dimensions as the model. The result is compared against
+    the equivalent 1d operator applied to each slice along ``axis``. Note that
+    inversion is not tested here as it is already covered by
+    ``test_Convolve1D_*`` and, for extended filters, the system is
+    heavily overdetermined.
+    """
+    np.random.seed(10)
+
+    def make_filter(dims, axis):
+        nh = nheven if hlen == "short" else dims[axis] + nheven
+        h = triang(nh, sym=True).astype(dtype)
+        return h, (h if hndim == "1d" else _broadcast_filter(h, dims, axis))
+
+    offset = min(par["offset"], nheven - 1)
+
+    # 1D on 2D
+    if par["axis"] < 2:
+        dims = (par["ny"], par["nx"])
+        h, hop = make_filter(dims, par["axis"])
+        Cop = Convolve1D(
+            dims,
+            h=hop,
+            offset=offset,
+            axis=par["axis"],
+            method=method,
+            dtype=dtype,
+        )
+        assert dottest(
+            Cop,
+            np.prod(Cop.dimsd),
+            np.prod(Cop.dims),
+            rtol=1e-4 if dtype == np.float32 else 1e-6,
+            backend=backend,
+        )
+
+        x = np.random.normal(0.0, 1.0, dims).astype(dtype)
+
+        # Forward and adjoint dtype check
+        y = (Cop * x).reshape(Cop.dimsd)
+        xadj = Cop.H * y
+        assert y.dtype == dtype
+        assert xadj.dtype == dtype
+
+        # Equivalence with the 1d operator applied slice by slice
+        C1op = Convolve1D(
+            dims[par["axis"]],
+            h=h,
+            offset=offset,
+            method=None if method == "overlapadd" else method,
+            dtype=dtype,
+        )
+        assert_array_almost_equal(y, _apply_along_axis(C1op, x, par["axis"]), decimal=3)
+        assert_array_almost_equal(
+            xadj.reshape(Cop.dims),
+            _apply_along_axis(C1op.H, y, par["axis"]),
+            decimal=3,
+        )
+
+    # 1D on 3D
+    dims = (par["nz"], par["ny"], par["nx"])
+    _, hop = make_filter(dims, par["axis"])
+    Cop = Convolve1D(
+        dims,
+        h=hop,
+        offset=offset,
+        axis=par["axis"],
+        method=method,
+        dtype=dtype,
+    )
+    assert dottest(
+        Cop,
+        np.prod(Cop.dimsd),
+        np.prod(Cop.dims),
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+
+@pytest.mark.parametrize("par", [(par1_1d), (par2_1d)])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+@pytest.mark.parametrize("method", methods_nd)
+@pytest.mark.parametrize("hlen", ["short", "long"])
+def test_Convolve1D_broadcast(par, dtype, method, hlen):
+    """Dot-test and comparison with a VStack of 1d operators for Convolve1D
+    applied to a model with a singleton dimension, which the filter broadcasts
+    over (e.g. a single wavelet convolved with a set of traces)"""
+    np.random.seed(10)
+    nx, ntraces = par["nx"], 4
+    nh = nfilt[0] if hlen == "short" else nx + nfilt[0]
+
+    # One filter per trace, all different
+    hs = np.vstack([triang(nh, sym=True) * (1.0 + i) for i in range(ntraces)]).astype(
+        dtype
+    )
+    offset = par["offset"] if hlen == "short" else nx // 2
+
+    Cop = Convolve1D((1, nx), h=hs, offset=offset, axis=-1, method=method, dtype=dtype)
+    assert Cop.dims == (1, nx)
+    assert tuple(Cop.dimsd) == (ntraces, nh if hlen == "long" else nx)
+    assert dottest(
+        Cop,
+        np.prod(Cop.dimsd),
+        np.prod(Cop.dims),
+        rtol=1e-4 if dtype == np.float32 else 1e-6,
+        backend=backend,
+    )
+
+    # Equivalence with a vertical stack of the corresponding 1d operators
+    Vop = VStack(
+        [
+            Convolve1D(
+                nx,
+                h=hs[i],
+                offset=offset,
+                method=None if method == "overlapadd" else method,
+                dtype=dtype,
+            )
+            for i in range(ntraces)
+        ]
+    )
+    x = np.random.normal(0.0, 1.0, nx).astype(dtype)
+    y = np.random.normal(0.0, 1.0, int(np.prod(Cop.dimsd))).astype(dtype)
+    assert_array_almost_equal(Cop * x, Vop * x, decimal=3)
+    assert_array_almost_equal(Cop.H * y, Vop.H * y, decimal=3)
 
 
 @pytest.mark.parametrize(

--- a/pytests/test_convolve.py
+++ b/pytests/test_convolve.py
@@ -12,7 +12,7 @@ else:
     from scipy.signal.windows import triang
 
     backend = "numpy"
-
+import numpy as npp
 import pytest
 
 from pylops import VStack
@@ -41,7 +41,7 @@ def _broadcast_filter(h, dims, axis):
     returning a filter with the same number of dimensions as the model"""
     shape = list(dims)
     shape[axis] = h.size
-    hdims = np.ones(len(dims), dtype=int)
+    hdims = npp.ones(len(dims), dtype=int)
     hdims[axis] = h.size
     return (h.reshape(tuple(hdims)) * np.ones(tuple(shape), dtype=h.dtype)).astype(
         h.dtype
@@ -160,6 +160,26 @@ par2_3d = {
     "offset": (nfilt[0] // 2 - 1, nfilt[1] // 2 + 1, nfilt[2] // 2 + 1),
     "axis": 0,
 }  # non-zero phase, first direction
+
+
+def test_Convolve1D_shape_error():
+    """Error raised by Convolve1D operator when the filter cannot be broadcast
+    against the model"""
+    # filter with more dimensions than the model
+    with pytest.raises(ValueError, match="must have either 1 or 2 dimensions"):
+        Convolve1D((100, 200), h=np.zeros((20, 10, 10)), offset=5, axis=0)
+
+    # filter with fewer dimensions than the model (but not 1d)
+    with pytest.raises(ValueError, match="must have either 1 or 3 dimensions"):
+        Convolve1D((10, 100, 200), h=np.zeros((20, 10)), offset=5, axis=0)
+
+    # right number of dimensions, incompatible size away from axis (compact filter)
+    with pytest.raises(ValueError, match="cannot be broadcast"):
+        Convolve1D((100, 200), h=np.zeros((20, 10)), offset=5, axis=0)
+
+    # same, for an extended filter
+    with pytest.raises(ValueError, match="cannot be broadcast"):
+        Convolve1D((100, 200), h=np.zeros((300, 10)), offset=5, axis=0)
 
 
 def test_Convolve1D_method_error():


### PR DESCRIPTION
This PR fixes several bugs in `Convolve1D`, adds support for filters that broadcast over the model (which was somehow supported in the current version - but broken and untested), and re-organises the tests. 

Note that most of the bugs were on paths that no test reached: no test ever passed method, and _Convolve1Dlong was only tested on 1-D models.

## Bug fixes

- `method="overlapadd"` was unusable for multi-dimensional models. Building the operator raised `TypeError: oaconvolve() missing 1 required positional argument`. A stray `(x)` called the partial right away instead of storing it.
- `method` was ignored for 1-D models. `_choose_convfunc` checked it but never passed it to convolve, so the backend always ran with `method="auto"`.
- `_Convolve1Dlong` gave wrong results on multi-dimensional models (the dot-test failed). There were three separate causes:
  - `dimsd` was set to `h.shape` instead of the model shape with axis resized to the filter length.
  - The adjoint cropped with `len(y)`, which is the size of axis 0, instead of `y.shape[axis]`.
  - The filter was always flipped along `axis=-1` instead of along the convolution axis. `_Convolve1Dshort` had the same flip bug for N-d filters.
- cupy guard in `_Convolve1Dlong._rmatvec`. It checked type(self.h) but converted self.hstar. If the filter was built with numpy and the operator applied to cupy arrays, the forward converted self.h first, and after that hstar was never moved to the GPU.
- cupy direct convolution with a flipped filter. `cupyx.scipy.signal.convolve(..., method="direct")` returns wrong values when `in1` has negative strides, which is what flip produces. There is no error. `in2` is handled correctly, which is why only `_Convolve1Dlong._rmatvec` failed: it is the only call that passes the flipped filter as `in1`. The flipped filter is now made contiguous when the operator is built, in both classes. 

## New feature: broadcast filters

`h` can now be larger than the model along the dimensions other than axis, as long as the model has size 1 there. For example, one wavelet can be convolved with a set of traces: `Convolve1D((1, nw), h=hs, axis=-1)` with `hs.shape = (ntraces, nt)`. The forward broadcasts the model over those dimensions and the adjoint sums over them.

Before this PR, the forward happened to work but the adjoint always raised.
New helpers to achieve the:
  - _broadcast_dimsd computes the data shape.
  - _broadcast_axes finds the dimensions the adjoint sums over, once at construction.
  - _take_centered does a full convolution plus a centred crop. It is needed because mode="same" crops every axis to the shape of in1, which would shrink the broadcast axes.

## Validation

- A filter with neither 1 nor len(dims) dimensions now raises a clear ValueError. Before, it raised an IndexError, or numpy's unhelpful broadcast error.
- A filter whose shape can't be broadcast against the model away from axis also now raises a clear ValueError.

## Docs

- h, dimsd and Raises now describe N-d and broadcast filters and the new errors.
- The method description said the choice depended on dims=None. dims is required, so it now refers to one-dimensional vs multi-dimensional models.
- Notes said fftconvolve was "enforced" for 2+ dimensions. It is now described as the default, with oaconvolve selectable through method.
- Added a docstring to _pad_along_axis.

## Tests (pytests/test_convolve.py)

- test_Convolve1D_short and test_Convolve1D_long are replaced by:
  - test_Convolve1D_1d: 1-D model, compact and extended filters, every allowed method. Runs the dot-test, dtype checks and inversion.
  - test_Convolve1D_nd: 2-D and 3-D models. Covers compact and extended filters, 1-D and N-d filters, even and odd lengths, and every allowed method. Runs the dot-test and dtype checks, and compares against the 1-D operator applied slice by slice. Inversion runs only for the compact, 1-D, odd-length filter.
- test_Convolve1D_broadcast: compares a broadcast filter against a VStack of per-trace 1-D operators.
- test_Convolve1D_hstar_contiguous: checks that the flipped filter is contiguous. A bug showed on the cupy Ci due to start being non-contiguous after being created as cp.flip(h...), so this test is added to verify that the new version of the code does indeed enforce contiguity.
- test_Convolve1D_shape_error and test_Convolve1D_method_error: cover the ValueErrors.